### PR TITLE
Add quotes to all identifiers in error messages for consistency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Shadowing built-in static functions is now forbidden: PR [#351](https://github.com/tact-lang/tact/pull/351)
 - Augmented assignment now throws compilation error for non-integer types: PR [#356](https://github.com/tact-lang/tact/pull/356)
 - Built-in function `address()` now handles parse errors correctly: PR [#357](https://github.com/tact-lang/tact/pull/357)
+- All identifiers in error messages are now quoted for consistency: PR [#363](https://github.com/tact-lang/tact/pull/363)
 
 ## [1.3.0] - 2024-05-03
 

--- a/src/abi/map.ts
+++ b/src/abi/map.ts
@@ -36,7 +36,7 @@ export const MapFunctions: Map<string, AbiFunction> = new Map([
                 }
                 if (args[1].name !== self.key) {
                     throwError(
-                        `set expects a ${self.key} as first argument`,
+                        `set expects a "${self.key}" as first argument`,
                         ref,
                     );
                 }
@@ -50,7 +50,7 @@ export const MapFunctions: Map<string, AbiFunction> = new Map([
                 }
                 if (args[2].kind !== "null" && args[2].name !== self.value) {
                     throwError(
-                        `set expects a ${self.value} as second argument`,
+                        `set expects a "${self.value}" as second argument`,
                         ref,
                     );
                 }
@@ -121,7 +121,7 @@ export const MapFunctions: Map<string, AbiFunction> = new Map([
                             }
                         } else {
                             throwError(
-                                `${t.name} can't be value of a map`,
+                                `"${t.name}" can't be value of a map`,
                                 ref,
                             );
                         }
@@ -170,7 +170,7 @@ export const MapFunctions: Map<string, AbiFunction> = new Map([
                             }
                         } else {
                             throwError(
-                                `${t.name} can't be value of a map`,
+                                `"${t.name}" can't be value of a map`,
                                 ref,
                             );
                         }
@@ -204,7 +204,7 @@ export const MapFunctions: Map<string, AbiFunction> = new Map([
                 }
                 if (args[1].name !== self.key) {
                     throwError(
-                        `set expects a ${self.key} as first argument`,
+                        `set expects a "${self.key}" as first argument`,
                         ref,
                     );
                 }
@@ -269,7 +269,7 @@ export const MapFunctions: Map<string, AbiFunction> = new Map([
                             return `${ops.readerOpt(t.name, ctx)}(__tact_dict_get_${kind}_cell(${resolved[0]}, ${bits}, ${resolved[1]}))`;
                         } else {
                             throwError(
-                                `${t.name} can't be value of a map`,
+                                `"${t.name}" can't be value of a map`,
                                 ref,
                             );
                         }
@@ -314,7 +314,7 @@ export const MapFunctions: Map<string, AbiFunction> = new Map([
                             return `${ops.readerOpt(t.name, ctx)}(__tact_dict_get_slice_cell(${resolved[0]}, 267, ${resolved[1]}))`;
                         } else {
                             throwError(
-                                `${t.name} can't be value of a map`,
+                                `"${t.name}" can't be value of a map`,
                                 ref,
                             );
                         }
@@ -348,7 +348,7 @@ export const MapFunctions: Map<string, AbiFunction> = new Map([
                 }
                 if (args[1].name !== self.key) {
                     throwError(
-                        `del expects a ${self.key} as first argument`,
+                        `del expects a "${self.key}" as first argument`,
                         ref,
                     );
                 }

--- a/src/generator/Writer.ts
+++ b/src/generator/Writer.ts
@@ -132,10 +132,10 @@ export class WriterContext {
         //
 
         if (this.#functions.has(name)) {
-            throw new Error(`Function ${name} already defined`); // Should not happen
+            throw new Error(`Function "${name}" already defined`); // Should not happen
         }
         if (this.#functionsRendering.has(name)) {
-            throw new Error(`Function ${name} already rendering`); // Should not happen
+            throw new Error(`Function "${name}" already rendering`); // Should not happen
         }
 
         //
@@ -189,10 +189,10 @@ export class WriterContext {
         const comment = this.#pendingComment;
         const context = this.#pendingContext;
         if (!signature && name !== "$main") {
-            throw new Error(`Function ${name} signature not set`);
+            throw new Error(`Function "${name}" signature not set`);
         }
         if (!code) {
-            throw new Error(`Function ${name} body not set`);
+            throw new Error(`Function "${name}" body not set`);
         }
         this.#pendingDepends = null;
         this.#pendingWriter = null;
@@ -319,7 +319,7 @@ export class WriterContext {
 
     markRendered(key: string) {
         if (this.#rendered.has(key)) {
-            throw new Error(`Key ${key} already rendered`);
+            throw new Error(`Key "${key}" already rendered`);
         }
         this.#rendered.add(key);
     }

--- a/src/generator/createABI.ts
+++ b/src/generator/createABI.ts
@@ -12,7 +12,7 @@ export function createABI(ctx: CompilerContext, name: string): ContractABI {
     // Contract
     const contract = allTypes.find((v) => v.name === name)!;
     if (!contract) {
-        throw Error(`Contract ${name} not found`);
+        throw Error(`Contract "${name}" not found`);
     }
     if (contract.kind !== "contract") {
         throw Error("Not a contract");

--- a/src/generator/writeProgram.ts
+++ b/src/generator/writeProgram.ts
@@ -303,7 +303,7 @@ function writeAll(
     const contracts = allTypes.filter((v) => v.kind === "contract");
     const c = contracts.find((v) => v.name === name);
     if (!c) {
-        throw Error(`Contract ${name} not found`);
+        throw Error(`Contract "${name}" not found`);
     }
 
     // Stdlib

--- a/src/generator/writers/writeExpression.ts
+++ b/src/generator/writers/writeExpression.ts
@@ -486,7 +486,7 @@ export function writeExpression(f: ASTExpression, ctx: WriterContext): string {
             ((src.kind !== "ref" || src.optional) && src.kind !== "ref_bounced")
         ) {
             throwError(
-                `Cannot access field of non-struct type: ${printTypeRef(src)}`,
+                `Cannot access field of non-struct type: "${printTypeRef(src)}"`,
                 f.ref,
             );
         }
@@ -609,7 +609,7 @@ export function writeExpression(f: ASTExpression, ctx: WriterContext): string {
         const src = getExpType(ctx.ctx, f.src);
         if (src === null) {
             throwError(
-                `Cannot call function of non - direct type: ${printTypeRef(src)} `,
+                `Cannot call function of non - direct type: "${printTypeRef(src)}"`,
                 f.ref,
             );
         }
@@ -618,7 +618,7 @@ export function writeExpression(f: ASTExpression, ctx: WriterContext): string {
         if (src.kind === "ref") {
             if (src.optional) {
                 throwError(
-                    `Cannot call function of non - direct type: ${printTypeRef(src)} `,
+                    `Cannot call function of non - direct type: "${printTypeRef(src)}"`,
                     f.ref,
                 );
             }
@@ -704,7 +704,7 @@ export function writeExpression(f: ASTExpression, ctx: WriterContext): string {
         }
 
         throwError(
-            `Cannot call function of non - direct type: ${printTypeRef(src)} `,
+            `Cannot call function of non - direct type: "${printTypeRef(src)}"`,
             f.ref,
         );
     }

--- a/src/generator/writers/writeFunction.ts
+++ b/src/generator/writers/writeFunction.ts
@@ -503,7 +503,7 @@ export function writeGetter(f: FunctionDescription, ctx: WriterContext) {
     // Render tensors
     const self = f.self ? getType(ctx.ctx, f.self) : null;
     if (!self) {
-        throw new Error(`No self type for getter ${f.name}`); // Impossible
+        throw new Error(`No self type for getter "${f.name}"`); // Impossible
     }
     ctx.append(
         `_ %${f.name}(${f.args.map((v) => resolveFuncTupledType(v.type, ctx) + " " + id("$" + v.name)).join(", ")}) method_id(${getMethodId(f.name)}) {`,

--- a/src/grammar/checkConstAttributes.ts
+++ b/src/grammar/checkConstAttributes.ts
@@ -8,7 +8,7 @@ export function checkConstAttributes(
     const k = new Set<string>();
     for (const a of attributes) {
         if (k.has(a.type)) {
-            throwError(`Duplicate function attribute ${a.type}`, a.ref);
+            throwError(`Duplicate function attribute "${a.type}"`, a.ref);
         }
         k.add(a.type);
     }

--- a/src/grammar/checkFunctionAttributes.ts
+++ b/src/grammar/checkFunctionAttributes.ts
@@ -8,7 +8,7 @@ export function checkFunctionAttributes(
     const k = new Set<string>();
     for (const a of attrs) {
         if (k.has(a.type)) {
-            throwError(`Duplicate function attribute ${a.type}`, a.ref);
+            throwError(`Duplicate function attribute "${a.type}"`, a.ref);
         }
         k.add(a.type);
     }

--- a/src/imports/resolveImports.ts
+++ b/src/imports/resolveImports.ts
@@ -42,7 +42,7 @@ export function resolveImports(args: {
                 stdlib: args.stdlib,
             });
             if (!resolved.ok) {
-                throw new Error(`Could not resolve import ${i} in ${path}`);
+                throw new Error(`Could not resolve import "${i}" in ${path}`);
             }
 
             // Check if already imported

--- a/src/test/feature-implicit-init.spec.ts
+++ b/src/test/feature-implicit-init.spec.ts
@@ -68,7 +68,7 @@ describe("feature-send", () => {
             projectNames: ["implicit-init-2"],
         });
         expect((consoleLogger.error as jest.Mock).mock.lastCall[0]).toContain(
-            "Field test_field is not set",
+            'Field "test_field" is not set',
         );
         expect(result).toBe(false);
     });

--- a/src/types/__snapshots__/resolveDescriptors.spec.ts.snap
+++ b/src/types/__snapshots__/resolveDescriptors.spec.ts.snap
@@ -59,7 +59,7 @@ Line 8, col 17:
 `;
 
 exports[`resolveDescriptors should fail descriptors for case-6 1`] = `
-"<unknown>:11:3: Field b already exists
+"<unknown>:11:3: Field "b" already exists
 Line 11, col 3:
   10 |   b: Int;
 > 11 |   b: Int;
@@ -69,7 +69,7 @@ Line 11, col 3:
 `;
 
 exports[`resolveDescriptors should fail descriptors for case-7 1`] = `
-"<unknown>:11:3: Field b already exists
+"<unknown>:11:3: Field "b" already exists
 Line 11, col 3:
   10 |   b: Int;
 > 11 |   b: Int;
@@ -119,7 +119,7 @@ Line 12, col 23:
 `;
 
 exports[`resolveDescriptors should fail descriptors for case-12 1`] = `
-"<unknown>:12:1: Type Main already exists
+"<unknown>:12:1: Type "Main" already exists
 Line 12, col 1:
   11 | 
 > 12 | struct Main {
@@ -129,7 +129,7 @@ Line 12, col 1:
 `;
 
 exports[`resolveDescriptors should fail descriptors for case-13 1`] = `
-"<unknown>:12:1: Type Main already exists
+"<unknown>:12:1: Type "Main" already exists
 Line 12, col 1:
   11 | 
 > 12 | struct Main {
@@ -139,7 +139,7 @@ Line 12, col 1:
 `;
 
 exports[`resolveDescriptors should fail descriptors for case-14 1`] = `
-"<unknown>:12:1: Type Main already exists
+"<unknown>:12:1: Type "Main" already exists
 Line 12, col 1:
   11 | 
 > 12 | contract Main {
@@ -149,7 +149,7 @@ Line 12, col 1:
 `;
 
 exports[`resolveDescriptors should fail descriptors for case-15 1`] = `
-"<unknown>:12:1: Struct Main must have at least one field
+"<unknown>:12:1: Struct "Main" must have at least one field
 Line 12, col 1:
   11 | 
 > 12 | struct Main {
@@ -159,7 +159,7 @@ Line 12, col 1:
 `;
 
 exports[`resolveDescriptors should fail descriptors for case-16 1`] = `
-"<unknown>:16:1: Struct Main must have at least one field
+"<unknown>:16:1: Struct "Main" must have at least one field
 Line 16, col 1:
   15 | 
 > 16 | struct Main {
@@ -169,7 +169,7 @@ Line 16, col 1:
 `;
 
 exports[`resolveDescriptors should fail descriptors for case-17 1`] = `
-"<unknown>:8:1: Function hello already exists in type Main
+"<unknown>:8:1: Function "hello" already exists in type "Main"
 Line 8, col 1:
   7 | 
 > 8 | contract Main {
@@ -199,7 +199,7 @@ Line 13, col 5:
 `;
 
 exports[`resolveDescriptors should fail descriptors for case-20 1`] = `
-"<unknown>:12:1: Function hello already exists in type Main
+"<unknown>:12:1: Function "hello" already exists in type "Main"
 Line 12, col 1:
   11 | 
 > 12 | extends fun hello(self: Main): Bool {
@@ -219,7 +219,7 @@ Line 17, col 3:
 `;
 
 exports[`resolveDescriptors should fail descriptors for case-22 1`] = `
-"<unknown>:24:3: Bounce receive function for A already exists
+"<unknown>:24:3: Bounce receive function for "A" already exists
 Line 24, col 3:
   23 |   
 > 24 |   bounced(msg: bounced<A>) {
@@ -259,7 +259,7 @@ Line 8, col 21:
 `;
 
 exports[`resolveDescriptors should fail descriptors for case-26 1`] = `
-"<unknown>:1:1: Static function ton already exists
+"<unknown>:1:1: Static function "ton" already exists
 Line 1, col 1:
 > 1 | fun ton() {
       ^~~~~~~~~~~
@@ -268,7 +268,7 @@ Line 1, col 1:
 `;
 
 exports[`resolveDescriptors should fail descriptors for case-27 1`] = `
-"<unknown>:1:1: Static function dumpStack already exists
+"<unknown>:1:1: Static function "dumpStack" already exists
 Line 1, col 1:
 > 1 | fun dumpStack() {
       ^~~~~~~~~~~~~~~~~

--- a/src/types/__snapshots__/resolveStatements.spec.ts.snap
+++ b/src/types/__snapshots__/resolveStatements.spec.ts.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`resolveStatements should fail statements for case-0 1`] = `
-"<unknown>:9:5: Type mismatch: Int is not assignable to Bool
+"<unknown>:9:5: Type mismatch: "Int" is not assignable to "Bool"
 Line 9, col 5:
    8 | fun isZero(x: Int): Bool {
 >  9 |     return x;
@@ -11,7 +11,7 @@ Line 9, col 5:
 `;
 
 exports[`resolveStatements should fail statements for case-1 1`] = `
-"<unknown>:9:5: Type mismatch: Bool is not assignable to Int
+"<unknown>:9:5: Type mismatch: "Bool" is not assignable to "Int"
 Line 9, col 5:
    8 | fun isZero(x: Int): Bool {
 >  9 |     repeat(true) {
@@ -21,7 +21,7 @@ Line 9, col 5:
 `;
 
 exports[`resolveStatements should fail statements for case-2 1`] = `
-"<unknown>:9:5: Type mismatch: Int is not assignable to bool
+"<unknown>:9:5: Type mismatch: "Int" is not assignable to "Bool"
 Line 9, col 5:
    8 | fun isZero(x: Int): Bool {
 >  9 |     while(x) {
@@ -31,7 +31,7 @@ Line 9, col 5:
 `;
 
 exports[`resolveStatements should fail statements for case-3 1`] = `
-"<unknown>:9:5: Type mismatch: Int is not assignable to bool
+"<unknown>:9:5: Type mismatch: "Int" is not assignable to "Bool"
 Line 9, col 5:
    8 | fun isZero(x: Int): Bool {
 >  9 |     do {
@@ -41,7 +41,7 @@ Line 9, col 5:
 `;
 
 exports[`resolveStatements should fail statements for case-4 1`] = `
-"<unknown>:9:5: Type mismatch: Int is not assignable to Bool
+"<unknown>:9:5: Type mismatch: "Int" is not assignable to "Bool"
 Line 9, col 5:
    8 | fun isZero(x: Int): Bool {
 >  9 |     if (x) {
@@ -51,7 +51,7 @@ Line 9, col 5:
 `;
 
 exports[`resolveStatements should fail statements for case-5 1`] = `
-"<unknown>:9:5: Type mismatch: String is not assignable to Int
+"<unknown>:9:5: Type mismatch: "String" is not assignable to "Int"
 Line 9, col 5:
    8 | fun isZero(x: Int): Bool {
 >  9 |     x = "hello world";
@@ -101,7 +101,7 @@ Line 20, col 27:
 `;
 
 exports[`resolveStatements should fail statements for case-10 1`] = `
-"<unknown>:10:5: Type mismatch: Int is not assignable to Bool
+"<unknown>:10:5: Type mismatch: "Int" is not assignable to "Bool"
 Line 10, col 5:
    9 |     let a: Int = 0;
 > 10 |     let b: Bool = 0;
@@ -111,7 +111,7 @@ Line 10, col 5:
 `;
 
 exports[`resolveStatements should fail statements for case-11 1`] = `
-"<unknown>:17:9: Invalid type "Bool" for fields "b" with type Int in type SomeStruct
+"<unknown>:17:9: Invalid type "Bool" for fields "b" with type "Int" in type "SomeStruct"
 Line 17, col 9:
   16 |         a: 1,
 > 17 |         b: false // Invalid type
@@ -131,7 +131,7 @@ Line 17, col 9:
 `;
 
 exports[`resolveStatements should fail statements for case-13 1`] = `
-"<unknown>:16:25: Missing fields "c" in type SomeStruct
+"<unknown>:16:25: Missing fields "c" in type "SomeStruct"
 Line 16, col 25:
   15 | fun main() {
 > 16 |     let a: SomeStruct = SomeStruct{
@@ -151,7 +151,7 @@ Line 26, col 25:
 `;
 
 exports[`resolveStatements should fail statements for case-15 1`] = `
-"<unknown>:10:5: Field value is not set
+"<unknown>:10:5: Field "value" is not set
 Line 10, col 5:
    9 |     value: Int;
 > 10 |     init() {
@@ -161,7 +161,7 @@ Line 10, col 5:
 `;
 
 exports[`resolveStatements should fail statements for case-16 1`] = `
-"<unknown>:10:5: Field value is not set
+"<unknown>:10:5: Field "value" is not set
 Line 10, col 5:
    9 |     value: Int;
 > 10 |     init(arg: Bool) {
@@ -171,7 +171,7 @@ Line 10, col 5:
 `;
 
 exports[`resolveStatements should fail statements for case-17 1`] = `
-"<unknown>:10:5: Field value is not set
+"<unknown>:10:5: Field "value" is not set
 Line 10, col 5:
    9 |     value: Int;
 > 10 |     init(arg: Bool) {
@@ -181,7 +181,7 @@ Line 10, col 5:
 `;
 
 exports[`resolveStatements should fail statements for case-18 1`] = `
-"<unknown>:10:5: Field value is not set
+"<unknown>:10:5: Field "value" is not set
 Line 10, col 5:
    9 |     value: Int;
 > 10 |     init(arg: Bool) {
@@ -281,7 +281,7 @@ Line 5, col 43:
 `;
 
 exports[`resolveStatements should fail statements for case-28 1`] = `
-"<unknown>:5:5: Type mismatch: Bool is not assignable to Int
+"<unknown>:5:5: Type mismatch: "Bool" is not assignable to "Int"
 Line 5, col 5:
   4 | fun sample(): Int {
 > 5 |     return (true ? true : false) ? true : false;
@@ -341,7 +341,7 @@ Line 5, col 16:
 `;
 
 exports[`resolveStatements should fail statements for case-34 1`] = `
-"<unknown>:6:5: Variable already exists: e
+"<unknown>:6:5: Variable already exists: "e"
 Line 6, col 5:
   5 |     let e: String = "qwe";
 > 6 |     try {
@@ -351,7 +351,7 @@ Line 6, col 5:
 `;
 
 exports[`resolveStatements should fail statements for case-35 1`] = `
-"<unknown>:8:9: Type mismatch: Int is not assignable to String
+"<unknown>:8:9: Type mismatch: "Int" is not assignable to "String"
 Line 8, col 9:
   7 |     } catch (e) {
 > 8 |         return e;
@@ -361,7 +361,7 @@ Line 8, col 9:
 `;
 
 exports[`resolveStatements should fail statements for case-36 1`] = `
-"<unknown>:14:26: Unknown fields "b" in type A
+"<unknown>:14:26: Unknown fields "b" in type "A"
 Line 14, col 26:
   13 | fun function() {
 > 14 |     let D: A = A { x: a, b };
@@ -371,7 +371,7 @@ Line 14, col 26:
 `;
 
 exports[`resolveStatements should fail statements for case-37 1`] = `
-"<unknown>:6:5: Type mismatch: Bool is not assignable to <void>
+"<unknown>:6:5: Type mismatch: "Bool" is not assignable to "<void>"
 Line 6, col 5:
   5 |     m.set(1, 2);
 > 6 |     return m.del(1);
@@ -471,7 +471,7 @@ Line 4, col 1:
 `;
 
 exports[`resolveStatements should fail statements for case-47 1`] = `
-"<unknown>:5:5: Variable already exists: k
+"<unknown>:5:5: Variable already exists: "k"
 Line 5, col 5:
   4 |     let m: map<Int, Int> = emptyMap();
 > 5 |     foreach (k, k in m) {
@@ -481,7 +481,7 @@ Line 5, col 5:
 `;
 
 exports[`resolveStatements should fail statements for case-48 1`] = `
-"<unknown>:5:5: Variable already exists: m
+"<unknown>:5:5: Variable already exists: "m"
 Line 5, col 5:
   4 |     let m: map<Int, Int> = emptyMap();
 > 5 |     foreach (k, m in m) {

--- a/src/types/resolveABITypeRef.ts
+++ b/src/types/resolveABITypeRef.ts
@@ -173,7 +173,7 @@ export function resolveABIType(src: ASTField): ABITypeRef {
             };
         }
         if (src.type.name === "StringBuilder") {
-            throwError(`Unsupported type ${src.type.name}`, src.ref);
+            throwError(`Unsupported type "${src.type.name}"`, src.ref);
         }
 
         //
@@ -232,7 +232,7 @@ export function resolveABIType(src: ASTField): ABITypeRef {
                 );
             }
         } else {
-            throwError(`Unsupported map key type ${src.type.key}`, src.ref);
+            throwError(`Unsupported map key type "${src.type.key}"`, src.ref);
         }
 
         // Resolve value type
@@ -267,7 +267,10 @@ export function resolveABIType(src: ASTField): ABITypeRef {
                 );
             }
         } else if (src.type.value === "Slice") {
-            throwError(`Unsupported map value type ${src.type.value}`, src.ref);
+            throwError(
+                `Unsupported map value type "${src.type.value}"`,
+                src.ref,
+            );
         } else if (src.type.value === "Address") {
             value = "address";
             if (src.type.valueAs) {
@@ -277,12 +280,18 @@ export function resolveABIType(src: ASTField): ABITypeRef {
                 );
             }
         } else if (src.type.value === "String") {
-            throwError(`Unsupported map value type ${src.type.value}`, src.ref);
+            throwError(
+                `Unsupported map value type "${src.type.value}"`,
+                src.ref,
+            );
         } else if (
             src.type.value === "StringBuilder" ||
             src.type.value === "Builder"
         ) {
-            throwError(`Unsupported map value type ${src.type.value}`, src.ref);
+            throwError(
+                `Unsupported map value type "${src.type.value}"`,
+                src.ref,
+            );
         } else {
             value = src.type.value;
             valueFormat = "ref";
@@ -333,7 +342,7 @@ export function createABITypeRefFromTypeRef(
             return { kind: "simple", type: "string", optional: src.optional };
         }
         if (src.name === "StringBuilder") {
-            throw Error(`Unsupported type ${src.name}`);
+            throw Error(`Unsupported type "${src.name}"`);
         }
 
         // Structs
@@ -366,7 +375,7 @@ export function createABITypeRefFromTypeRef(
                 throwError(`Unsupported format ${src.keyAs} for map key`, ref);
             }
         } else {
-            throw Error(`Unsupported map key type ${src.key}`);
+            throw Error(`Unsupported map key type "${src.key}"`);
         }
 
         // Resolve value type
@@ -401,7 +410,7 @@ export function createABITypeRefFromTypeRef(
                 );
             }
         } else if (src.value === "Slice") {
-            throw Error(`Unsupported map value type ${src.value}`);
+            throw Error(`Unsupported map value type "${src.value}"`);
         } else if (src.value === "Address") {
             value = "address";
             if (src.valueAs) {
@@ -411,9 +420,9 @@ export function createABITypeRefFromTypeRef(
                 );
             }
         } else if (src.value === "String") {
-            throw Error(`Unsupported map value type ${src.value}`);
+            throw Error(`Unsupported map value type "${src.value}"`);
         } else if (src.value === "StringBuilder" || src.value === "Builder") {
-            throw Error(`Unsupported map value type ${src.value}`);
+            throw Error(`Unsupported map value type "${src.value}"`);
         } else {
             value = src.value;
             valueFormat = "ref";

--- a/src/types/resolveConstantValue.ts
+++ b/src/types/resolveConstantValue.ts
@@ -185,7 +185,7 @@ export function resolveConstantValue(
 
     if (type.kind !== "ref") {
         throwError(
-            `Expected constant value, got ${printTypeRef(type)}`,
+            `Expected constant value, got "${printTypeRef(type)}"`,
             ast.ref,
         );
     }
@@ -222,5 +222,5 @@ export function resolveConstantValue(
         return reduceCell(ast);
     }
 
-    throwError(`Expected constant value, got ${printTypeRef(type)}`, ast.ref);
+    throwError(`Expected constant value, got "${printTypeRef(type)}"`, ast.ref);
 }

--- a/src/types/resolveDescriptors.ts
+++ b/src/types/resolveDescriptors.ts
@@ -200,7 +200,7 @@ export function resolveDescriptors(ctx: CompilerContext) {
 
     for (const a of ast.types) {
         if (types.has(a.name)) {
-            throwError(`Type ${a.name} already exists`, a.ref);
+            throwError(`Type "${a.name}" already exists`, a.ref);
         }
 
         const uid = uidForName(a.name, types);
@@ -347,14 +347,17 @@ export function resolveDescriptors(ctx: CompilerContext) {
                     if (
                         types.get(a.name)!.fields.find((v) => v.name === f.name)
                     ) {
-                        throwError(`Field ${f.name} already exists`, f.ref);
+                        throwError(`Field "${f.name}" already exists`, f.ref);
                     }
                     if (
                         types
                             .get(a.name)!
                             .constants.find((v) => v.name === f.name)
                     ) {
-                        throwError(`Constant ${f.name} already exists`, f.ref);
+                        throwError(
+                            `Constant "${f.name}" already exists`,
+                            f.ref,
+                        );
                     }
                     types
                         .get(a.name)!
@@ -368,14 +371,17 @@ export function resolveDescriptors(ctx: CompilerContext) {
                     if (
                         types.get(a.name)!.fields.find((v) => v.name === f.name)
                     ) {
-                        throwError(`Field ${f.name} already exists`, f.ref);
+                        throwError(`Field "${f.name}" already exists`, f.ref);
                     }
                     if (
                         types
                             .get(a.name)!
                             .constants.find((v) => v.name === f.name)
                     ) {
-                        throwError(`Constant ${f.name} already exists`, f.ref);
+                        throwError(
+                            `Constant "${f.name}" already exists`,
+                            f.ref,
+                        );
                     }
                     if (f.attributes.find((v) => v.type !== "overrides")) {
                         throwError(`Constant can be only overridden`, f.ref);
@@ -391,7 +397,7 @@ export function resolveDescriptors(ctx: CompilerContext) {
         if (a.kind === "def_struct") {
             for (const f of a.fields) {
                 if (types.get(a.name)!.fields.find((v) => v.name === f.name)) {
-                    throwError(`Field ${f.name} already exists`, f.ref);
+                    throwError(`Field "${f.name}" already exists`, f.ref);
                 }
                 types
                     .get(a.name)!
@@ -404,7 +410,7 @@ export function resolveDescriptors(ctx: CompilerContext) {
             }
             if (a.fields.length === 0 && !a.message) {
                 throwError(
-                    `Struct ${a.name} must have at least one field`,
+                    `Struct "${a.name}" must have at least one field`,
                     a.ref,
                 );
             }
@@ -417,7 +423,7 @@ export function resolveDescriptors(ctx: CompilerContext) {
                     if (
                         types.get(a.name)!.fields.find((v) => v.name === f.name)
                     ) {
-                        throwError(`Field ${f.name} already exists`, f.ref);
+                        throwError(`Field "${f.name}" already exists`, f.ref);
                     }
                     if (f.as) {
                         throwError(
@@ -437,14 +443,17 @@ export function resolveDescriptors(ctx: CompilerContext) {
                     if (
                         types.get(a.name)!.fields.find((v) => v.name === f.name)
                     ) {
-                        throwError(`Field ${f.name} already exists`, f.ref);
+                        throwError(`Field "${f.name}" already exists`, f.ref);
                     }
                     if (
                         types
                             .get(a.name)!
                             .constants.find((v) => v.name === f.name)
                     ) {
-                        throwError(`Constant ${f.name} already exists`, f.ref);
+                        throwError(
+                            `Constant "${f.name}" already exists`,
+                            f.ref,
+                        );
                     }
                     if (f.attributes.find((v) => v.type === "overrides")) {
                         throwError(
@@ -765,7 +774,7 @@ export function resolveDescriptors(ctx: CompilerContext) {
                     }
                     if (s.functions.has(f.name)) {
                         throwError(
-                            `Function ${f.name} already exists in type ${s.name}`,
+                            `Function "${f.name}" already exists in type "${s.name}"`,
                             s.ast.ref,
                         );
                     }
@@ -912,7 +921,7 @@ export function resolveDescriptors(ctx: CompilerContext) {
                                 )
                             ) {
                                 throwError(
-                                    `Receive function for ${arg.type.name} already exists`,
+                                    `Receive function for "${arg.type.name}" already exists`,
                                     d.ref,
                                 );
                             }
@@ -1055,7 +1064,7 @@ export function resolveDescriptors(ctx: CompilerContext) {
                                     )
                                 ) {
                                     throwError(
-                                        `Bounce receive function for ${arg.type.name} already exists`,
+                                        `Bounce receive function for "${arg.type.name}" already exists`,
                                         d.ref,
                                     );
                                 }
@@ -1097,7 +1106,7 @@ export function resolveDescriptors(ctx: CompilerContext) {
                                 )
                             ) {
                                 throwError(
-                                    `Bounce receive function for ${t.name} already exists`,
+                                    `Bounce receive function for "${t.name}" already exists`,
                                     d.ref,
                                 );
                             }
@@ -1213,7 +1222,7 @@ export function resolveDescriptors(ctx: CompilerContext) {
                 const ex = t.fields.find((v) => v.name === f.name);
                 if (!ex) {
                     throwError(
-                        `Trait ${tr.name} requires field ${f.name}`,
+                        `Trait "${tr.name}" requires field "${f.name}"`,
                         t.ast.ref,
                     );
                 }
@@ -1221,7 +1230,7 @@ export function resolveDescriptors(ctx: CompilerContext) {
                 // Check type
                 if (!typeRefEquals(f.type, ex.type)) {
                     throwError(
-                        `Trait ${tr.name} requires field ${f.name} of type ${printTypeRef(f.type)}`,
+                        `Trait "${tr.name}" requires field "${f.name}" of type "${printTypeRef(f.type)}"`,
                         t.ast.ref,
                     );
                 }
@@ -1240,7 +1249,7 @@ export function resolveDescriptors(ctx: CompilerContext) {
                 const ex = t.functions.get(f.name);
                 if (!ex && f.isAbstract) {
                     throwError(
-                        `Trait ${tr.name} requires function ${f.name}`,
+                        `Trait "${tr.name}" requires function "${f.name}"`,
                         t.ast.ref,
                     );
                 }
@@ -1249,25 +1258,25 @@ export function resolveDescriptors(ctx: CompilerContext) {
                 if (ex && ex.isOverrides) {
                     if (f.isGetter) {
                         throwError(
-                            `Overridden function ${f.name} can not be a getter`,
+                            `Overridden function "${f.name}" can not be a getter`,
                             ex.ast.ref,
                         );
                     }
                     if (f.isMutating !== ex.isMutating) {
                         throwError(
-                            `Overridden function ${f.name} should have same mutability`,
+                            `Overridden function "${f.name}" should have same mutability`,
                             ex.ast.ref,
                         );
                     }
                     if (!typeRefEquals(f.returns, ex.returns)) {
                         throwError(
-                            `Overridden function ${f.name} should have same return type`,
+                            `Overridden function "${f.name}" should have same return type`,
                             ex.ast.ref,
                         );
                     }
                     if (f.args.length !== ex.args.length) {
                         throwError(
-                            `Overridden function ${f.name} should have same number of arguments`,
+                            `Overridden function "${f.name}" should have same number of arguments`,
                             ex.ast.ref,
                         );
                     }
@@ -1276,7 +1285,7 @@ export function resolveDescriptors(ctx: CompilerContext) {
                         const b = f.args[i];
                         if (!typeRefEquals(a.type, b.type)) {
                             throwError(
-                                `Overridden function ${f.name} should have same argument types`,
+                                `Overridden function "${f.name}" should have same argument types`,
                                 ex.ast.ref,
                             );
                         }
@@ -1287,7 +1296,7 @@ export function resolveDescriptors(ctx: CompilerContext) {
                 // Check duplicates
                 if (ex) {
                     throwError(
-                        `Function ${f.name} already exist in ${t.name}`,
+                        `Function "${f.name}" already exist in "${t.name}"`,
                         t.ast.ref,
                     );
                 }
@@ -1308,7 +1317,7 @@ export function resolveDescriptors(ctx: CompilerContext) {
                     f.ast.attributes.find((v) => v.type === "abstract")
                 ) {
                     throwError(
-                        `Trait ${tr.name} requires constant ${f.name}`,
+                        `Trait "${tr.name}" requires constant "${f.name}"`,
                         t.ast.ref,
                     );
                 }
@@ -1320,7 +1329,7 @@ export function resolveDescriptors(ctx: CompilerContext) {
                 ) {
                     if (!typeRefEquals(f.type, ex.type)) {
                         throwError(
-                            `Overridden constant ${f.name} should have same type`,
+                            `Overridden constant "${f.name}" should have same type`,
                             ex.ast.ref,
                         );
                     }
@@ -1330,7 +1339,7 @@ export function resolveDescriptors(ctx: CompilerContext) {
                 // Check duplicates
                 if (ex) {
                     throwError(
-                        `Constant ${f.name} already exist in ${t.name}`,
+                        `Constant "${f.name}" already exist in "${t.name}"`,
                         t.ast.ref,
                     );
                 }
@@ -1430,7 +1439,7 @@ export function resolveDescriptors(ctx: CompilerContext) {
         }
         if (processing.has(name)) {
             throwError(
-                `Circular dependency detected for type ${name}`,
+                `Circular dependency detected for type "${name}"`,
                 types.get(name)!.ast.ref,
             );
         }
@@ -1464,7 +1473,7 @@ export function resolveDescriptors(ctx: CompilerContext) {
         const handler = (src: ASTNode) => {
             if (src.kind === "init_of") {
                 if (!types.has(src.name)) {
-                    throwError(`Type ${src.name} not found`, src.ref);
+                    throwError(`Type "${src.name}" not found`, src.ref);
                 }
                 dependsOn.add(src.name);
             }
@@ -1520,7 +1529,7 @@ export function resolveDescriptors(ctx: CompilerContext) {
         if (r.self) {
             if (types.get(r.self)!.functions.has(r.name)) {
                 throwError(
-                    `Function ${r.name} already exists in type ${r.self}`,
+                    `Function "${r.name}" already exists in type "${r.self}"`,
                     r.ast.ref,
                 );
             }
@@ -1528,12 +1537,12 @@ export function resolveDescriptors(ctx: CompilerContext) {
         } else {
             if (staticFunctions.has(r.name) || GlobalFunctions.has(r.name)) {
                 throwError(
-                    `Static function ${r.name} already exists`,
+                    `Static function "${r.name}" already exists`,
                     r.ast.ref,
                 );
             }
             if (staticConstants.has(r.name)) {
-                throwError(`Static constant ${r.name} already exists`, a.ref);
+                throwError(`Static constant "${r.name}" already exists`, a.ref);
             }
             staticFunctions.set(r.name, r);
         }
@@ -1545,10 +1554,10 @@ export function resolveDescriptors(ctx: CompilerContext) {
 
     for (const a of ast.constants) {
         if (staticConstants.has(a.name)) {
-            throwError(`Static constant ${a.name} already exists`, a.ref);
+            throwError(`Static constant "${a.name}" already exists`, a.ref);
         }
         if (staticFunctions.has(a.name) || GlobalFunctions.has(a.name)) {
-            throwError(`Static function ${a.name} already exists`, a.ref);
+            throwError(`Static function "${a.name}" already exists`, a.ref);
         }
         staticConstants.set(a.name, buildConstantDescription(a));
     }

--- a/src/types/resolveErrors.ts
+++ b/src/types/resolveErrors.ts
@@ -34,7 +34,7 @@ function resolveStringsInAST(ast: ASTNode, ctx: CompilerContext) {
                 if (
                     Object.values(exceptions.all(ctx)).find((v) => v.id === id)
                 ) {
-                    throw new Error(`Duplicate error id: ${resolved}`);
+                    throw new Error(`Duplicate error id: "${resolved}"`);
                 }
                 ctx = exceptions.set(ctx, resolved, { value: resolved, id });
             }

--- a/src/types/resolveExpression.ts
+++ b/src/types/resolveExpression.ts
@@ -131,7 +131,10 @@ function resolveStructNew(
         // Check existing
         const f = tp.fields.find((v) => v.name === e.name);
         if (!f) {
-            throwError(`Unknown fields "${e.name}" in type ${tp.name}`, e.ref);
+            throwError(
+                `Unknown fields "${e.name}" in type "${tp.name}"`,
+                e.ref,
+            );
         }
 
         // Resolve expression
@@ -141,7 +144,7 @@ function resolveStructNew(
         const expressionType = getExpType(ctx, e.exp);
         if (!isAssignable(expressionType, f.type)) {
             throwError(
-                `Invalid type "${printTypeRef(expressionType)}" for fields "${e.name}" with type ${printTypeRef(f.type)} in type ${tp.name}`,
+                `Invalid type "${printTypeRef(expressionType)}" for fields "${e.name}" with type "${printTypeRef(f.type)}" in type "${tp.name}"`,
                 e.ref,
             );
         }
@@ -151,7 +154,7 @@ function resolveStructNew(
     for (const f of tp.fields) {
         if (f.default === undefined && !processed.has(f.name)) {
             throwError(
-                `Missing fields "${f.name}" in type ${tp.name}`,
+                `Missing fields "${f.name}" in type "${tp.name}"`,
                 exp.ref,
             );
         }

--- a/src/types/resolveStatements.ts
+++ b/src/types/resolveStatements.ts
@@ -182,7 +182,7 @@ function processStatements(
 
             // Add variable to statement context
             if (sctx.vars.has(s.name)) {
-                throwError(`Variable already exists: "${s.name}"`, s.ref);
+                throwError(`Variable "${s.name}" already exists`, s.ref);
             }
             sctx = addVariable(s.name, variableType, sctx);
         } else if (s.kind === "statement_assign") {

--- a/src/types/resolveStatements.ts
+++ b/src/types/resolveStatements.ts
@@ -175,14 +175,14 @@ function processStatements(
             const variableType = resolveTypeRef(ctx, s.type);
             if (!isAssignable(expressionType, variableType)) {
                 throwError(
-                    `Type mismatch: ${printTypeRef(expressionType)} is not assignable to ${printTypeRef(variableType)}`,
+                    `Type mismatch: "${printTypeRef(expressionType)}" is not assignable to "${printTypeRef(variableType)}"`,
                     s.ref,
                 );
             }
 
             // Add variable to statement context
             if (sctx.vars.has(s.name)) {
-                throwError(`Variable already exists: ${s.name}`, s.ref);
+                throwError(`Variable already exists: "${s.name}"`, s.ref);
             }
             sctx = addVariable(s.name, variableType, sctx);
         } else if (s.kind === "statement_assign") {
@@ -197,7 +197,7 @@ function processStatements(
             const tailType = getExpType(ctx, s.path[s.path.length - 1]);
             if (!isAssignable(expressionType, tailType)) {
                 throwError(
-                    `Type mismatch: ${printTypeRef(expressionType)} is not assignable to ${printTypeRef(tailType)}`,
+                    `Type mismatch: "${printTypeRef(expressionType)}" is not assignable to "${printTypeRef(tailType)}"`,
                     s.ref,
                 );
             }
@@ -259,7 +259,7 @@ function processStatements(
                 expressionType.optional
             ) {
                 throwError(
-                    `Type mismatch: ${printTypeRef(expressionType)} is not assignable to Bool`,
+                    `Type mismatch: "${printTypeRef(expressionType)}" is not assignable to "Bool"`,
                     s.ref,
                 );
             }
@@ -272,14 +272,14 @@ function processStatements(
                 const expressionType = getExpType(ctx, s.expression);
                 if (!isAssignable(expressionType, sctx.returns)) {
                     throwError(
-                        `Type mismatch: ${printTypeRef(expressionType)} is not assignable to ${printTypeRef(sctx.returns)}`,
+                        `Type mismatch: "${printTypeRef(expressionType)}" is not assignable to "${printTypeRef(sctx.returns)}"`,
                         s.ref,
                     );
                 }
             } else {
                 if (sctx.returns.kind !== "void") {
                     throwError(
-                        `Type mismatch: void is not assignable to ${printTypeRef(sctx.returns)}`,
+                        `Type mismatch: "void" is not assignable to "${printTypeRef(sctx.returns)}"`,
                         s.ref,
                     );
                 }
@@ -289,12 +289,12 @@ function processStatements(
             if (sctx.requiredFields.length > 0) {
                 if (sctx.requiredFields.length === 1) {
                     throwError(
-                        `Field ${sctx.requiredFields[0]} is not set`,
+                        `Field "${sctx.requiredFields[0]}" is not set`,
                         sctx.root,
                     );
                 } else {
                     throwError(
-                        `Fields ${sctx.requiredFields.join(", ")} are not set`,
+                        `Fields ${sctx.requiredFields.map((x) => '"' + x + '"').join(", ")} are not set`,
                         sctx.root,
                     );
                 }
@@ -317,7 +317,7 @@ function processStatements(
                 expressionType.optional
             ) {
                 throwError(
-                    `Type mismatch: ${printTypeRef(expressionType)} is not assignable to Int`,
+                    `Type mismatch: "${printTypeRef(expressionType)}" is not assignable to "Int"`,
                     s.ref,
                 );
             }
@@ -340,7 +340,7 @@ function processStatements(
                 expressionType.optional
             ) {
                 throwError(
-                    `Type mismatch: ${printTypeRef(expressionType)} is not assignable to bool`,
+                    `Type mismatch: "${printTypeRef(expressionType)}" is not assignable to "Bool"`,
                     s.ref,
                 );
             }
@@ -363,7 +363,7 @@ function processStatements(
                 expressionType.optional
             ) {
                 throwError(
-                    `Type mismatch: ${printTypeRef(expressionType)} is not assignable to bool`,
+                    `Type mismatch: "${printTypeRef(expressionType)}" is not assignable to "Bool"`,
                     s.ref,
                 );
             }
@@ -383,7 +383,7 @@ function processStatements(
 
             // Process catchName variable for exit code
             if (initialCtx.vars.has(s.catchName)) {
-                throwError(`Variable already exists: ${s.catchName}`, s.ref);
+                throwError(`Variable already exists: "${s.catchName}"`, s.ref);
             }
             let catchCtx = addVariable(
                 s.catchName,
@@ -419,12 +419,12 @@ function processStatements(
             // Check if map is valid
             const mapVariable = sctx.vars.get(s.map.value);
             if (!mapVariable || mapVariable.kind !== "map") {
-                throwError(`Variable ${s.map.value} is not a map`, s.ref);
+                throwError(`Variable "${s.map.value}" is not a map`, s.ref);
             }
 
             // Add key and value to statement context
             if (initialCtx.vars.has(s.keyName)) {
-                throwError(`Variable already exists: ${s.keyName}`, s.ref);
+                throwError(`Variable already exists: "${s.keyName}"`, s.ref);
             }
             let foreachCtx = addVariable(
                 s.keyName,
@@ -432,7 +432,7 @@ function processStatements(
                 initialCtx,
             );
             if (foreachCtx.vars.has(s.valueName)) {
-                throwError(`Variable already exists: ${s.valueName}`, s.ref);
+                throwError(`Variable already exists: "${s.valueName}"`, s.ref);
             }
             foreachCtx = addVariable(
                 s.valueName,
@@ -484,12 +484,12 @@ function processFunctionBody(
     if (res.sctx.requiredFields.length > 0) {
         if (res.sctx.requiredFields.length === 1) {
             throwError(
-                `Field ${res.sctx.requiredFields[0]} is not set`,
+                `Field "${res.sctx.requiredFields[0]}" is not set`,
                 res.sctx.root,
             );
         } else {
             throwError(
-                `Fields ${res.sctx.requiredFields.join(", ")} are not set`,
+                `Fields ${res.sctx.requiredFields.map((x) => '"' + x + '"').join(", ")} are not set`,
                 res.sctx.root,
             );
         }


### PR DESCRIPTION
Closes #361 

- [x] I have updated CHANGELOG.md
- [x] I have added tests to demonstrate the contribution is correctly implemented: this usually includes both positive and negative tests, showing the happy path(s) and featuring intentionally broken cases
- [x] I have run all the tests locally and no test failure was reported
- [x] I did not do unrelated and/or undiscussed refactorings
