### PR TITLE
fix: always use POSIX-normalized paths in .pkg files

### DIFF
--- a/.github/workflows/tact.yml
+++ b/.github/workflows/tact.yml
@@ -49,6 +49,11 @@ jobs:
         run: |
           yarn lint:schema
 
+      - name: Show an example .pkg file on Windows
+        if: runner.os == 'Windows'
+        run: |
+          type examples\output\echo_Echo.pkg
+
       - name: Compare Tact version from CLI flag `--version` against package.json
         if: runner.os != 'Windows'
         run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - The `dump()` and `dumpStack()` functions now print the file path, line number, and column number in addition to the data: PR [#271](https://github.com/tact-lang/tact/pull/271)
 - Use `|` instead of `+` for send mode flags because the bitwise OR operation is idempotent and hence safer: PR [#274](https://github.com/tact-lang/tact/pull/274)
 - Bumped the versions of `@ton/core` and `ohm-js` to the most recent ones: PR [#276](https://github.com/tact-lang/tact/pull/276)
+- Generated `.pkg`-files always use POSIX file paths (even on Windows): PR [# 300](https://github.com/tact-lang/tact/pull/300)
 
 ### Fixed
 

--- a/src/pipeline/build.ts
+++ b/src/pipeline/build.ts
@@ -37,7 +37,7 @@ export async function build(args: {
     // Configure context
     let ctx: CompilerContext = new CompilerContext({ shared: {} });
     const cfg: string = JSON.stringify({
-        entrypoint: config.path,
+        entrypoint: posixNormalize(config.path),
         options: config.options || {},
     });
     if (config.options) {
@@ -235,9 +235,12 @@ export async function build(args: {
                 source.path.startsWith(project.root) &&
                 !source.path.startsWith(stdlib.root)
             ) {
-                sources[source.path.slice(project.root.length)] = Buffer.from(
-                    source.code,
-                ).toString("base64");
+                const source_path = posixNormalize(
+                    source.path.slice(project.root.length),
+                );
+                sources[source_path] = Buffer.from(source.code).toString(
+                    "base64",
+                );
             }
         }
 


### PR DESCRIPTION
This makes it easier for TON verifiers to work with .pkg files produced on Windows

Closes #299

<!--
IMPORTANT:
If your PR doesn't close a particular issue, please, create the issue first and describe the whole context: what you're adding/changing and why you're doing so. And only then open the Pull Request, which would close that issue!
-->

- [x] I have updated CHANGELOG.md
- ~~[ ] I have added unit tests to demonstrate the contribution is correctly implemented~~ It's hard to test in this case, but there is "Show an example .pkg file on Windows" section in CI
- [x] I have run all the tests locally and no test failure was reported
- [x] I did not do unrelated and/or undiscussed refactorings
