### PR TITLE
chore(ast): Create named union types for fields of AST nodes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 ### Changed
+
 - Refactor AST types to simplify access to third-party tools (#325)
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Refactor AST types to simplify access to third-party tools (#325)
+- Refactor AST types to simplify access to third-party tools: PR [#325](https://github.com/tact-lang/tact/pull/325)
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 ### Changed
+- Refactor AST types to simplify access to third-party tools (#325)
 
 ### Fixed
 

--- a/src/grammar/ast.ts
+++ b/src/grammar/ast.ts
@@ -124,7 +124,7 @@ export type ASTTypeRef = ASTTypeRefSimple | ASTTypeRefMap | ASTTypeRefBounced;
 // Expressions
 //
 
-export type ASTBinaryOperations =
+export type ASTBinaryOperation =
     | "+"
     | "-"
     | "*"
@@ -147,7 +147,7 @@ export type ASTBinaryOperations =
 export type ASTOpBinary = {
     kind: "op_binary";
     id: number;
-    op: ASTBinaryOperations;
+    op: ASTBinaryOperation;
     left: ASTExpression;
     right: ASTExpression;
     ref: ASTRef;
@@ -259,7 +259,7 @@ export type ASTStruct = {
     ref: ASTRef;
 };
 
-export type ASTTraitDeclarations =
+export type ASTTraitDeclaration =
     | ASTField
     | ASTFunction
     | ASTReceive
@@ -272,7 +272,7 @@ export type ASTTrait = {
     name: string;
     traits: ASTString[];
     attributes: ASTContractAttribute[];
-    declarations: ASTTraitDeclarations[];
+    declarations: ASTTraitDeclaration[];
     ref: ASTRef;
 };
 
@@ -307,7 +307,7 @@ export type ASTContractAttribute = {
     ref: ASTRef;
 };
 
-export type ASTContractDeclarations =
+export type ASTContractDeclaration =
     | ASTField
     | ASTFunction
     | ASTInitFunction
@@ -321,7 +321,7 @@ export type ASTContract = {
     name: string;
     traits: ASTString[];
     attributes: ASTContractAttribute[];
-    declarations: ASTContractDeclarations[];
+    declarations: ASTContractDeclaration[];
     ref: ASTRef;
 };
 
@@ -443,12 +443,12 @@ export type ASTSTatementAssign = {
     ref: ASTRef;
 };
 
-export type ASTAugmentedAssignOperations = "+" | "-" | "*" | "/" | "%";
+export type ASTAugmentedAssignOperation = "+" | "-" | "*" | "/" | "%";
 
 export type ASTSTatementAugmentedAssign = {
     kind: "statement_augmentedassign";
     id: number;
-    op: ASTAugmentedAssignOperations;
+    op: ASTAugmentedAssignOperation;
     path: ASTLvalueRef[];
     expression: ASTExpression;
     ref: ASTRef;

--- a/src/grammar/ast.ts
+++ b/src/grammar/ast.ts
@@ -153,12 +153,12 @@ export type ASTOpBinary = {
     ref: ASTRef;
 };
 
-export type ASTUnaryOperations = "+" | "-" | "!" | "!!";
+export type ASTUnaryOperation = "+" | "-" | "!" | "!!";
 
 export type ASTOpUnary = {
     kind: "op_unary";
     id: number;
-    op: ASTUnaryOperations;
+    op: ASTUnaryOperation;
     right: ASTExpression;
     ref: ASTRef;
 };

--- a/src/grammar/ast.ts
+++ b/src/grammar/ast.ts
@@ -124,37 +124,41 @@ export type ASTTypeRef = ASTTypeRefSimple | ASTTypeRefMap | ASTTypeRefBounced;
 // Expressions
 //
 
+export type ASTBinaryOperations =
+    | "+"
+    | "-"
+    | "*"
+    | "/"
+    | "!="
+    | ">"
+    | "<"
+    | ">="
+    | "<="
+    | "=="
+    | "&&"
+    | "||"
+    | "%"
+    | "<<"
+    | ">>"
+    | "&"
+    | "|"
+    | "^";
+
 export type ASTOpBinary = {
     kind: "op_binary";
     id: number;
-    op:
-        | "+"
-        | "-"
-        | "*"
-        | "/"
-        | "!="
-        | ">"
-        | "<"
-        | ">="
-        | "<="
-        | "=="
-        | "&&"
-        | "||"
-        | "%"
-        | "<<"
-        | ">>"
-        | "&"
-        | "|"
-        | "^";
+    op: ASTBinaryOperations;
     left: ASTExpression;
     right: ASTExpression;
     ref: ASTRef;
 };
 
+export type ASTUnaryOperations = "+" | "-" | "!" | "!!";
+
 export type ASTOpUnary = {
     kind: "op_unary";
     id: number;
-    op: "+" | "-" | "!" | "!!";
+    op: ASTUnaryOperations;
     right: ASTExpression;
     ref: ASTRef;
 };
@@ -221,19 +225,20 @@ export type ASTConditional = {
 // Program
 //
 
+export type ASTProgramEntry =
+    | ASTStruct
+    | ASTContract
+    | ASTPrimitive
+    | ASTFunction
+    | ASTNativeFunction
+    | ASTTrait
+    | ASTProgramImport
+    | ASTConstant;
+
 export type ASTProgram = {
     kind: "program";
     id: number;
-    entries: (
-        | ASTStruct
-        | ASTContract
-        | ASTPrimitive
-        | ASTFunction
-        | ASTNativeFunction
-        | ASTTrait
-        | ASTProgramImport
-        | ASTConstant
-    )[];
+    entries: ASTProgramEntry[];
 };
 
 export type ASTProgramImport = {
@@ -254,6 +259,12 @@ export type ASTStruct = {
     ref: ASTRef;
 };
 
+export type ASTTraitDeclarations =
+    | ASTField
+    | ASTFunction
+    | ASTReceive
+    | ASTConstant;
+
 export type ASTTrait = {
     kind: "def_trait";
     origin: TypeOrigin;
@@ -261,7 +272,7 @@ export type ASTTrait = {
     name: string;
     traits: ASTString[];
     attributes: ASTContractAttribute[];
-    declarations: (ASTField | ASTFunction | ASTReceive | ASTConstant)[];
+    declarations: ASTTraitDeclarations[];
     ref: ASTRef;
 };
 
@@ -296,6 +307,13 @@ export type ASTContractAttribute = {
     ref: ASTRef;
 };
 
+export type ASTContractDeclarations =
+    | ASTField
+    | ASTFunction
+    | ASTInitFunction
+    | ASTReceive
+    | ASTConstant;
+
 export type ASTContract = {
     kind: "def_contract";
     origin: TypeOrigin;
@@ -303,13 +321,7 @@ export type ASTContract = {
     name: string;
     traits: ASTString[];
     attributes: ASTContractAttribute[];
-    declarations: (
-        | ASTField
-        | ASTFunction
-        | ASTInitFunction
-        | ASTReceive
-        | ASTConstant
-    )[];
+    declarations: ASTContractDeclarations[];
     ref: ASTRef;
 };
 
@@ -431,10 +443,12 @@ export type ASTSTatementAssign = {
     ref: ASTRef;
 };
 
+export type ASTAugmentedAssignOperations = "+" | "-" | "*" | "/" | "%";
+
 export type ASTSTatementAugmentedAssign = {
     kind: "statement_augmentedassign";
     id: number;
-    op: "+" | "-" | "*" | "/" | "%";
+    op: ASTAugmentedAssignOperations;
     path: ASTLvalueRef[];
     expression: ASTExpression;
     ref: ASTRef;


### PR DESCRIPTION
Addresses #314 (see this [comment](https://github.com/tact-lang/tact/issues/314#issuecomment-2093106166))

- [x] I have updated CHANGELOG.md
- (n/a) I have added tests to demonstrate the contribution is correctly implemented: this usually includes both positive and negative tests, showing the happy path(s) and featuring intentionally broken cases
- [x] I have run all the tests locally and no test failure was reported
- [x] I did not do unrelated and/or undiscussed refactorings
