### PR TITLE
refactor(grammar): simplify grammatical categories

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Refactor AST types to simplify access to third-party tools: PR [#325](https://github.com/tact-lang/tact/pull/325)
 - Refactor the compiler API used to access AST store: PR [#326](https://github.com/tact-lang/tact/pull/326)
 - Update JSON Schema to inform about usage in Blueprint: PR [#330](https://github.com/tact-lang/tact/pull/330)
+- The Tact grammar has been refactored for better readability: PR [#365](https://github.com/tact-lang/tact/pull/365)
 
 ### Fixed
 
@@ -25,6 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Augmented assignment now throws compilation error for non-integer types: PR [#356](https://github.com/tact-lang/tact/pull/356)
 - Built-in function `address()` now handles parse errors correctly: PR [#357](https://github.com/tact-lang/tact/pull/357)
 - All identifiers in error messages are now quoted for consistency: PR [#363](https://github.com/tact-lang/tact/pull/363)
+- The grammar of the unary operators has been fixed, constant and function declarations are prohibited for contracts and at the top level of Tact modules: PR [#365](https://github.com/tact-lang/tact/pull/365)
 
 ## [1.3.0] - 2024-05-03
 

--- a/src/grammar/__snapshots__/grammar.spec.ts.snap
+++ b/src/grammar/__snapshots__/grammar.spec.ts.snap
@@ -1,10 +1,10 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`grammar should fail case-0 1`] = `
-"<unknown>:1:1: Abstract function doesn't have abstract modifier
-Line 1, col 1:
+"<unknown>:1:20: Syntax error: expected "{" 
+Line 1, col 20:
 > 1 | fun testFunc(): Int;
-      ^~~~~~~~~~~~~~~~~~~~
+                         ^
 "
 `;
 
@@ -230,18 +230,22 @@ Line 2, col 23:
 `;
 
 exports[`grammar should fail case-24 1`] = `
-"<unknown>:1:31: Empty parameter list should not have a dangling comma.
-Line 1, col 31:
-> 1 | abstract fun testFuncAbstract(,);
+"<unknown>:2:31: Empty parameter list should not have a dangling comma.
+Line 2, col 31:
+  1 | trait Test {
+> 2 |     abstract fun testAbstract(,);
                                     ^
+  3 | }
 "
 `;
 
 exports[`grammar should fail case-25 1`] = `
-"<unknown>:1:39: Empty parameter list should not have a dangling comma.
-Line 1, col 39:
-> 1 | abstract fun testFuncAbstractWithType(,): Int;
+"<unknown>:2:39: Empty parameter list should not have a dangling comma.
+Line 2, col 39:
+  1 | trait Test {
+> 2 |     abstract fun testAbstractWithType(,): Int;
                                             ^
+  3 | }
 "
 `;
 
@@ -2231,7 +2235,7 @@ exports[`grammar should parse case-17 1`] = `
       "id": 10,
       "kind": "def_constant",
       "name": "a",
-      "ref": const a: A = new { x: 1 };,
+      "ref": const a: A = A { x: 1 };,
       "type": {
         "id": 6,
         "kind": "type_ref_simple",
@@ -2256,8 +2260,8 @@ exports[`grammar should parse case-17 1`] = `
         ],
         "id": 9,
         "kind": "op_new",
-        "ref": new { x: 1 },
-        "type": "new",
+        "ref": A { x: 1 },
+        "type": "A",
       },
     },
     {
@@ -2375,7 +2379,7 @@ exports[`grammar should parse case-17 1`] = `
       "id": 30,
       "kind": "def_constant",
       "name": "b",
-      "ref": const b: B = new {
+      "ref": const b: B = B {
     x: 2,
     y: 3,
 };,
@@ -2415,11 +2419,11 @@ exports[`grammar should parse case-17 1`] = `
         ],
         "id": 29,
         "kind": "op_new",
-        "ref": new {
+        "ref": B {
     x: 2,
     y: 3,
 },
-        "type": "new",
+        "type": "B",
       },
     },
     {

--- a/src/grammar/ast.ts
+++ b/src/grammar/ast.ts
@@ -354,36 +354,38 @@ export type ASTFunction = {
     ref: ASTRef;
 };
 
+export type ASTReceiveType =
+    | {
+          kind: "internal-simple";
+          arg: ASTArgument;
+      }
+    | {
+          kind: "internal-fallback";
+      }
+    | {
+          kind: "internal-comment";
+          comment: ASTString;
+      }
+    | {
+          kind: "bounce";
+          arg: ASTArgument;
+      }
+    | {
+          kind: "external-simple";
+          arg: ASTArgument;
+      }
+    | {
+          kind: "external-fallback";
+      }
+    | {
+          kind: "external-comment";
+          comment: ASTString;
+      };
+
 export type ASTReceive = {
     kind: "def_receive";
     id: number;
-    selector:
-        | {
-              kind: "internal-simple";
-              arg: ASTArgument;
-          }
-        | {
-              kind: "internal-fallback";
-          }
-        | {
-              kind: "internal-comment";
-              comment: ASTString;
-          }
-        | {
-              kind: "bounce";
-              arg: ASTArgument;
-          }
-        | {
-              kind: "external-simple";
-              arg: ASTArgument;
-          }
-        | {
-              kind: "external-fallback";
-          }
-        | {
-              kind: "external-comment";
-              comment: ASTString;
-          };
+    selector: ASTReceiveType;
     statements: ASTStatement[];
     ref: ASTRef;
 };

--- a/src/grammar/grammar.ohm
+++ b/src/grammar/grammar.ohm
@@ -1,90 +1,88 @@
 Tact {
 
-    // Starting point of the program
-    Program = ProgramItem*
-    ProgramItem = Struct
-                | Contract
-                | Primitive
-                | StaticFunction
-                | NativeFunction
-                | ProgramImport
-                | Trait
-                | Constant
-    ProgramImport = import stringLiteral ";"
+    Module = Import* ModuleItem*
+
+    ModuleItem = PrimitiveTypeDecl
+               | ModuleFunction
+               | NativeFunctionDecl
+               | ModuleConstant
+               | StructDecl
+               | Contract
+               | Trait
+
+    Import = import stringLiteral ";"
 
     // Built-in declarations
-    Primitive = "primitive" Type ";"
+    PrimitiveTypeDecl = primitive Type ";"
 
-    // Static function
-    StaticFunction = Function
-    NativeFunction = nameAttribute "(" funcId ")" FunctionAttribute* native id "(" ListOf<FunctionArg,","> ","? ")" ";" --withVoid
-                   | nameAttribute "(" funcId ")" FunctionAttribute* native id "(" ListOf<FunctionArg,","> ","? ")" ":" Type ";" --withType
-    
-    // Field declarations
-    Type = typeLiteral "?" --optional
-         | typeLiteral --required
-         | "map" "<" typeLiteral (as id)? "," typeLiteral (as id)? ">" --map
-         | "bounced" "<" typeLiteral ">" --bounced
-    Field = id ":" Type ";" --default
-          | id ":" Type "=" Expression ";" --defaultWithInit
-          | id ":" Type as id ";" --withSerialization
-          | id ":" Type as id "=" Expression ";" --withSerializationAndInit
-    
-    // Constant
+    ModuleFunction = FunctionDefinition
+
+    ModuleConstant = ConstantDefinition
+
+    NativeFunctionDecl = "@name" "(" funcId ")" FunctionAttribute* native id "(" ListOf<Parameter,","> ","? ")" (":" Type)? ";"
+
+    Type = typeId "?" --optional
+         | typeId --regular
+         | map "<" typeId (as id)? "," typeId (as id)? ">" --map
+         | "bounced" "<" typeId ">" --bounced
+
+    FieldDecl = id ":" Type (as id)? ("=" Expression)? ";"
+
     ConstantAttribute = virtual    --virtual
                       | override   --override
                       | abstract   --abstract
-    Constant = ConstantAttribute* ~fun const id ":" Type "=" Expression ";" --withValue
-             | ConstantAttribute* ~fun const id ":" Type ";"                --withEmpty
 
-    // Struct
-    Struct = "struct" typeLiteral "{" StructBody* "}" --originary
-           | "message" typeLiteral "{" StructBody* "}" --message
-           | "message" "(" integerLiteral ")" typeLiteral "{" StructBody* "}" --messageWithId
-    StructBody = Field
+    ConstantDefinition = ConstantAttribute* const id ":" Type "=" Expression ";"
 
-    // Contract
-    Contract = ContractAttribute* contract id "{" ContractBody* "}" --simple
-             | ContractAttribute* contract id with NonemptyListOf<id,","> ","? "{" ContractBody* "}" --withTraits
-    ContractInit = "init" "(" ListOf<FunctionArg,","> ","? ")" "{" Statement* "}"
-    ContractBody = Field
-                 | ContractInit
-                 | ReceiveFunction
-                 | Function
-                 | Constant
-    
-    // Trait
-    Trait = ContractAttribute* trait id "{" TraitBody* "}" --originary
-          | ContractAttribute* trait id with NonemptyListOf<id,","> ","? "{" TraitBody* "}" --withTraits
-    TraitBody = Field
-              | ReceiveFunction
-              | Function
-              | Constant
+    ConstantDeclaration = ConstantAttribute* const id ":" Type ";"
 
-    // Contract attributes
+    StructDecl = "struct" typeId "{" StructField* "}" --regular
+               | "message" ("(" integerLiteral ")")? typeId "{" StructField* "}" --message
+
+    StructField = FieldDecl
+
+    Contract = ContractAttribute* contract id (with NonemptyListOf<id,","> ","?)? "{" ContractItemDecl* "}"
+
+    ContractItemDecl = ContractInit
+                     | StorageVar
+                     | Receiver
+                     | FunctionDefinition
+                     | ConstantDefinition
+
+    Trait = ContractAttribute* trait id (with NonemptyListOf<id,","> ","?)? "{" TraitItemDecl* "}"
+
+    TraitItemDecl = StorageVar
+                  | Receiver
+                  | FunctionDeclaration
+                  | FunctionDefinition
+                  | ConstantDefinition
+                  | ConstantDeclaration
+
+    StorageVar = FieldDecl
+
+    ContractInit = "init" "(" ListOf<Parameter,","> ","? ")" "{" Statement* "}"
+
     ContractAttribute = "@interface" "(" stringLiteral ")" --interface
 
-    // Function
-    FunctionAttribute = "get"     --getter
+    FunctionAttribute = "get"     --getter      // 'get' cannot be a reserved word because there is the map '.get' method
                       | mutates   --mutates
                       | extends   --extends
                       | virtual   --virtual
                       | override  --override
                       | inline    --inline
                       | abstract  --abstract
-    Function = FunctionAttribute* fun id "(" ListOf<FunctionArg,","> ","? ")" "{" Statement* "}" --withVoid
-             | FunctionAttribute* fun id "(" ListOf<FunctionArg,","> ","? ")" ":" Type "{" Statement* "}" --withType
-             | FunctionAttribute* fun id "(" ListOf<FunctionArg,","> ","? ")" ";" --abstractVoid
-             | FunctionAttribute* fun id "(" ListOf<FunctionArg,","> ","? ")" ":" Type ";" --abstractType
-    FunctionArg = id ":" Type
-    
-    ReceiveFunction = "receive" "(" FunctionArg ")" "{" Statement* "}" --simple
-                    | "receive" "(" ")" "{" Statement* "}" --empty
-                    | "receive" "(" stringLiteral ")" "{" Statement* "}" --comment
-                    | "bounced" "(" FunctionArg ")" "{" Statement* "}" --bounced
-                    | "external" "(" FunctionArg ")" "{" Statement* "}" --externalSimple
-                    | "external" "(" stringLiteral ")" "{" Statement* "}" --externalComment
-                    | "external" "(" ")" "{" Statement* "}" --externalEmpty
+
+    FunctionDefinition = FunctionAttribute* fun id "(" ListOf<Parameter,","> ","? ")" (":" Type)? "{" Statement* "}"
+
+    FunctionDeclaration = FunctionAttribute* fun id "(" ListOf<Parameter,","> ","? ")" (":" Type)? ";"
+
+    Parameter = id ":" Type
+
+    Receiver = receive "(" Parameter? ")" "{" Statement* "}" --regular
+             | receive "(" stringLiteral ")" "{" Statement* "}" --comment
+             | "bounced" "(" Parameter ")" "{" Statement* "}" --bounced            // cannot be a reserved word because there a 'bounced' field in stdlib's 'Context' structure
+             | external "(" Parameter? ")" "{" Statement* "}" --externalRegular
+             | external "(" stringLiteral ")" "{" Statement* "}" --externalComment
 
     // Statements
     Statement = StatementLet
@@ -92,155 +90,181 @@ Tact {
               | StatementReturn
               | StatementExpression
               | StatementAssign
-              | StatementAugmentedAssign
               | StatementCondition
               | StatementWhile
               | StatementRepeat
               | StatementUntil
               | StatementTry
               | StatementForEach
+
     StatementBlock = "{" Statement* "}"
+
     StatementLet = let id ":" Type "=" Expression ";"
-    StatementReturn = return Expression ";" --withExpression
-                    | return ";" --withoutExpression    
+
+    StatementReturn = return Expression? ";"
+
     StatementExpression = Expression ";"
-    StatementAssign = LValue "=" Expression ";"
-    StatementAugmentedAssign = StatementAugmentedAssignAdd
-                             | StatementAugmentedAssignSub
-                             | StatementAugmentedAssignMul
-                             | StatementAugmentedAssignDiv
-                             | StatementAugmentedAssignRem
-    StatementAugmentedAssignAdd = LValue "+=" Expression ";"
-    StatementAugmentedAssignSub = LValue "-=" Expression ";"
-    StatementAugmentedAssignMul = LValue "*=" Expression ";"
-    StatementAugmentedAssignDiv = LValue "/=" Expression ";"
-    StatementAugmentedAssignRem = LValue "%=" Expression ";"
-    StatementCondition = if Expression "{" Statement* "}" ~else --simple
+
+    StatementAssign = LValue ("=" | "+=" | "-=" | "*=" | "/=" | "%=") Expression ";"
+
+    StatementCondition = if Expression "{" Statement* "}" ~else --noElse
                        | if Expression "{" Statement* "}" else "{" Statement* "}" --withElse
                        | if Expression "{" Statement* "}" else StatementCondition --withElseIf
+
     StatementWhile = while "(" Expression ")" "{" Statement* "}"
+
     StatementRepeat = repeat "(" Expression ")" "{" Statement* "}"
+
     StatementUntil = do "{" Statement* "}" until "(" Expression ")" ";"
-    StatementTry = try "{" Statement* "}" ~catch --simple
+
+    // making the catch clause optional using Ohm's `?` does not make sense
+    // because Ohm will create _independent_ optional grammar nodes which
+    // results in lots of unwrapping with unreachable cases
+    StatementTry = try "{" Statement* "}" ~catch --noCatch
                  | try "{" Statement* "}" catch "(" id ")" "{" Statement* "}" --withCatch
+
     StatementForEach = foreach "(" id "," id "in" id ")" "{" Statement* "}"
 
-    // L-value
-    LValue = id "." LValue --more
-           | id --single
+    LValue = id "." LValue --fieldAccess
+           | id --variable
 
-    // Expressions
     Expression = ExpressionConditional
-    
+
     ExpressionConditional = ExpressionOr "?" ExpressionOr ":" ExpressionConditional --ternary
                           | ExpressionOr
-    
+
     ExpressionOr = ExpressionOr "||" ExpressionAnd --or
                  | ExpressionAnd
-    
-    ExpressionAnd = ExpressionAnd "&&" ExpressionBinaryOr --and
-                  | ExpressionBinaryOr
-    
-    ExpressionBinaryOr = ExpressionBinaryOr "|" ExpressionBinaryXor --bin_or
-                       | ExpressionBinaryXor
-    
-    ExpressionBinaryXor = ExpressionBinaryXor "^" ExpressionBinaryAnd --bin_xor
-                       | ExpressionBinaryAnd
-    
-    ExpressionBinaryAnd = ExpressionBinaryAnd "&" ExpressionEquality --bin_and
-                        | ExpressionEquality
-    
+
+    ExpressionAnd = ExpressionAnd "&&" ExpressionBitwiseOr --and
+                  | ExpressionBitwiseOr
+
+    ExpressionBitwiseOr = ExpressionBitwiseOr "|" ExpressionBitwiseXor --bitwiseOr
+                        | ExpressionBitwiseXor
+
+    ExpressionBitwiseXor = ExpressionBitwiseXor "^" ExpressionBitwiseAnd --bitwiseXor
+                         | ExpressionBitwiseAnd
+
+    ExpressionBitwiseAnd = ExpressionBitwiseAnd "&" ExpressionEquality --bitwiseAnd
+                         | ExpressionEquality
+
     ExpressionEquality = ExpressionEquality "!=" ExpressionCompare --not
                        | ExpressionEquality "==" ExpressionCompare --eq
                        | ExpressionCompare
-    
-    ExpressionCompare = ExpressionCompare ">" ExpressionBinaryShift --gt
-                      | ExpressionCompare ">=" ExpressionBinaryShift --gte
-                      | ExpressionCompare "<" ExpressionBinaryShift --lt
-                      | ExpressionCompare "<=" ExpressionBinaryShift --lte
-                      | ExpressionBinaryShift
-    
-    ExpressionBinaryShift = ExpressionBinaryShift "<<" ExpressionAdd --shl
-                          | ExpressionBinaryShift ">>" ExpressionAdd --shr
-                          | ExpressionAdd
-    
+
+    ExpressionCompare = ExpressionCompare ">" ExpressionBitwiseShift --gt
+                      | ExpressionCompare ">=" ExpressionBitwiseShift --gte
+                      | ExpressionCompare "<" ExpressionBitwiseShift --lt
+                      | ExpressionCompare "<=" ExpressionBitwiseShift --lte
+                      | ExpressionBitwiseShift
+
+    ExpressionBitwiseShift = ExpressionBitwiseShift "<<" ExpressionAdd --shl
+                           | ExpressionBitwiseShift ">>" ExpressionAdd --shr
+                           | ExpressionAdd
+
     ExpressionAdd = ExpressionAdd "+" ~"+" ExpressionMul --add
                   | ExpressionAdd "-" ~"-" ExpressionMul --sub
                   | ExpressionMul
-    
+
     ExpressionMul = ExpressionMul "*" ExpressionUnary --mul
                   | ExpressionMul "/" ExpressionUnary --div
                   | ExpressionMul "%" ExpressionUnary --rem
                   | ExpressionUnary
-    
-    ExpressionUnary = "-" ExpressionValue --neg
-                    | "+" ExpressionValue --add
-                    | "!" ExpressionValue --not
-                    | ExpressionValue
-    
-    ExpressionBracket = "(" Expression ")"
+
+    ExpressionUnary = "-" ExpressionUnary --minus
+                    | "+" ExpressionUnary --plus
+                    | "!" ExpressionUnary --not
+                    | ExpressionPrimary
 
     // Order is important
-    ExpressionValue = ExpressionUnboxNotNull
-                    | ExpressionCall
-                    | ExpressionField
-                    | ExpressionStaticCall
-                    | ExpressionBracket
-                    | ExpressionNew
-                    | integerLiteral
-                    | boolLiteral
-                    | id
-                    | null
-                    | ExpressionInitOf
-                    | ExpressionString
-    ExpressionUnboxNotNull = ExpressionValue "!!"
-    ExpressionString = stringLiteral
-    ExpressionField = ExpressionValue "." id ~"("
-    ExpressionCall = ExpressionValue "." id "(" ListOf<Expression, ","> ","? ")"
-    ExpressionNew = id "{" ListOf<NewParameter, ","> ","? "}"
-    NewParameter = id ":" Expression --full
-                 | id                --punned 
+    ExpressionPrimary = ExpressionUnboxNotNull
+                      | ExpressionMethodCall
+                      | ExpressionFieldAccess
+                      | ExpressionStaticCall
+                      | ExpressionParens
+                      | ExpressionStructInstance
+                      | integerLiteral
+                      | boolLiteral
+                      | id
+                      | null
+                      | ExpressionInitOf
+                      | stringLiteral
+
+    ExpressionParens = "(" Expression ")"
+
+    ExpressionUnboxNotNull = ExpressionPrimary "!!"
+
+    ExpressionFieldAccess = ExpressionPrimary "." id ~"("
+
+    ExpressionMethodCall = ExpressionPrimary "." id "(" ListOf<Expression, ","> ","? ")"
+
+    ExpressionStructInstance = typeId "{" ListOf<StructFieldInitializer, ","> ","? "}"
+
     ExpressionStaticCall = id "(" ListOf<Expression, ","> ","? ")"
+
     ExpressionInitOf = initOf id "(" ListOf<Expression, ","> ","? ")"
 
-    // Type Literal
-    typeLiteral = letterAsciiUC typeLiteralPart*
-    typeLiteralPart = letterAscii | digit | "_"
+    StructFieldInitializer = id ":" Expression --full
+                           | id --punned   // shorthand for `id: id`
+
+    // Type identifiers
+    typeId = letterAsciiUC typeIdPart*
+
+    typeIdPart = letterAscii | digit | "_"
 
     // Integer Literal
     // hexDigit defined in Ohm's built-in rules (otherwise: hexDigit = "0".."9" | "a".."f" | "A".."F")
     // digit defined in Ohm's built-in rules (otherwise: digit = "0".."9")
-    integerLiteral = integerLiteralHex | integerLiteralBin | integerLiteralOct | integerLiteralDec // Order is important
+    // order is important
+    integerLiteral = integerLiteralHex
+                   | integerLiteralBin
+                   | integerLiteralOct
+                   | integerLiteralDec
+
     integerLiteralDec = nonZeroDigit ("_"? digit)*  --nonZeroIntegerLiteralDec
                       | "0" digit*                  --integerLiteralWithLeadingZero
+
     integerLiteralHex = ("0x" | "0X") hexDigit ("_"? hexDigit)*
+
     integerLiteralBin = ("0b" | "0B") binDigit ("_"? binDigit)*
+
     integerLiteralOct = ("0o" | "0O") octDigit ("_"? octDigit)*
+
     binDigit = "0" | "1"
+
     octDigit = "0".."7"
+
     nonZeroDigit = "1".."9"
 
     // Letters
     letterAsciiLC = "a".."z"
+
     letterAsciiUC = "A".."Z"
+
     letterAscii = letterAsciiLC | letterAsciiUC
+
     letterComment = letterAsciiLC | letterAsciiUC | digit | "_"
 
-    // ID Literal
+    // Tact identifiers
     idStart = letterAscii | "_"
+
     idPart = letterAscii | digit | "_"
+
     id = ~reservedWord #idStart #(idPart*)
 
-    // FunC id
+    // FunC identifiers
     funcLetter = letterAscii | "_" | "'" | "?" | "!" | "::" | "&"
+
     funcId = funcLetter #(funcLetter | digit)*
 
-    // Bool Literal
+    // Boolean literals
     boolLiteral = ("true" | "false") ~idPart
 
-    // String literal
+    // String literals
     stringLiteral = "\"" (nonQuoteOrBackslashChar | escapeSequence)* "\""
+
     nonQuoteOrBackslashChar = ~("\"" | "\\") any
+
     escapeSequence = "\\\\" -- backslash
                    | "\\\"" -- doubleQuote
                    | "\\n" -- newline
@@ -255,25 +279,29 @@ Tact {
 
     // Keywords
     // NOTE Order is important
-    keyword = fun 
+    keyword = fun
             | let
-            | return 
-            | extend 
-            | native 
-            | public 
-            | null 
-            | if 
-            | else 
-            | while 
-            | repeat 
-            | do 
-            | until 
+            | return
+            | receive
+            | extend
+            | native
+            | primitive
+            | public
+            | null
+            | if
+            | else
+            | while
+            | repeat
+            | do
+            | until
             | try
             | catch
             | foreach
-            | as  
+            | as
+            | map
             | mutates
             | extends
+            | external
             | import
             | with
             | trait
@@ -283,12 +311,16 @@ Tact {
             | virtual
             | inline
             | const
+
     contract = "contract" ~idPart
     let = "let" ~idPart
     fun = "fun" ~idPart
     return = "return" ~idPart
+    receive = "receive" ~idPart
     extend = "extend" ~idPart
+    external = "external" ~idPart
     native = "native" ~idPart
+    primitive = "primitive" ~idPart
     public = "public" ~idPart
     null = "null" ~idPart
     if = "if" ~idPart
@@ -301,6 +333,7 @@ Tact {
     catch = "catch" ~idPart
     foreach = "foreach" ~idPart
     as = "as" ~idPart
+    map = "map" ~idPart
     mutates = "mutates" ~idPart
     extends = "extends" ~idPart
     import = "import" ~idPart
@@ -313,16 +346,17 @@ Tact {
     const = "const" ~idPart
     abstract = "abstract" ~idPart
 
-    // Attributes
-    nameAttribute = "@name"
-
     // Reserved
     reservedWord = keyword
 
     // Comments
     space += comment | lineTerminator
+
     comment = multiLineComment | singleLineComment
+
     lineTerminator = "\n" | "\r" | "\u2028" | "\u2029"
+
     multiLineComment = "/*" (~"*/" any)* "*/"
+
     singleLineComment = "//" (~lineTerminator any)*
 }

--- a/src/grammar/grammar.ts
+++ b/src/grammar/grammar.ts
@@ -1,10 +1,12 @@
 import rawGrammar from "./grammar.ohm-bundle";
 import {
+    ASTAugmentedAssignOperation,
     ASTConstantAttribute,
     ASTContractAttribute,
     ASTFunctionAttribute,
     ASTNode,
     ASTProgram,
+    ASTReceiveType,
     ASTRef,
     ASTString,
     ASTTypeRef,
@@ -15,1273 +17,1217 @@ import {
 } from "./ast";
 import { checkVariableName } from "./checkVariableName";
 import { TactSyntaxError } from "./../errors";
-import { MatchResult } from "ohm-js";
+import { Node, IterationNode, MatchResult } from "ohm-js";
 import { TypeOrigin } from "../types/types";
 import { checkFunctionAttributes } from "./checkFunctionAttributes";
 import { checkConstAttributes } from "./checkConstAttributes";
 
 let ctx: { origin: TypeOrigin } | null;
 
-// Semantics
+// helper to unwrap optional grammar elements (marked with "?")
+// ohm-js represents those essentially as lists (IterationNodes)
+function unwrapOptNode<T>(
+    optional: IterationNode,
+    f: (n: Node) => T,
+): T | null {
+    const optNode = optional.children[0];
+    return optNode ? f(optNode) : null;
+}
+
 const semantics = rawGrammar.createSemantics();
 
-// Resolve program
-semantics.addOperation<ASTNode>("resolve_program", {
-    Program(arg0) {
+semantics.addOperation<ASTNode>("astOfModule", {
+    Module(imports, items) {
         return createNode({
             kind: "program",
-            entries: arg0.children.map((v) => v.resolve_program_item()),
+            entries: imports.children
+                .concat(items.children)
+                .map((item) => item.astOfModuleItem()),
         });
     },
 });
 
-// Resolve program items
-semantics.addOperation<ASTNode>("resolve_program_item", {
-    ProgramImport(_arg0, arg1, _arg2) {
-        const pp = arg1.resolve_expression() as ASTString;
-        if (pp.value.indexOf("\\") >= 0) {
-            throwError('Import path can\'t contain "\\"', createRef(arg1));
+semantics.addOperation<ASTNode>("astOfModuleItem", {
+    Import(_importKwd, path, _semicolon) {
+        const pathAST = path.astOfExpression() as ASTString;
+        if (pathAST.value.indexOf("\\") >= 0) {
+            throwError('Import path can\'t contain "\\"', createRef(path));
         }
         return createNode({
             kind: "program_import",
-            path: arg1.resolve_expression(),
+            path: pathAST,
             ref: createRef(this),
         });
     },
-    Primitive(_arg0, arg1, _arg2) {
-        checkVariableName(arg1.sourceString, createRef(arg1));
+    PrimitiveTypeDecl(_primitive_kwd, type, _semicolon) {
+        checkVariableName(type.sourceString, createRef(type));
         return createNode({
             kind: "primitive",
             origin: ctx!.origin,
-            name: arg1.sourceString,
+            name: type.sourceString,
             ref: createRef(this),
         });
     },
-    Struct_originary(_arg0, arg1, _arg2, arg3, _arg4) {
-        checkVariableName(arg1.sourceString, createRef(arg1));
+    NativeFunctionDecl(
+        _name,
+        _lparen1,
+        funcId,
+        _rparen1,
+        funAttributes,
+        _nativeKwd,
+        tactId,
+        _lparen2,
+        params,
+        optTrailingComma,
+        _rparen2,
+        _optColon,
+        optReturnType,
+        _semicolon,
+    ) {
+        if (
+            params.source.contents === "" &&
+            optTrailingComma.sourceString === ","
+        ) {
+            throwError(
+                "Empty parameter list should not have a dangling comma.",
+                createRef(optTrailingComma),
+            );
+        }
+        checkVariableName(tactId.sourceString, createRef(tactId));
+        return createNode({
+            kind: "def_native_function",
+            origin: ctx!.origin,
+            attributes: funAttributes.children.map((a) =>
+                a.astOfFunctionAttributes(),
+            ),
+            name: tactId.sourceString,
+            nativeName: funcId.sourceString,
+            return: unwrapOptNode(optReturnType, (t) => t.astOfType()),
+            args: params
+                .asIteration()
+                .children.map((p) => p.astOfDeclaration()),
+            ref: createRef(this),
+        });
+    },
+    StructDecl_regular(_structKwd, typeId, _lbrace, fields, _rbrace) {
+        checkVariableName(typeId.sourceString, createRef(typeId));
         return createNode({
             kind: "def_struct",
             origin: ctx!.origin,
-            name: arg1.sourceString,
-            fields: arg3.children.map((v) => v.resolve_declaration()),
+            name: typeId.sourceString,
+            fields: fields.children.map((f) => f.astOfDeclaration()),
             prefix: null,
             message: false,
             ref: createRef(this),
         });
     },
-    Struct_message(_arg0, arg1, _arg2, arg3, _arg4) {
-        checkVariableName(arg1.sourceString, createRef(arg1));
+    StructDecl_message(
+        _messageKwd,
+        _optLparen,
+        optId,
+        _optRparen,
+        typeId,
+        _lbrace,
+        fields,
+        _rbrace,
+    ) {
+        checkVariableName(typeId.sourceString, createRef(typeId));
         return createNode({
             kind: "def_struct",
             origin: ctx!.origin,
-            name: arg1.sourceString,
-            fields: arg3.children.map((v) => v.resolve_declaration()),
-            prefix: null,
+            name: typeId.sourceString,
+            fields: fields.children.map((f) => f.astOfDeclaration()),
+            prefix: unwrapOptNode(optId, (id) => parseInt(id.sourceString)),
             message: true,
             ref: createRef(this),
         });
     },
-    Struct_messageWithId(_arg0, arg1, arg2, _arg3, arg4, _arg5, arg6, _arg7) {
-        checkVariableName(arg1.sourceString, createRef(arg1));
-        return createNode({
-            kind: "def_struct",
-            origin: ctx!.origin,
-            name: arg4.sourceString,
-            fields: arg6.children.map((v) => v.resolve_declaration()),
-            prefix: parseInt(arg2.sourceString),
-            message: true,
-            ref: createRef(this),
-        });
-    },
-    Contract_simple(arg0, _arg1, arg2, _arg3, arg4, _arg5) {
-        checkVariableName(arg2.sourceString, createRef(arg2));
+    Contract(
+        attributes,
+        _contractKwd,
+        contractId,
+        _optWithKwd,
+        optInheritedTraits,
+        _optTrailingComma,
+        _lbrace,
+        contractItems,
+        _rbrace,
+    ) {
+        checkVariableName(contractId.sourceString, createRef(contractId));
         return createNode({
             kind: "def_contract",
             origin: ctx!.origin,
-            name: arg2.sourceString,
-            attributes: arg0.children.map((v) =>
-                v.resolve_contract_attributes(),
+            name: contractId.sourceString,
+            attributes: attributes.children.map((ca) =>
+                ca.astOfContractAttributes(),
             ),
-            declarations: arg4.children.map((v) => v.resolve_declaration()),
-            traits: [],
+            declarations: contractItems.children.map((item) =>
+                item.astOfItem(),
+            ),
+            traits:
+                optInheritedTraits.children[0]
+                    ?.asIteration()
+                    .children.map((e) => e.astOfExpression()) ?? [],
             ref: createRef(this),
         });
     },
-    Contract_withTraits(
-        arg0,
-        _arg1,
-        arg2,
-        _arg3,
-        arg4,
-        _arg5,
-        _arg6,
-        arg7,
-        _arg8,
+    Trait(
+        attributes,
+        _traitKwd,
+        traitId,
+        _optWithKwd,
+        optInheritedTraits,
+        _optTrailingComma,
+        _lbrace,
+        traitItems,
+        _rbrace,
     ) {
-        checkVariableName(arg2.sourceString, createRef(arg2));
-        return createNode({
-            kind: "def_contract",
-            origin: ctx!.origin,
-            name: arg2.sourceString,
-            attributes: arg0.children.map((v) =>
-                v.resolve_contract_attributes(),
-            ),
-            declarations: arg7.children.map((v) => v.resolve_declaration()),
-            traits: arg4
-                .asIteration()
-                .children.map((v) => v.resolve_expression()),
-            ref: createRef(this),
-        });
-    },
-    Trait_originary(arg0, _arg1, arg2, _arg3, arg4, _arg5) {
-        checkVariableName(arg2.sourceString, createRef(arg2));
+        checkVariableName(traitId.sourceString, createRef(traitId));
         return createNode({
             kind: "def_trait",
             origin: ctx!.origin,
-            name: arg2.sourceString,
-            attributes: arg0.children.map((v) =>
-                v.resolve_contract_attributes(),
+            name: traitId.sourceString,
+            attributes: attributes.children.map((ca) =>
+                ca.astOfContractAttributes(),
             ),
-            declarations: arg4.children.map((v) => v.resolve_declaration()),
-            traits: [],
+            declarations: traitItems.children.map((item) => item.astOfItem()),
+            traits:
+                optInheritedTraits.children[0]
+                    ?.asIteration()
+                    .children.map((e) => e.astOfExpression()) ?? [],
             ref: createRef(this),
         });
     },
-    Trait_withTraits(
-        arg0,
-        _arg1,
-        arg2,
-        _arg3,
-        arg4,
-        _arg5,
-        _arg6,
-        arg7,
-        _arg8,
+    ModuleFunction(fun) {
+        return fun.astOfItem();
+    },
+    ModuleConstant(constant) {
+        return constant.astOfItem();
+    },
+});
+
+// top-level (module-level), contract or trait items:
+// constant declarations/definitions, functions, receivers,
+// getters, etc.
+semantics.addOperation<ASTNode>("astOfItem", {
+    ConstantDefinition(
+        constAttributes,
+        _constKwd,
+        constId,
+        _colon,
+        constType,
+        _equals,
+        initExpr,
+        _semicolon,
     ) {
-        checkVariableName(arg2.sourceString, createRef(arg2));
-        return createNode({
-            kind: "def_trait",
-            origin: ctx!.origin,
-            name: arg2.sourceString,
-            attributes: arg0.children.map((v) =>
-                v.resolve_contract_attributes(),
-            ),
-            declarations: arg7.children.map((v) => v.resolve_declaration()),
-            traits: arg4
-                .asIteration()
-                .children.map((v) => v.resolve_expression()),
-            ref: createRef(this),
-        });
-    },
-    StaticFunction(arg0) {
-        return arg0.resolve_declaration();
-    },
-    NativeFunction(arg0) {
-        return arg0.resolve_declaration();
-    },
-    Constant_withValue(arg0, _arg1, arg2, _arg3, arg4, _arg5, arg6, _arg7) {
-        const attributes = arg0.children.map((v) =>
-            v.resolve_const_attributes(),
+        const attributes = constAttributes.children.map((a) =>
+            a.astOfConstAttribute(),
         ) as ASTConstantAttribute[];
         checkConstAttributes(false, attributes, createRef(this));
         return createNode({
             kind: "def_constant",
-            name: arg2.sourceString,
-            type: arg4.resolve_expression(),
-            value: arg6.resolve_expression(),
+            name: constId.sourceString,
+            type: constType.astOfType(),
+            value: initExpr.astOfExpression(),
             attributes,
             ref: createRef(this),
         });
     },
-    Constant_withEmpty(arg0, _arg1, arg2, _arg3, arg4, _arg5) {
-        const attributes = arg0.children.map((v) =>
-            v.resolve_const_attributes(),
+    ConstantDeclaration(
+        constAttributes,
+        _constKwd,
+        constId,
+        _colon,
+        constType,
+        _semicolon,
+    ) {
+        const attributes = constAttributes.children.map((a) =>
+            a.astOfConstAttribute(),
         ) as ASTConstantAttribute[];
         checkConstAttributes(true, attributes, createRef(this));
         return createNode({
             kind: "def_constant",
-            name: arg2.sourceString,
-            type: arg4.resolve_expression(),
+            name: constId.sourceString,
+            type: constType.astOfType(),
             value: null,
             attributes,
             ref: createRef(this),
         });
     },
-});
-
-// Resolve attributes
-semantics.addOperation<ASTFunctionAttribute>("resolve_attributes", {
-    FunctionAttribute_getter(_arg0) {
-        return { type: "get", ref: createRef(this) };
+    StorageVar(fieldDecl) {
+        return fieldDecl.astOfDeclaration();
     },
-    FunctionAttribute_extends(_arg0) {
-        return { type: "extends", ref: createRef(this) };
-    },
-    FunctionAttribute_mutates(_arg0) {
-        return { type: "mutates", ref: createRef(this) };
-    },
-    FunctionAttribute_override(_arg0) {
-        return { type: "overrides", ref: createRef(this) };
-    },
-    FunctionAttribute_inline(_arg0) {
-        return { type: "inline", ref: createRef(this) };
-    },
-    FunctionAttribute_virtual(_arg0) {
-        return { type: "virtual", ref: createRef(this) };
-    },
-    FunctionAttribute_abstract(_arg0) {
-        return { type: "abstract", ref: createRef(this) };
-    },
-});
-
-// Resolve const attributes
-semantics.addOperation<ASTConstantAttribute>("resolve_const_attributes", {
-    ConstantAttribute_override(_arg0) {
-        return { type: "overrides", ref: createRef(this) };
-    },
-    ConstantAttribute_virtual(_arg0) {
-        return { type: "virtual", ref: createRef(this) };
-    },
-    ConstantAttribute_abstract(_arg0) {
-        return { type: "abstract", ref: createRef(this) };
-    },
-});
-
-// Resolve contract
-semantics.addOperation<ASTContractAttribute>("resolve_contract_attributes", {
-    ContractAttribute_interface(_arg0, _arg1, arg2, _arg3) {
-        return {
-            type: "interface",
-            name: arg2.resolve_expression(),
-            ref: createRef(this),
-        };
-    },
-});
-
-// Struct and class declarations
-semantics.addOperation<ASTNode>("resolve_declaration", {
-    Field_default(arg0, _arg1, arg2, _arg3) {
-        return createNode({
-            kind: "def_field",
-            name: arg0.sourceString,
-            type: arg2.resolve_expression(),
-            as: null,
-            init: null,
-            ref: createRef(this),
-        });
-    },
-    Field_defaultWithInit(arg0, _arg1, arg2, _arg3, arg4, _arg5) {
-        const tr = arg2.resolve_expression() as ASTTypeRef;
-        return createNode({
-            kind: "def_field",
-            name: arg0.sourceString,
-            type: tr,
-            as: null,
-            init: arg4.resolve_expression(),
-            ref: createRef(this),
-        });
-    },
-    Field_withSerialization(arg0, _arg1, arg2, _arg3, arg4, _arg5) {
-        return createNode({
-            kind: "def_field",
-            name: arg0.sourceString,
-            type: arg2.resolve_expression(),
-            as: arg4.sourceString,
-            init: null,
-            ref: createRef(this),
-        });
-    },
-    Field_withSerializationAndInit(
-        arg0,
-        _arg1,
-        arg2,
-        _arg3,
-        arg4,
-        _arg5,
-        arg6,
-        _arg7,
+    FunctionDefinition(
+        funAttributes,
+        _funKwd,
+        funId,
+        _lparen,
+        funParameters,
+        optTrailingComma,
+        _rparen,
+        _optColon,
+        optReturnType,
+        _lbrace,
+        funBody,
+        _rbrace,
     ) {
-        const tr = arg2.resolve_expression() as ASTTypeRef;
-        return createNode({
-            kind: "def_field",
-            name: arg0.sourceString,
-            type: tr,
-            as: arg4.sourceString,
-            init: arg6.resolve_expression(),
-            ref: createRef(this),
-        });
-    },
-    Constant_withValue(arg0, _arg1, arg2, _arg3, arg4, _arg5, arg6, _arg7) {
-        const attributes = arg0.children.map((v) =>
-            v.resolve_const_attributes(),
-        ) as ASTConstantAttribute[];
-        checkConstAttributes(false, attributes, createRef(this));
-        return createNode({
-            kind: "def_constant",
-            name: arg2.sourceString,
-            type: arg4.resolve_expression(),
-            value: arg6.resolve_expression(),
-            attributes,
-            ref: createRef(this),
-        });
-    },
-    Constant_withEmpty(arg0, _arg1, arg2, _arg3, arg4, _) {
-        const attributes = arg0.children.map((v) =>
-            v.resolve_const_attributes(),
-        ) as ASTConstantAttribute[];
-        checkConstAttributes(true, attributes, createRef(this));
-        return createNode({
-            kind: "def_constant",
-            name: arg2.sourceString,
-            type: arg4.resolve_expression(),
-            value: null,
-            attributes,
-            ref: createRef(this),
-        });
-    },
-    FunctionArg(arg0, _arg1, arg2) {
-        checkVariableName(arg0.sourceString, createRef(arg0));
-        return createNode({
-            kind: "def_argument",
-            name: arg0.sourceString,
-            type: arg2.resolve_expression(),
-            ref: createRef(this),
-        });
-    },
-    Function_withType(
-        arg0,
-        _arg1,
-        arg2,
-        _arg3,
-        arg4,
-        arg5,
-        _arg6,
-        _arg7,
-        arg8,
-        _arg9,
-        arg10,
-        _arg11,
-    ) {
-        if (arg4.source.contents === "" && arg5.sourceString === ",") {
+        if (
+            funParameters.source.contents === "" &&
+            optTrailingComma.sourceString === ","
+        ) {
             throwError(
                 "Empty parameter list should not have a dangling comma.",
-                createRef(arg5),
+                createRef(optTrailingComma),
             );
         }
 
-        const attributes = arg0.children.map((v) =>
-            v.resolve_attributes(),
+        const attributes = funAttributes.children.map((a) =>
+            a.astOfFunctionAttributes(),
         ) as ASTFunctionAttribute[];
-        checkVariableName(arg2.sourceString, createRef(arg2));
+        checkVariableName(funId.sourceString, createRef(funId));
         checkFunctionAttributes(false, attributes, createRef(this));
         return createNode({
             kind: "def_function",
             origin: ctx!.origin,
             attributes,
-            name: arg2.sourceString,
-            return: arg8.resolve_expression(),
-            args: arg4
+            name: funId.sourceString,
+            return: unwrapOptNode(optReturnType, (t) => t.astOfType()),
+            args: funParameters
                 .asIteration()
-                .children.map((v) => v.resolve_declaration()),
-            statements: arg10.children.map((v) => v.resolve_statement()),
+                .children.map((p) => p.astOfDeclaration()),
+            statements: funBody.children.map((s) => s.astOfStatement()),
             ref: createRef(this),
         });
     },
-    Function_withVoid(
-        arg0,
-        _arg1,
-        arg2,
-        _arg3,
-        arg4,
-        arg5,
-        _arg6,
-        _arg7,
-        arg8,
-        _arg9,
+    FunctionDeclaration(
+        funAttributes,
+        _funKwd,
+        funId,
+        _lparen,
+        funParameters,
+        optTrailingComma,
+        _rparen,
+        _optColon,
+        optReturnType,
+        _semicolon,
     ) {
-        if (arg4.source.contents === "" && arg5.sourceString === ",") {
+        if (
+            funParameters.source.contents === "" &&
+            optTrailingComma.sourceString === ","
+        ) {
             throwError(
                 "Empty parameter list should not have a dangling comma.",
-                createRef(arg5),
+                createRef(optTrailingComma),
             );
         }
 
-        const attributes = arg0.children.map((v) =>
-            v.resolve_attributes(),
+        const attributes = funAttributes.children.map((a) =>
+            a.astOfFunctionAttributes(),
         ) as ASTFunctionAttribute[];
-        checkVariableName(arg2.sourceString, createRef(arg2));
-        checkFunctionAttributes(false, attributes, createRef(this));
-        return createNode({
-            kind: "def_function",
-            origin: ctx!.origin,
-            attributes,
-            name: arg2.sourceString,
-            return: null,
-            args: arg4
-                .asIteration()
-                .children.map((v) => v.resolve_declaration()),
-            statements: arg8.children.map((v) => v.resolve_statement()),
-            ref: createRef(this),
-        });
-    },
-    Function_abstractVoid(arg0, _arg1, arg2, _arg3, arg4, arg5, _arg6, _arg7) {
-        if (arg4.source.contents === "" && arg5.sourceString === ",") {
-            throwError(
-                "Empty parameter list should not have a dangling comma.",
-                createRef(arg5),
-            );
-        }
-
-        const attributes = arg0.children.map((v) =>
-            v.resolve_attributes(),
-        ) as ASTFunctionAttribute[];
-        checkVariableName(arg2.sourceString, createRef(arg2));
+        checkVariableName(funId.sourceString, createRef(funId));
         checkFunctionAttributes(true, attributes, createRef(this));
         return createNode({
             kind: "def_function",
             origin: ctx!.origin,
             attributes,
-            name: arg2.sourceString,
-            return: null,
-            args: arg4
+            name: funId.sourceString,
+            return: unwrapOptNode(optReturnType, (t) => t.astOfType()),
+            args: funParameters
                 .asIteration()
-                .children.map((v) => v.resolve_declaration()),
+                .children.map((p) => p.astOfDeclaration()),
             statements: null,
             ref: createRef(this),
         });
     },
-    Function_abstractType(
-        arg0,
-        _arg1,
-        arg2,
-        _arg3,
-        arg4,
-        arg5,
-        _arg6,
-        _arg7,
-        arg8,
-        _arg9,
+    ContractInit(
+        _initKwd,
+        _lparen,
+        initParameters,
+        optTrailingComma,
+        _rparen,
+        _lbrace,
+        initBody,
+        _rbrace,
     ) {
-        if (arg4.source.contents === "" && arg5.sourceString === ",") {
+        if (
+            initParameters.source.contents === "" &&
+            optTrailingComma.sourceString === ","
+        ) {
             throwError(
                 "Empty parameter list should not have a dangling comma.",
-                createRef(arg5),
-            );
-        }
-
-        const attributes = arg0.children.map((v) =>
-            v.resolve_attributes(),
-        ) as ASTFunctionAttribute[];
-        checkVariableName(arg2.sourceString, createRef(arg2));
-        checkFunctionAttributes(true, attributes, createRef(this));
-        return createNode({
-            kind: "def_function",
-            origin: ctx!.origin,
-            attributes,
-            name: arg2.sourceString,
-            return: arg8.resolve_expression(),
-            args: arg4
-                .asIteration()
-                .children.map((v) => v.resolve_declaration()),
-            statements: null,
-            ref: createRef(this),
-        });
-    },
-    NativeFunction_withType(
-        _arg0,
-        _arg1,
-        arg2,
-        _arg3,
-        arg4,
-        arg5,
-        arg6,
-        _arg7,
-        arg8,
-        arg9,
-        _arg10,
-        _arg11,
-        arg12,
-        _arg13,
-    ) {
-        if (arg8.source.contents === "" && arg9.sourceString === ",") {
-            throwError(
-                "Empty parameter list should not have a dangling comma.",
-                createRef(arg9),
-            );
-        }
-
-        checkVariableName(arg5.sourceString, createRef(arg5));
-        return createNode({
-            kind: "def_native_function",
-            origin: ctx!.origin,
-            attributes: arg4.children.map((v) => v.resolve_attributes()),
-            name: arg6.sourceString,
-            nativeName: arg2.sourceString,
-            return: arg12.resolve_expression(),
-            args: arg8
-                .asIteration()
-                .children.map((v) => v.resolve_declaration()),
-            ref: createRef(this),
-        });
-    },
-    NativeFunction_withVoid(
-        _arg0,
-        _arg1,
-        arg2,
-        _arg3,
-        arg4,
-        arg5,
-        arg6,
-        _arg7,
-        arg8,
-        arg9,
-        _arg10,
-        _arg11,
-    ) {
-        if (arg8.source.contents === "" && arg9.sourceString === ",") {
-            throwError(
-                "Empty parameter list should not have a dangling comma.",
-                createRef(arg9),
-            );
-        }
-
-        checkVariableName(arg5.sourceString, createRef(arg5));
-        return createNode({
-            kind: "def_native_function",
-            origin: ctx!.origin,
-            attributes: arg4.children.map((v) => v.resolve_attributes()),
-            name: arg6.sourceString,
-            nativeName: arg2.sourceString,
-            return: null,
-            args: arg8
-                .asIteration()
-                .children.map((v) => v.resolve_declaration()),
-            ref: createRef(this),
-        });
-    },
-    ContractInit(_arg0, _arg1, arg2, arg3, _arg4, _arg5, arg6, _arg7) {
-        if (arg2.source.contents === "" && arg3.sourceString === ",") {
-            throwError(
-                "Empty parameter list should not have a dangling comma.",
-                createRef(arg3),
+                createRef(optTrailingComma),
             );
         }
 
         return createNode({
             kind: "def_init_function",
-            args: arg2
+            args: initParameters
                 .asIteration()
-                .children.map((v) => v.resolve_declaration()),
-            statements: arg6.children.map((v) => v.resolve_statement()),
+                .children.map((p) => p.astOfDeclaration()),
+            statements: initBody.children.map((s) => s.astOfStatement()),
             ref: createRef(this),
         });
     },
-    ReceiveFunction_simple(_arg0, _arg1, arg2, _arg3, _arg4, arg5, _arg6) {
+    Receiver_regular(
+        _receiveKwd,
+        _lparen,
+        optParameter,
+        _rparen,
+        _lbrace,
+        receiverBody,
+        _rbrace,
+    ) {
+        const optParam = optParameter.children[0];
+        const selector: ASTReceiveType = optParam
+            ? {
+                  kind: "internal-simple",
+                  arg: optParam.astOfDeclaration(),
+              }
+            : { kind: "internal-fallback" };
         return createNode({
             kind: "def_receive",
-            selector: {
-                kind: "internal-simple",
-                arg: arg2.resolve_declaration(),
-            },
-            statements: arg5.children.map((v) => v.resolve_statement()),
+            selector,
+            statements: receiverBody.children.map((s) => s.astOfStatement()),
             ref: createRef(this),
         });
     },
-    ReceiveFunction_empty(_arg0, _arg1, _arg2, _arg3, arg4, _arg5) {
-        return createNode({
-            kind: "def_receive",
-            selector: { kind: "internal-fallback" },
-            statements: arg4.children.map((v) => v.resolve_statement()),
-            ref: createRef(this),
-        });
-    },
-    ReceiveFunction_comment(_arg0, _arg1, arg2, _arg3, _arg4, arg5, _arg6) {
-        return createNode({
-            kind: "def_receive",
-            selector: {
-                kind: "internal-comment",
-                comment: arg2.resolve_expression(),
-            },
-            statements: arg5.children.map((v) => v.resolve_statement()),
-            ref: createRef(this),
-        });
-    },
-    ReceiveFunction_bounced(_arg0, _arg1, arg2, _arg3, _arg4, arg5, _arg6) {
-        return createNode({
-            kind: "def_receive",
-            selector: { kind: "bounce", arg: arg2.resolve_declaration() },
-            statements: arg5.children.map((v) => v.resolve_statement()),
-            ref: createRef(this),
-        });
-    },
-    ReceiveFunction_externalSimple(
-        _arg0,
-        _arg1,
-        arg2,
-        _arg3,
-        _arg4,
-        arg5,
-        _arg6,
+    Receiver_comment(
+        _receiveKwd,
+        _lparen,
+        comment,
+        _rparen,
+        _lbrace,
+        receiverBody,
+        _rbrace,
     ) {
         return createNode({
             kind: "def_receive",
             selector: {
-                kind: "external-simple",
-                arg: arg2.resolve_declaration(),
+                kind: "internal-comment",
+                comment: comment.astOfExpression(),
             },
-            statements: arg5.children.map((v) => v.resolve_statement()),
+            statements: receiverBody.children.map((s) => s.astOfStatement()),
             ref: createRef(this),
         });
     },
-    ReceiveFunction_externalComment(
-        _arg0,
-        _arg1,
-        arg2,
-        _arg3,
-        _arg4,
-        arg5,
-        _arg6,
+    Receiver_bounced(
+        _bouncedKwd,
+        _lparen,
+        parameter,
+        _rparen,
+        _lbrace,
+        receiverBody,
+        _rbrace,
+    ) {
+        return createNode({
+            kind: "def_receive",
+            selector: { kind: "bounce", arg: parameter.astOfDeclaration() },
+            statements: receiverBody.children.map((s) => s.astOfStatement()),
+            ref: createRef(this),
+        });
+    },
+    Receiver_externalRegular(
+        _externalKwd,
+        _lparen,
+        optParameter,
+        _rparen,
+        _lbrace,
+        receiverBody,
+        _rbrace,
+    ) {
+        const optParam = optParameter.children[0];
+        const selector: ASTReceiveType = optParam
+            ? {
+                  kind: "external-simple",
+                  arg: optParam.astOfDeclaration(),
+              }
+            : { kind: "external-fallback" };
+        return createNode({
+            kind: "def_receive",
+            selector,
+            statements: receiverBody.children.map((s) => s.astOfStatement()),
+            ref: createRef(this),
+        });
+    },
+    Receiver_externalComment(
+        _externalKwd,
+        _lparen,
+        comment,
+        _rparen,
+        _lbrace,
+        receiverBody,
+        _rbrace,
     ) {
         return createNode({
             kind: "def_receive",
             selector: {
                 kind: "external-comment",
-                comment: arg2.resolve_expression(),
+                comment: comment.astOfExpression(),
             },
-            statements: arg5.children.map((v) => v.resolve_statement()),
+            statements: receiverBody.children.map((s) => s.astOfStatement()),
+            ref: createRef(this),
+        });
+    },
+});
+
+semantics.addOperation<ASTFunctionAttribute>("astOfFunctionAttributes", {
+    FunctionAttribute_getter(_) {
+        return { type: "get", ref: createRef(this) };
+    },
+    FunctionAttribute_extends(_) {
+        return { type: "extends", ref: createRef(this) };
+    },
+    FunctionAttribute_mutates(_) {
+        return { type: "mutates", ref: createRef(this) };
+    },
+    FunctionAttribute_override(_) {
+        return { type: "overrides", ref: createRef(this) };
+    },
+    FunctionAttribute_inline(_) {
+        return { type: "inline", ref: createRef(this) };
+    },
+    FunctionAttribute_virtual(_) {
+        return { type: "virtual", ref: createRef(this) };
+    },
+    FunctionAttribute_abstract(_) {
+        return { type: "abstract", ref: createRef(this) };
+    },
+});
+
+semantics.addOperation<ASTConstantAttribute>("astOfConstAttribute", {
+    ConstantAttribute_override(_) {
+        return { type: "overrides", ref: createRef(this) };
+    },
+    ConstantAttribute_virtual(_) {
+        return { type: "virtual", ref: createRef(this) };
+    },
+    ConstantAttribute_abstract(_) {
+        return { type: "abstract", ref: createRef(this) };
+    },
+});
+
+semantics.addOperation<ASTContractAttribute>("astOfContractAttributes", {
+    ContractAttribute_interface(_interface, _lparen, interfaceName, _rparen) {
+        return {
+            type: "interface",
+            name: interfaceName.astOfExpression(),
+            ref: createRef(this),
+        };
+    },
+});
+
+semantics.addOperation<ASTNode>("astOfDeclaration", {
+    FieldDecl(
+        id,
+        _colon,
+        type,
+        _optAs,
+        optStorageType,
+        _optEq,
+        optInitializer,
+        _semicolon,
+    ) {
+        return createNode({
+            kind: "def_field",
+            name: id.sourceString,
+            type: type.astOfType() as ASTTypeRef,
+            as: unwrapOptNode(optStorageType, (t) => t.sourceString),
+            init: unwrapOptNode(optInitializer, (e) => e.astOfExpression()),
+            ref: createRef(this),
+        });
+    },
+    Parameter(id, _colon, type) {
+        checkVariableName(id.sourceString, createRef(id));
+        return createNode({
+            kind: "def_argument",
+            name: id.sourceString,
+            type: type.astOfType(),
+            ref: createRef(this),
+        });
+    },
+    StructFieldInitializer_full(fieldId, _colon, initializer) {
+        return createNode({
+            kind: "new_parameter",
+            name: fieldId.sourceString,
+            exp: initializer.astOfExpression(),
+            ref: createRef(this),
+        });
+    },
+    StructFieldInitializer_punned(fieldId) {
+        return createNode({
+            kind: "new_parameter",
+            name: fieldId.sourceString,
+            exp: fieldId.astOfExpression(),
             ref: createRef(this),
         });
     },
 });
 
 // Statements
-semantics.addOperation<ASTNode>("resolve_statement", {
-    StatementLet(_arg0, arg1, _arg2, arg3, _arg4, arg5, _arg6) {
-        checkVariableName(arg1.sourceString, createRef(arg1));
+semantics.addOperation<ASTNode>("astOfStatement", {
+    // TODO: process StatementBlock
+
+    StatementLet(_letKwd, id, _colon, type, _equals, expression, _semicolon) {
+        checkVariableName(id.sourceString, createRef(id));
 
         return createNode({
             kind: "statement_let",
-            name: arg1.sourceString,
-            type: arg3.resolve_expression(),
-            expression: arg5.resolve_expression(),
+            name: id.sourceString,
+            type: type.astOfType(),
+            expression: expression.astOfExpression(),
             ref: createRef(this),
         });
     },
-    StatementReturn_withExpression(_arg0, arg1, _arg2) {
+    StatementReturn(_returnKwd, optExpression, _semicolon) {
         return createNode({
             kind: "statement_return",
-            expression: arg1.resolve_expression(),
+            expression: unwrapOptNode(optExpression, (e) =>
+                e.astOfExpression(),
+            ),
             ref: createRef(this),
         });
     },
-    StatementReturn_withoutExpression(_arg0, _arg1) {
-        return createNode({
-            kind: "statement_return",
-            expression: null,
-            ref: createRef(this),
-        });
-    },
-    StatementExpression(arg0, _arg1) {
+    StatementExpression(expression, _semicolon) {
         return createNode({
             kind: "statement_expression",
-            expression: arg0.resolve_expression(),
+            expression: expression.astOfExpression(),
             ref: createRef(this),
         });
     },
-    StatementAssign(arg0, _arg1, arg2, _arg3) {
-        return createNode({
-            kind: "statement_assign",
-            path: arg0.resolve_lvalue(),
-            expression: arg2.resolve_expression(),
-            ref: createRef(this),
-        });
+    StatementAssign(lvalue, operator, expression, _semicolon) {
+        if (operator.sourceString === "=") {
+            return createNode({
+                kind: "statement_assign",
+                path: lvalue.astOfLValue(),
+                expression: expression.astOfExpression(),
+                ref: createRef(this),
+            });
+        } else {
+            let op: ASTAugmentedAssignOperation;
+            switch (operator.sourceString) {
+                case "+=":
+                    op = "+";
+                    break;
+                case "-=":
+                    op = "-";
+                    break;
+                case "*=":
+                    op = "*";
+                    break;
+                case "/=":
+                    op = "/";
+                    break;
+                case "%=":
+                    op = "%";
+                    break;
+                default:
+                    throw "Internal compiler error: unreachable augmented assignment operator. Please report at https://github.com/tact-lang/tact/issues";
+            }
+            return createNode({
+                kind: "statement_augmentedassign",
+                path: lvalue.astOfLValue(),
+                op,
+                expression: expression.astOfExpression(),
+                ref: createRef(this),
+            });
+        }
     },
-    StatementAugmentedAssignAdd(arg0, _arg1, arg2, _arg3) {
-        return createNode({
-            kind: "statement_augmentedassign",
-            path: arg0.resolve_lvalue(),
-            op: "+",
-            expression: arg2.resolve_expression(),
-            ref: createRef(this),
-        });
-    },
-    StatementAugmentedAssignSub(arg0, _arg1, arg2, _arg3) {
-        return createNode({
-            kind: "statement_augmentedassign",
-            path: arg0.resolve_lvalue(),
-            op: "-",
-            expression: arg2.resolve_expression(),
-            ref: createRef(this),
-        });
-    },
-    StatementAugmentedAssignMul(arg0, _arg1, arg2, _arg3) {
-        return createNode({
-            kind: "statement_augmentedassign",
-            path: arg0.resolve_lvalue(),
-            op: "*",
-            expression: arg2.resolve_expression(),
-            ref: createRef(this),
-        });
-    },
-    StatementAugmentedAssignDiv(arg0, _arg1, arg2, _arg3) {
-        return createNode({
-            kind: "statement_augmentedassign",
-            path: arg0.resolve_lvalue(),
-            op: "/",
-            expression: arg2.resolve_expression(),
-            ref: createRef(this),
-        });
-    },
-    StatementAugmentedAssignRem(arg0, _arg1, arg2, _arg3) {
-        return createNode({
-            kind: "statement_augmentedassign",
-            path: arg0.resolve_lvalue(),
-            op: "%",
-            expression: arg2.resolve_expression(),
-            ref: createRef(this),
-        });
-    },
-    StatementCondition_simple(_arg0, arg1, _arg2, arg3, _arg4) {
+    StatementCondition_noElse(_ifKwd, condition, _lbrace, thenBlock, _rbrace) {
         return createNode({
             kind: "statement_condition",
-            expression: arg1.resolve_expression(),
-            trueStatements: arg3.children.map((v) => v.resolve_statement()),
+            expression: condition.astOfExpression(),
+            trueStatements: thenBlock.children.map((s) => s.astOfStatement()),
             falseStatements: null,
             elseif: null,
             ref: createRef(this),
         });
     },
     StatementCondition_withElse(
-        _arg0,
-        arg1,
-        _arg2,
-        arg3,
-        _arg4,
-        _arg5,
-        _arg6,
-        arg7,
-        _arg8,
+        _ifKwd,
+        condition,
+        _lbraceThen,
+        thenBlock,
+        _rbraceThen,
+        _elseKwd,
+        _lbraceElse,
+        elseBlock,
+        _rbraceElse,
     ) {
         return createNode({
             kind: "statement_condition",
-            expression: arg1.resolve_expression(),
-            trueStatements: arg3.children.map((v) => v.resolve_statement()),
-            falseStatements: arg7.children.map((v) => v.resolve_statement()),
+            expression: condition.astOfExpression(),
+            trueStatements: thenBlock.children.map((s) => s.astOfStatement()),
+            falseStatements: elseBlock.children.map((s) => s.astOfStatement()),
             elseif: null,
             ref: createRef(this),
         });
     },
     StatementCondition_withElseIf(
-        _arg0,
-        arg1,
-        _arg2,
-        arg3,
-        _arg4,
-        _arg5,
-        arg6,
+        _ifKwd,
+        condition,
+        _lbraceThen,
+        thenBlock,
+        _rbraceThen,
+        _elseKwd,
+        elseifClause,
     ) {
         return createNode({
             kind: "statement_condition",
-            expression: arg1.resolve_expression(),
-            trueStatements: arg3.children.map((v) => v.resolve_statement()),
+            expression: condition.astOfExpression(),
+            trueStatements: thenBlock.children.map((s) => s.astOfStatement()),
             falseStatements: null,
-            elseif: arg6.resolve_statement(),
+            elseif: elseifClause.astOfStatement(),
             ref: createRef(this),
         });
     },
-    StatementWhile(_arg0, _arg1, arg2, _arg3, _arg4, arg5, _arg6) {
+    StatementWhile(
+        _whileKwd,
+        _lparen,
+        condition,
+        _rparen,
+        _lbrace,
+        loopBody,
+        _rbrace,
+    ) {
         return createNode({
             kind: "statement_while",
-            condition: arg2.resolve_expression(),
-            statements: arg5.children.map((v) => v.resolve_statement()),
+            condition: condition.astOfExpression(),
+            statements: loopBody.children.map((s) => s.astOfStatement()),
             ref: createRef(this),
         });
     },
-    StatementRepeat(_arg0, _arg1, arg2, _arg3, _arg4, arg5, _arg6) {
+    StatementRepeat(
+        _repeatKwd,
+        _lparen,
+        iterations,
+        _rparen,
+        _lbrace,
+        loopBody,
+        _rbrace,
+    ) {
         return createNode({
             kind: "statement_repeat",
-            iterations: arg2.resolve_expression(),
-            statements: arg5.children.map((v) => v.resolve_statement()),
+            iterations: iterations.astOfExpression(),
+            statements: loopBody.children.map((s) => s.astOfStatement()),
             ref: createRef(this),
         });
     },
     StatementUntil(
-        _arg0,
-        _arg1,
-        arg2,
-        _arg3,
-        _arg4,
-        _arg5,
-        arg6,
-        _arg7,
-        _arg8,
+        _doKwd,
+        _lbrace,
+        loopBody,
+        _rbrace,
+        _untilKwd,
+        _lparen,
+        condition,
+        _rparen,
+        _semicolon,
     ) {
         return createNode({
             kind: "statement_until",
-            condition: arg6.resolve_expression(),
-            statements: arg2.children.map((v) => v.resolve_statement()),
+            condition: condition.astOfExpression(),
+            statements: loopBody.children.map((s) => s.astOfStatement()),
             ref: createRef(this),
         });
     },
-    StatementTry_simple(_arg0, _arg1, arg2, _arg3) {
+    StatementTry_noCatch(_tryKwd, _lbraceTry, tryBlock, _rbraceTry) {
         return createNode({
             kind: "statement_try",
-            statements: arg2.children.map((v) => v.resolve_statement()),
+            statements: tryBlock.children.map((s) => s.astOfStatement()),
             ref: createRef(this),
         });
     },
     StatementTry_withCatch(
-        _arg0,
-        _arg1,
-        arg2,
-        _arg3,
-        _arg4,
-        _arg5,
-        arg6,
-        _arg7,
-        _arg8,
-        arg9,
-        _arg10,
+        _tryKwd,
+        _lbraceTry,
+        tryBlock,
+        _rbraceTry,
+        _catchKwd,
+        _lparen,
+        exitCodeId,
+        _rparen,
+        _lbraceCatch,
+        catchBlock,
+        _rbraceCatch,
     ) {
         return createNode({
             kind: "statement_try_catch",
-            statements: arg2.children.map((v) => v.resolve_statement()),
-            catchName: arg6.sourceString,
-            catchStatements: arg9.children.map((v) => v.resolve_statement()),
+            statements: tryBlock.children.map((s) => s.astOfStatement()),
+            catchName: exitCodeId.sourceString,
+            catchStatements: catchBlock.children.map((s) => s.astOfStatement()),
             ref: createRef(this),
         });
     },
     StatementForEach(
-        _arg0,
-        _arg1,
-        arg2,
-        _arg3,
-        arg4,
-        _arg5,
-        arg6,
-        _arg7,
-        _arg8,
-        arg9,
-        _arg10,
+        _foreachKwd,
+        _lparen,
+        keyId,
+        _comma,
+        valueId,
+        _inKwd,
+        mapId,
+        _rparen,
+        _lbrace,
+        foreachBlock,
+        _rbrace,
     ) {
-        checkVariableName(arg2.sourceString, createRef(arg2));
-        checkVariableName(arg4.sourceString, createRef(arg4));
+        checkVariableName(keyId.sourceString, createRef(keyId));
+        checkVariableName(valueId.sourceString, createRef(valueId));
         return createNode({
             kind: "statement_foreach",
-            keyName: arg2.sourceString,
-            valueName: arg4.sourceString,
-            map: arg6.resolve_expression(),
-            statements: arg9.children.map((v) => v.resolve_statement()),
+            keyName: keyId.sourceString,
+            valueName: valueId.sourceString,
+            map: mapId.astOfExpression(),
+            statements: foreachBlock.children.map((s) => s.astOfStatement()),
             ref: createRef(this),
         });
     },
 });
 
 // LValue
-semantics.addOperation<ASTNode[]>("resolve_lvalue", {
-    LValue_single(arg0) {
+semantics.addOperation<ASTNode[]>("astOfLValue", {
+    LValue_variable(id) {
         return [
             createNode({
                 kind: "lvalue_ref",
-                name: arg0.sourceString,
+                name: id.sourceString,
                 ref: createRef(this),
             }),
         ];
     },
-    LValue_more(arg0, arg1, arg2) {
+    LValue_fieldAccess(id, dot, lvalue) {
         return [
             createNode({
                 kind: "lvalue_ref",
-                name: arg0.sourceString,
-                ref: createRef(arg0, arg1),
+                name: id.sourceString,
+                ref: createRef(id, dot),
             }),
-            ...arg2.resolve_lvalue(),
+            ...lvalue.astOfLValue(),
         ];
     },
 });
 
-// Expressions
-semantics.addOperation<ASTNode>("resolve_expression", {
-    // Literals
-    integerLiteral(n) {
-        return createNode({
-            kind: "number",
-            value: BigInt(n.sourceString.replaceAll("_", "")),
-            ref: createRef(this),
-        }); // Parses dec, hex, and bin numbers
-    },
-    boolLiteral(arg0) {
-        return createNode({
-            kind: "boolean",
-            value: arg0.sourceString === "true",
-            ref: createRef(this),
-        });
-    },
-    id(arg0, arg1) {
-        return createNode({
-            kind: "id",
-            value: arg0.sourceString + arg1.sourceString,
-            ref: createRef(this),
-        });
-    },
-    funcId(arg0, arg1) {
-        return createNode({
-            kind: "id",
-            value: arg0.sourceString + arg1.sourceString,
-            ref: createRef(this),
-        });
-    },
-    null(_arg0) {
-        return createNode({ kind: "null", ref: createRef(this) });
-    },
-    stringLiteral(_arg0, arg1, _arg2) {
-        return createNode({
-            kind: "string",
-            value: arg1.sourceString,
-            ref: createRef(this),
-        });
-    },
-
+semantics.addOperation<ASTNode>("astOfType", {
     // TypeRefs
-    Type_optional(arg0, _arg1) {
+    Type_optional(typeId, _questionMark) {
         return createNode({
             kind: "type_ref_simple",
-            name: arg0.sourceString,
+            name: typeId.sourceString,
             optional: true,
             ref: createRef(this),
         });
     },
-    Type_required(arg0) {
+    Type_regular(typeId) {
         return createNode({
             kind: "type_ref_simple",
-            name: arg0.sourceString,
+            name: typeId.sourceString,
             optional: false,
             ref: createRef(this),
         });
     },
-    Type_map(_arg0, _arg1, arg2, _arg3, arg4, _arg5, arg6, _arg7, arg8, _arg9) {
+    Type_map(
+        _mapKwd,
+        _langle,
+        keyTypeId,
+        _optAsKwdKey,
+        optKeyStorageType,
+        _comma,
+        valueTypeId,
+        _optAsKwdValue,
+        optValueStorageType,
+        _rangle,
+    ) {
         return createNode({
             kind: "type_ref_map",
-            key: arg2.sourceString,
-            keyAs:
-                arg4.numChildren === 1 ? arg4.children[0].sourceString : null,
-            value: arg6.sourceString,
-            valueAs:
-                arg8.numChildren === 1 ? arg8.children[0].sourceString : null,
+            key: keyTypeId.sourceString,
+            keyAs: unwrapOptNode(optKeyStorageType, (t) => t.sourceString),
+            value: valueTypeId.sourceString,
+            valueAs: unwrapOptNode(optValueStorageType, (t) => t.sourceString),
             ref: createRef(this),
         });
     },
-    Type_bounced(_arg0, _arg1, arg2, _arg3) {
+    Type_bounced(_bouncedKwd, _langle, typeId, _rangle) {
         return createNode({
             kind: "type_ref_bounced",
-            name: arg2.sourceString,
+            name: typeId.sourceString,
             ref: createRef(this),
         });
     },
+});
 
-    // Binary
-    ExpressionAdd_add(arg0, _arg1, arg2) {
+// Expressions
+semantics.addOperation<ASTNode>("astOfExpression", {
+    // Literals
+    integerLiteral(number) {
+        return createNode({
+            kind: "number",
+            value: BigInt(number.sourceString.replaceAll("_", "")),
+            ref: createRef(this),
+        }); // Parses dec, hex, and bin numbers
+    },
+    boolLiteral(boolValue) {
+        return createNode({
+            kind: "boolean",
+            value: boolValue.sourceString === "true",
+            ref: createRef(this),
+        });
+    },
+    id(firstTactIdCharacter, restOfTactId) {
+        return createNode({
+            kind: "id",
+            value:
+                firstTactIdCharacter.sourceString + restOfTactId.sourceString,
+            ref: createRef(this),
+        });
+    },
+    funcId(firstFuncIdCharacter, restOfFuncId) {
+        return createNode({
+            kind: "id",
+            value:
+                firstFuncIdCharacter.sourceString + restOfFuncId.sourceString,
+            ref: createRef(this),
+        });
+    },
+    null(_nullKwd) {
+        return createNode({ kind: "null", ref: createRef(this) });
+    },
+    stringLiteral(_startQuotationMark, string, _endQuotationMark) {
+        return createNode({
+            kind: "string",
+            value: string.sourceString,
+            ref: createRef(this),
+        });
+    },
+    ExpressionAdd_add(left, _plus, right) {
         return createNode({
             kind: "op_binary",
             op: "+",
-            left: arg0.resolve_expression(),
-            right: arg2.resolve_expression(),
+            left: left.astOfExpression(),
+            right: right.astOfExpression(),
             ref: createRef(this),
         });
     },
-    ExpressionAdd_sub(arg0, _arg1, arg2) {
+    ExpressionAdd_sub(left, _minus, right) {
         return createNode({
             kind: "op_binary",
             op: "-",
-            left: arg0.resolve_expression(),
-            right: arg2.resolve_expression(),
+            left: left.astOfExpression(),
+            right: right.astOfExpression(),
             ref: createRef(this),
         });
     },
-    ExpressionMul_div(arg0, _arg1, arg2) {
+    ExpressionMul_div(left, _slash, right) {
         return createNode({
             kind: "op_binary",
             op: "/",
-            left: arg0.resolve_expression(),
-            right: arg2.resolve_expression(),
+            left: left.astOfExpression(),
+            right: right.astOfExpression(),
             ref: createRef(this),
         });
     },
-    ExpressionMul_mul(arg0, _arg1, arg2) {
+    ExpressionMul_mul(left, _star, right) {
         return createNode({
             kind: "op_binary",
             op: "*",
-            left: arg0.resolve_expression(),
-            right: arg2.resolve_expression(),
+            left: left.astOfExpression(),
+            right: right.astOfExpression(),
             ref: createRef(this),
         });
     },
-    ExpressionMul_rem(arg0, _arg1, arg2) {
+    ExpressionMul_rem(left, _percent, right) {
         return createNode({
             kind: "op_binary",
             op: "%",
-            left: arg0.resolve_expression(),
-            right: arg2.resolve_expression(),
+            left: left.astOfExpression(),
+            right: right.astOfExpression(),
             ref: createRef(this),
         });
     },
-    ExpressionEquality_eq(arg0, _arg1, arg2) {
+    ExpressionEquality_eq(left, _equalsEquals, right) {
         return createNode({
             kind: "op_binary",
             op: "==",
-            left: arg0.resolve_expression(),
-            right: arg2.resolve_expression(),
+            left: left.astOfExpression(),
+            right: right.astOfExpression(),
             ref: createRef(this),
         });
     },
-    ExpressionEquality_not(arg0, _arg1, arg2) {
+    ExpressionEquality_not(left, _bangEquals, right) {
         return createNode({
             kind: "op_binary",
             op: "!=",
-            left: arg0.resolve_expression(),
-            right: arg2.resolve_expression(),
+            left: left.astOfExpression(),
+            right: right.astOfExpression(),
             ref: createRef(this),
         });
     },
-    ExpressionCompare_gt(arg0, _arg1, arg2) {
+    ExpressionCompare_gt(left, _rangle, right) {
         return createNode({
             kind: "op_binary",
             op: ">",
-            left: arg0.resolve_expression(),
-            right: arg2.resolve_expression(),
+            left: left.astOfExpression(),
+            right: right.astOfExpression(),
             ref: createRef(this),
         });
     },
-    ExpressionCompare_gte(arg0, _arg1, arg2) {
+    ExpressionCompare_gte(left, _rangleEquals, right) {
         return createNode({
             kind: "op_binary",
             op: ">=",
-            left: arg0.resolve_expression(),
-            right: arg2.resolve_expression(),
+            left: left.astOfExpression(),
+            right: right.astOfExpression(),
             ref: createRef(this),
         });
     },
-    ExpressionCompare_lt(arg0, _arg1, arg2) {
+    ExpressionCompare_lt(left, _langle, right) {
         return createNode({
             kind: "op_binary",
             op: "<",
-            left: arg0.resolve_expression(),
-            right: arg2.resolve_expression(),
+            left: left.astOfExpression(),
+            right: right.astOfExpression(),
             ref: createRef(this),
         });
     },
-    ExpressionCompare_lte(arg0, _arg1, arg2) {
+    ExpressionCompare_lte(left, _langleEquals, right) {
         return createNode({
             kind: "op_binary",
             op: "<=",
-            left: arg0.resolve_expression(),
-            right: arg2.resolve_expression(),
+            left: left.astOfExpression(),
+            right: right.astOfExpression(),
             ref: createRef(this),
         });
     },
-    ExpressionOr_or(arg0, _arg1, arg2) {
+    ExpressionOr_or(left, _pipePipe, right) {
         return createNode({
             kind: "op_binary",
             op: "||",
-            left: arg0.resolve_expression(),
-            right: arg2.resolve_expression(),
+            left: left.astOfExpression(),
+            right: right.astOfExpression(),
             ref: createRef(this),
         });
     },
-    ExpressionAnd_and(arg0, _arg1, arg2) {
+    ExpressionAnd_and(left, _ampersandAmpersand, right) {
         return createNode({
             kind: "op_binary",
             op: "&&",
-            left: arg0.resolve_expression(),
-            right: arg2.resolve_expression(),
+            left: left.astOfExpression(),
+            right: right.astOfExpression(),
             ref: createRef(this),
         });
     },
-    ExpressionBinaryShift_shr(arg0, _arg1, arg2) {
+    ExpressionBitwiseShift_shr(left, _rangleRangle, right) {
         return createNode({
             kind: "op_binary",
             op: ">>",
-            left: arg0.resolve_expression(),
-            right: arg2.resolve_expression(),
+            left: left.astOfExpression(),
+            right: right.astOfExpression(),
             ref: createRef(this),
         });
     },
-    ExpressionBinaryShift_shl(arg0, _arg1, arg2) {
+    ExpressionBitwiseShift_shl(left, _langleLangle, right) {
         return createNode({
             kind: "op_binary",
             op: "<<",
-            left: arg0.resolve_expression(),
-            right: arg2.resolve_expression(),
+            left: left.astOfExpression(),
+            right: right.astOfExpression(),
             ref: createRef(this),
         });
     },
-    ExpressionBinaryAnd_bin_and(arg0, _arg1, arg2) {
+    ExpressionBitwiseAnd_bitwiseAnd(left, _ampersand, right) {
         return createNode({
             kind: "op_binary",
             op: "&",
-            left: arg0.resolve_expression(),
-            right: arg2.resolve_expression(),
+            left: left.astOfExpression(),
+            right: right.astOfExpression(),
             ref: createRef(this),
         });
     },
-    ExpressionBinaryOr_bin_or(arg0, _arg1, arg2) {
+    ExpressionBitwiseOr_bitwiseOr(left, _pipe, right) {
         return createNode({
             kind: "op_binary",
             op: "|",
-            left: arg0.resolve_expression(),
-            right: arg2.resolve_expression(),
+            left: left.astOfExpression(),
+            right: right.astOfExpression(),
             ref: createRef(this),
         });
     },
-    ExpressionBinaryXor_bin_xor(arg0, _arg1, arg2) {
+    ExpressionBitwiseXor_bitwiseXor(left, _caret, right) {
         return createNode({
             kind: "op_binary",
             op: "^",
-            left: arg0.resolve_expression(),
-            right: arg2.resolve_expression(),
+            left: left.astOfExpression(),
+            right: right.astOfExpression(),
             ref: createRef(this),
         });
     },
 
     // Unary
-    ExpressionUnary_add(_arg0, arg1) {
+    ExpressionUnary_plus(_plus, operand) {
         return createNode({
             kind: "op_unary",
             op: "+",
-            right: arg1.resolve_expression(),
+            right: operand.astOfExpression(),
             ref: createRef(this),
         });
     },
-    ExpressionUnary_neg(_arg0, arg1) {
+    ExpressionUnary_minus(_minus, operand) {
         return createNode({
             kind: "op_unary",
             op: "-",
-            right: arg1.resolve_expression(),
+            right: operand.astOfExpression(),
             ref: createRef(this),
         });
     },
-    ExpressionUnary_not(_arg0, arg1) {
+    ExpressionUnary_not(_bang, operand) {
         return createNode({
             kind: "op_unary",
             op: "!",
-            right: arg1.resolve_expression(),
+            right: operand.astOfExpression(),
             ref: createRef(this),
         });
     },
-    ExpressionBracket(_arg0, arg1, _arg2) {
-        return arg1.resolve_expression();
+    ExpressionParens(_lparen, expression, _rparen) {
+        return expression.astOfExpression();
     },
-    ExpressionUnboxNotNull(arg0, _arg1) {
+    ExpressionUnboxNotNull(operand, _bangBang) {
         return createNode({
             kind: "op_unary",
             op: "!!",
-            right: arg0.resolve_expression(),
+            right: operand.astOfExpression(),
             ref: createRef(this),
         });
     },
 
-    // Access
-    ExpressionField(arg0, _arg1, arg2) {
+    ExpressionFieldAccess(source, _dot, fieldId) {
         return createNode({
             kind: "op_field",
-            src: arg0.resolve_expression(),
-            name: arg2.sourceString,
+            src: source.astOfExpression(),
+            name: fieldId.sourceString,
             ref: createRef(this),
         });
     },
-    ExpressionCall(arg0, _arg1, arg2, _arg3, arg4, arg5, _arg6) {
-        if (arg4.source.contents === "" && arg5.sourceString === ",") {
+    ExpressionMethodCall(
+        source,
+        _dot,
+        methodId,
+        _lparen,
+        methodArguments,
+        optTrailingComma,
+        _rparen,
+    ) {
+        if (
+            methodArguments.source.contents === "" &&
+            optTrailingComma.sourceString === ","
+        ) {
             throwError(
                 "Empty parameter list should not have a dangling comma.",
-                createRef(arg5),
+                createRef(optTrailingComma),
             );
         }
 
         return createNode({
             kind: "op_call",
-            src: arg0.resolve_expression(),
-            name: arg2.sourceString,
-            args: arg4
+            src: source.astOfExpression(),
+            name: methodId.sourceString,
+            args: methodArguments
                 .asIteration()
-                .children.map((v) => v.resolve_expression()),
+                .children.map((s) => s.astOfExpression()),
             ref: createRef(this),
         });
     },
-    ExpressionStaticCall(arg0, _arg1, arg2, arg3, _arg4) {
-        if (arg2.source.contents === "" && arg3.sourceString === ",") {
+    ExpressionStaticCall(
+        functionId,
+        _lparen,
+        functionArguments,
+        optTrailingComma,
+        _rparen,
+    ) {
+        if (
+            functionArguments.source.contents === "" &&
+            optTrailingComma.sourceString === ","
+        ) {
             throwError(
                 "Empty parameter list should not have a dangling comma.",
-                createRef(arg3),
+                createRef(optTrailingComma),
             );
         }
 
         return createNode({
             kind: "op_static_call",
-            name: arg0.sourceString,
-            args: arg2
+            name: functionId.sourceString,
+            args: functionArguments
                 .asIteration()
-                .children.map((v) => v.resolve_expression()),
+                .children.map((e) => e.astOfExpression()),
             ref: createRef(this),
         });
     },
-    ExpressionNew(arg0, _arg1, arg2, arg3, _arg4) {
-        if (arg2.source.contents === "" && arg3.sourceString === ",") {
+    ExpressionStructInstance(
+        typeId,
+        _lbrace,
+        structFields,
+        optTrailingComma,
+        _rbrace,
+    ) {
+        if (
+            structFields.source.contents === "" &&
+            optTrailingComma.sourceString === ","
+        ) {
             throwError(
                 "Empty parameter list should not have a dangling comma.",
-                createRef(arg3),
+                createRef(optTrailingComma),
             );
         }
 
         return createNode({
             kind: "op_new",
-            type: arg0.sourceString,
-            args: arg2
+            type: typeId.sourceString,
+            args: structFields
                 .asIteration()
-                .children.map((v) => v.resolve_expression()),
+                .children.map((d) => d.astOfDeclaration()),
             ref: createRef(this),
         });
     },
-    NewParameter_full(arg0, _arg1, arg2) {
-        return createNode({
-            kind: "new_parameter",
-            name: arg0.sourceString,
-            exp: arg2.resolve_expression(),
-            ref: createRef(this),
-        });
-    },
-    NewParameter_punned(arg0) {
-        return createNode({
-            kind: "new_parameter",
-            name: arg0.sourceString,
-            exp: arg0.resolve_expression(),
-            ref: createRef(this),
-        });
-    },
-    ExpressionInitOf(_arg0, arg1, _arg2, arg3, arg4, _arg5) {
-        if (arg3.source.contents === "" && arg4.sourceString === ",") {
+    ExpressionInitOf(
+        _initOfKwd,
+        contractId,
+        _lparen,
+        initArguments,
+        optTrailingComma,
+        _rparen,
+    ) {
+        if (
+            initArguments.source.contents === "" &&
+            optTrailingComma.sourceString === ","
+        ) {
             throwError(
                 "Empty parameter list should not have a dangling comma.",
-                createRef(arg4),
+                createRef(optTrailingComma),
             );
         }
 
         return createNode({
             kind: "init_of",
-            name: arg1.sourceString,
-            args: arg3
+            name: contractId.sourceString,
+            args: initArguments
                 .asIteration()
-                .children.map((v) => v.resolve_expression()),
+                .children.map((a) => a.astOfExpression()),
             ref: createRef(this),
         });
     },
 
     // Ternary conditional
-    ExpressionConditional_ternary(arg0, _arg1, arg2, _arg3, arg4) {
+    ExpressionConditional_ternary(
+        condition,
+        _questionMark,
+        thenExpression,
+        _colon,
+        elseExpression,
+    ) {
         return createNode({
             kind: "conditional",
-            condition: arg0.resolve_expression(),
-            thenBranch: arg2.resolve_expression(),
-            elseBranch: arg4.resolve_expression(),
+            condition: condition.astOfExpression(),
+            thenBranch: thenExpression.astOfExpression(),
+            elseBranch: elseExpression.astOfExpression(),
             ref: createRef(this),
         });
     },
@@ -1320,7 +1266,7 @@ export function parse(
         }
         ctx = { origin };
         try {
-            return semantics(matchResult).resolve_program();
+            return semantics(matchResult).astOfModule();
         } finally {
             ctx = null;
         }
@@ -1332,18 +1278,8 @@ export function parseImports(
     path: string,
     origin: TypeOrigin,
 ): string[] {
-    const r = parse(src, path, origin);
-    const imports: string[] = [];
-    let hasExpression = false;
-    for (const e of r.entries) {
-        if (e.kind === "program_import") {
-            if (hasExpression) {
-                throwError("Import must be at the top of the file", e.ref);
-            }
-            imports.push(e.path.value);
-        } else {
-            hasExpression = true;
-        }
-    }
-    return imports;
+    const fullAst: ASTProgram = parse(src, path, origin);
+    return fullAst.entries.flatMap((item) =>
+        item.kind === "program_import" ? [item.path.value] : [],
+    );
 }

--- a/src/grammar/test-failed/case-24.tact
+++ b/src/grammar/test-failed/case-24.tact
@@ -1,1 +1,3 @@
-abstract fun testFuncAbstract(,);
+trait Test {
+    abstract fun testAbstract(,);
+}

--- a/src/grammar/test-failed/case-25.tact
+++ b/src/grammar/test-failed/case-25.tact
@@ -1,1 +1,3 @@
-abstract fun testFuncAbstractWithType(,): Int;
+trait Test {
+    abstract fun testAbstractWithType(,): Int;
+}

--- a/src/grammar/test/case-17.tact
+++ b/src/grammar/test/case-17.tact
@@ -3,7 +3,7 @@ struct A {
     y: Int;
 }
 
-const a: A = new { x: 1 };
+const a: A = A { x: 1 };
 
 fun getA(): A {
     return A {
@@ -17,7 +17,7 @@ message B {
     y: Int;
 }
 
-const b: B = new {
+const b: B = B {
     x: 2,
     y: 3,
 };


### PR DESCRIPTION
and introduce some renamings to make it sound more standard

Closes #341

Incidentally, it should fix #332, because we forbid constant and function declarations everywhere except for traits.

<!--
IMPORTANT:
If your PR doesn't close a particular issue, please, create the issue first and describe the whole context: what you're adding/changing and why you're doing so. And only then open the Pull Request, which would close that issue!
-->

- [x] I have updated CHANGELOG.md
- [x] I have added tests to demonstrate the contribution is correctly implemented: this usually includes both positive and negative tests, showing the happy path(s) and featuring intentionally broken cases
- [x] I have run all the tests locally and no test failure was reported
- [x] I did not do unrelated and/or undiscussed refactorings
