### PR TITLE
Compiler error on incorrect `address()` input

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - `log2` and `log` math functions were adjusted for consistency in error throwing: PR [#342](https://github.com/tact-lang/tact/pull/342)
+- Built-in function `address()` now handles parse errors correctly: PR [#357](https://github.com/tact-lang/tact/pull/357)
 
 ## [1.3.0] - 2024-05-03
 

--- a/src/abi/global.ts
+++ b/src/abi/global.ts
@@ -104,7 +104,7 @@ export const GlobalFunctions: Map<string, AbiFunction> = new Map([
                 try {
                     address = Address.parse(str);
                 } catch {
-                    throwError(`Address ${str} invalid address`, ref);
+                    throwError(`${str} is not a valid address`, ref);
                 }
                 if (address.workChain !== 0 && address.workChain !== -1) {
                     throwError(`Address ${str} invalid address`, ref);

--- a/src/abi/global.ts
+++ b/src/abi/global.ts
@@ -100,7 +100,12 @@ export const GlobalFunctions: Map<string, AbiFunction> = new Map([
                     resolved[0],
                     ctx.ctx,
                 ) as string;
-                const address = Address.parse(str);
+                let address: Address;
+                try {
+                    address = Address.parse(str);
+                } catch {
+                    throwError(`Address ${str} invalid address`, ref);
+                }
                 if (address.workChain !== 0 && address.workChain !== -1) {
                     throwError(`Address ${str} invalid address`, ref);
                 }

--- a/src/test/feature-address.spec.ts
+++ b/src/test/feature-address.spec.ts
@@ -47,7 +47,7 @@ describe("feature-address", () => {
             projectNames: ["invalid-address"],
         });
         expect((consoleLogger.error as jest.Mock).mock.lastCall[0]).toContain(
-            "Address FQCD39VS5jcptHL8vMjEXrzGaRcCVYto7HUn4bpAOg8xqB2N invalid address",
+            "FQCD39VS5jcptHL8vMjEXrzGaRcCVYto7HUn4bpAOg8xqB2N is not a valid address",
         );
         expect(result).toBe(false);
     });

--- a/src/test/feature-address.spec.ts
+++ b/src/test/feature-address.spec.ts
@@ -2,10 +2,24 @@ import { toNano } from "@ton/core";
 import { ContractSystem } from "@tact-lang/emulator";
 import { __DANGER_resetNodeId } from "../grammar/ast";
 import { AddressTester } from "./features/output/address_AddressTester";
+import { consoleLogger } from "../logger";
+import { run } from "../node";
 
 describe("feature-address", () => {
+    beforeAll(() => {
+        jest.spyOn(consoleLogger, "error").mockImplementation(() => {});
+    });
+
     beforeEach(() => {
         __DANGER_resetNodeId();
+    });
+
+    afterAll(() => {
+        (consoleLogger.error as jest.Mock).mockRestore();
+    });
+
+    afterEach(() => {
+        (consoleLogger.error as jest.Mock).mockClear();
     });
     it("should implement addresses correctly", async () => {
         // Init
@@ -25,5 +39,16 @@ describe("feature-address", () => {
         expect((await contract.getTest3()).toRawString()).toEqual(
             "0:4a81708d2cf7b15a1b362fbf64880451d698461f52f05f145b36c08517d76873",
         );
+    });
+
+    it("should not compile with uninitialized storage fields", async () => {
+        const result = await run({
+            configPath: __dirname + "/test-tact.config.json",
+            projectNames: ["invalid-address"],
+        });
+        expect((consoleLogger.error as jest.Mock).mock.lastCall[0]).toContain(
+            "Address FQCD39VS5jcptHL8vMjEXrzGaRcCVYto7HUn4bpAOg8xqB2N invalid address",
+        );
+        expect(result).toBe(false);
     });
 });

--- a/src/test/features/invalid-address.tact
+++ b/src/test/features/invalid-address.tact
@@ -1,0 +1,10 @@
+import "@stdlib/deploy";
+
+contract SampleTactContract with Deployable {
+    init() {
+    }
+    get fun test_address(): Address {
+        let a1: Address = address("FQCD39VS5jcptHL8vMjEXrzGaRcCVYto7HUn4bpAOg8xqB2N");
+        return a1;
+    }
+}

--- a/src/test/test-tact.config.json
+++ b/src/test/test-tact.config.json
@@ -8,6 +8,11 @@
       "options": {
         "debug": true
       }
+    },
+    {
+      "name": "invalid-address",
+      "path": "./features/invalid-address.tact",
+      "output": "./features/output"
     }
   ]
 }


### PR DESCRIPTION
Closes #354 

- [x] I have updated CHANGELOG.md
- [x] I have added tests to demonstrate the contribution is correctly implemented: this usually includes both positive and negative tests, showing the happy path(s) and featuring intentionally broken cases
- [x] I have run all the tests locally and no test failure was reported
- [x] I did not do unrelated and/or undiscussed refactorings
