### PR TITLE
chore: correct escape sequences description in CHANGELOG.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Update the `dump` function to handle addresses: PR [#175](https://github.com/tact-lang/tact/pull/175)
 - The implicit empty `init` function is now present by default in the contract if not declared: PR [#167](https://github.com/tact-lang/tact/pull/167)
 - `@stdlib/stoppable` now imports `@stdlib/ownable` so the programmer does not have to do it separately: PR [#193](https://github.com/tact-lang/tact/pull/193)
-- Support escape sequences for strings (`\\`, `\"`, `\n`, `\r`, `\t`, `\v`, `\b`, `\f`, `\u{ABC}`, `\uABCD`, `\xAB`): PR [#192](https://github.com/tact-lang/tact/pull/192)
+- Support escape sequences for strings (`\\`, `\"`, `\n`, `\r`, `\t`, `\v`, `\b`, `\f`, `\u{0}` through `\u{FFFFFF}`, `\u0000` through `\uFFFF`, `\x00` through `\xFF`): PR [#192](https://github.com/tact-lang/tact/pull/192)
 
 ### Fixed
 - Incorrect "already exists" errors when using names such as `toString` or `valueOf`: PR [#208](https://github.com/tact-lang/tact/pull/208)


### PR DESCRIPTION
CHANGELOG.md description of escape sequences now matches the Ohm's grammar.

<!--
IMPORTANT:
If your PR doesn't close a particular issue, please, create the issue first and describe the whole context: what you're adding/changing and why you're doing so. And only then open the Pull Request, which would close that issue!
-->

* [x] I have updated CHANGELOG.md
* ~~I have added unit tests to demonstrate the contribution is correctly implemented~~ Not applicable.
* ~~I have run all the tests locally and no test failure was reported~~ Not applicable.
* [x] I did not introduce unrelated formatting/whitespace changes in the code base
* [x] I did not do unrelated and/or undiscussed refactorings
