### PR TITLE
Implement `fromCell` and `fromSlice` methods for structs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - The `loadBool` method for `Slice` type: PR [#412](https://github.com/tact-lang/tact/pull/412)
 - CLI flag `--with-decompilation` to turn on decompilation of BoC files at the end of the compilation pipeline: PR [#417](https://github.com/tact-lang/tact/pull/417)
 - Support more Tact expressions in the constant evaluator: condition expressions, struct instances, struct field access, `emptyMap()`: PR [#432](https://github.com/tact-lang/tact/pull/432)
+- The `fromCell` and `fromSlice` methods for struct parsing: PR [#418](https://github.com/tact-lang/tact/pull/418)
 
 ### Changed
 

--- a/src/abi/struct.ts
+++ b/src/abi/struct.ts
@@ -42,4 +42,96 @@ export const StructFunctions: Map<string, AbiFunction> = new Map([
             },
         },
     ],
+    [
+        "fromCell",
+        {
+            name: "fromCell",
+            resolve: (ctx, args, ref) => {
+                if (args.length !== 2) {
+                    throwError("fromCell() expects one argument", ref);
+                }
+                if (args[0].kind !== "ref") {
+                    throwError(
+                        "fromCell() is implemented only a struct type",
+                        ref,
+                    );
+                }
+                const tp = getType(ctx, args[0].name);
+                if (tp.kind !== "struct") {
+                    throwError(
+                        "fromCell() is implemented only a struct type",
+                        ref,
+                    );
+                }
+                if (args[1].kind !== "ref" || args[1].name !== "Cell") {
+                    throwError("fromCell() expects a Cell as an argument", ref);
+                }
+                return { kind: "ref", name: args[0].name, optional: false };
+            },
+            generate: (ctx, args, resolved, ref) => {
+                if (resolved.length !== 2) {
+                    throwError("fromCell() expects one argument", ref);
+                }
+                if (args[0].kind !== "ref") {
+                    throwError(
+                        "fromCell() is implemented only a struct type",
+                        ref,
+                    );
+                }
+                if (args[1].kind !== "ref" || args[1].name !== "Cell") {
+                    throwError("fromCell() expects a Cell as an argument", ref);
+                }
+                return `${ops.readerNonModifying(args[0].name, ctx)}(${writeExpression(resolved[1], ctx)}.begin_parse())`;
+            },
+        },
+    ],
+    [
+        "fromSlice",
+        {
+            name: "fromSlice",
+            resolve: (ctx, args, ref) => {
+                if (args.length !== 2) {
+                    throwError("fromSlice() expects one argument", ref);
+                }
+                if (args[0].kind !== "ref") {
+                    throwError(
+                        "fromSlice() is implemented only a struct type",
+                        ref,
+                    );
+                }
+                const tp = getType(ctx, args[0].name);
+                if (tp.kind !== "struct") {
+                    throwError(
+                        "fromSlice() is implemented only a struct type",
+                        ref,
+                    );
+                }
+                if (args[1].kind !== "ref" || args[1].name !== "Slice") {
+                    throwError(
+                        "fromSlice() expects a Slice as an argument",
+                        ref,
+                    );
+                }
+                return { kind: "ref", name: args[0].name, optional: false };
+            },
+            generate: (ctx, args, resolved, ref) => {
+                if (resolved.length !== 2) {
+                    throwError("fromSlice() expects one argument", ref);
+                }
+                if (args[0].kind !== "ref") {
+                    throwError(
+                        "fromSlice() is implemented only a struct type",
+                        ref,
+                    );
+                }
+                if (args[1].kind !== "ref" || args[1].name !== "Slice") {
+                    throwError(
+                        "fromSlice() expects a Slice as an argument",
+                        ref,
+                    );
+                }
+                return `${ops.readerNonModifying(args[0].name, ctx)}(${writeExpression(resolved[1], ctx)})`;
+            },
+        },
+    ],
 ]);

--- a/src/abi/struct.ts
+++ b/src/abi/struct.ts
@@ -52,14 +52,14 @@ export const StructFunctions: Map<string, AbiFunction> = new Map([
                 }
                 if (args[0].kind !== "ref") {
                     throwError(
-                        "fromCell() is implemented only a struct type",
+                        "fromCell() is implemented only for struct types",
                         ref,
                     );
                 }
                 const tp = getType(ctx, args[0].name);
                 if (tp.kind !== "struct") {
                     throwError(
-                        "fromCell() is implemented only a struct type",
+                        "fromCell() is implemented only for struct types",
                         ref,
                     );
                 }
@@ -74,7 +74,7 @@ export const StructFunctions: Map<string, AbiFunction> = new Map([
                 }
                 if (args[0].kind !== "ref") {
                     throwError(
-                        "fromCell() is implemented only a struct type",
+                        "fromCell() is implemented only for struct types",
                         ref,
                     );
                 }
@@ -95,14 +95,14 @@ export const StructFunctions: Map<string, AbiFunction> = new Map([
                 }
                 if (args[0].kind !== "ref") {
                     throwError(
-                        "fromSlice() is implemented only a struct type",
+                        "fromSlice() is implemented only for struct types",
                         ref,
                     );
                 }
                 const tp = getType(ctx, args[0].name);
                 if (tp.kind !== "struct") {
                     throwError(
-                        "fromSlice() is implemented only a struct type",
+                        "fromSlice() is implemented only for struct types",
                         ref,
                     );
                 }
@@ -120,7 +120,7 @@ export const StructFunctions: Map<string, AbiFunction> = new Map([
                 }
                 if (args[0].kind !== "ref") {
                     throwError(
-                        "fromSlice() is implemented only a struct type",
+                        "fromSlice() is implemented only for struct types",
                         ref,
                     );
                 }

--- a/src/abi/struct.ts
+++ b/src/abi/struct.ts
@@ -48,38 +48,44 @@ export const StructFunctions: Map<string, AbiFunction> = new Map([
             name: "fromCell",
             resolve: (ctx, args, ref) => {
                 if (args.length !== 2) {
-                    throwError("fromCell() expects one argument", ref);
+                    throwSyntaxError("fromCell() expects one argument", ref);
                 }
                 if (args[0].kind !== "ref") {
-                    throwError(
+                    throwSyntaxError(
                         "fromCell() is implemented only for struct types",
                         ref,
                     );
                 }
                 const tp = getType(ctx, args[0].name);
                 if (tp.kind !== "struct") {
-                    throwError(
+                    throwSyntaxError(
                         "fromCell() is implemented only for struct types",
                         ref,
                     );
                 }
                 if (args[1].kind !== "ref" || args[1].name !== "Cell") {
-                    throwError("fromCell() expects a Cell as an argument", ref);
+                    throwSyntaxError(
+                        "fromCell() expects a Cell as an argument",
+                        ref,
+                    );
                 }
                 return { kind: "ref", name: args[0].name, optional: false };
             },
             generate: (ctx, args, resolved, ref) => {
                 if (resolved.length !== 2) {
-                    throwError("fromCell() expects one argument", ref);
+                    throwSyntaxError("fromCell() expects one argument", ref);
                 }
                 if (args[0].kind !== "ref") {
-                    throwError(
+                    throwSyntaxError(
                         "fromCell() is implemented only for struct types",
                         ref,
                     );
                 }
                 if (args[1].kind !== "ref" || args[1].name !== "Cell") {
-                    throwError("fromCell() expects a Cell as an argument", ref);
+                    throwSyntaxError(
+                        "fromCell() expects a Cell as an argument",
+                        ref,
+                    );
                 }
                 return `${ops.readerNonModifying(args[0].name, ctx)}(${writeExpression(resolved[1], ctx)}.begin_parse())`;
             },
@@ -91,23 +97,23 @@ export const StructFunctions: Map<string, AbiFunction> = new Map([
             name: "fromSlice",
             resolve: (ctx, args, ref) => {
                 if (args.length !== 2) {
-                    throwError("fromSlice() expects one argument", ref);
+                    throwSyntaxError("fromSlice() expects one argument", ref);
                 }
                 if (args[0].kind !== "ref") {
-                    throwError(
+                    throwSyntaxError(
                         "fromSlice() is implemented only for struct types",
                         ref,
                     );
                 }
                 const tp = getType(ctx, args[0].name);
                 if (tp.kind !== "struct") {
-                    throwError(
+                    throwSyntaxError(
                         "fromSlice() is implemented only for struct types",
                         ref,
                     );
                 }
                 if (args[1].kind !== "ref" || args[1].name !== "Slice") {
-                    throwError(
+                    throwSyntaxError(
                         "fromSlice() expects a Slice as an argument",
                         ref,
                     );
@@ -116,16 +122,16 @@ export const StructFunctions: Map<string, AbiFunction> = new Map([
             },
             generate: (ctx, args, resolved, ref) => {
                 if (resolved.length !== 2) {
-                    throwError("fromSlice() expects one argument", ref);
+                    throwSyntaxError("fromSlice() expects one argument", ref);
                 }
                 if (args[0].kind !== "ref") {
-                    throwError(
+                    throwSyntaxError(
                         "fromSlice() is implemented only for struct types",
                         ref,
                     );
                 }
                 if (args[1].kind !== "ref" || args[1].name !== "Slice") {
-                    throwError(
+                    throwSyntaxError(
                         "fromSlice() expects a Slice as an argument",
                         ref,
                     );

--- a/src/generator/writers/__snapshots__/writeSerialization.spec.ts.snap
+++ b/src/generator/writers/__snapshots__/writeSerialization.spec.ts.snap
@@ -4600,7 +4600,9 @@ return (sc_0, (v'a, v'b, v'c, v'd, v'e, v'f, v'g));",
   },
   {
     "code": {
-      "code": "return sc_0~$A$_load();",
+      "code": "var r = sc_0~$A$_load();
+sc_0.end_parse();
+return r;",
       "kind": "generic",
     },
     "comment": null,
@@ -9215,7 +9217,9 @@ return (sc_0, (v'a, v'b, v'c, v'd, v'e, v'f, v'g));",
   },
   {
     "code": {
-      "code": "return sc_0~$B$_load();",
+      "code": "var r = sc_0~$B$_load();
+sc_0.end_parse();
+return r;",
       "kind": "generic",
     },
     "comment": null,
@@ -13836,7 +13840,9 @@ return (sc_0, (v'a, v'b, v'c, v'd, v'e, v'f, v'g, v'h));",
   },
   {
     "code": {
-      "code": "return sc_0~$C$_load();",
+      "code": "var r = sc_0~$C$_load();
+sc_0.end_parse();
+return r;",
       "kind": "generic",
     },
     "comment": null,

--- a/src/generator/writers/__snapshots__/writeSerialization.spec.ts.snap
+++ b/src/generator/writers/__snapshots__/writeSerialization.spec.ts.snap
@@ -4598,6 +4598,20 @@ return (sc_0, (v'a, v'b, v'c, v'd, v'e, v'f, v'g));",
     "name": "$A$_load",
     "signature": "(slice, ((int, int, int, int, int, int, int))) $A$_load(slice sc_0)",
   },
+  {
+    "code": {
+      "code": "return sc_0~$A$_load();",
+      "kind": "generic",
+    },
+    "comment": null,
+    "context": "type:A",
+    "depends": Set {
+      "$A$_load",
+    },
+    "flags": Set {},
+    "name": "$A$_load_not_mut",
+    "signature": "((int, int, int, int, int, int, int)) $A$_load_not_mut(slice sc_0)",
+  },
 ]
 `;
 
@@ -9198,6 +9212,20 @@ return (sc_0, (v'a, v'b, v'c, v'd, v'e, v'f, v'g));",
     "flags": Set {},
     "name": "$B$_load",
     "signature": "(slice, ((int, int, int, int, int, int, int))) $B$_load(slice sc_0)",
+  },
+  {
+    "code": {
+      "code": "return sc_0~$B$_load();",
+      "kind": "generic",
+    },
+    "comment": null,
+    "context": "type:B",
+    "depends": Set {
+      "$B$_load",
+    },
+    "flags": Set {},
+    "name": "$B$_load_not_mut",
+    "signature": "((int, int, int, int, int, int, int)) $B$_load_not_mut(slice sc_0)",
   },
 ]
 `;
@@ -13805,6 +13833,20 @@ return (sc_0, (v'a, v'b, v'c, v'd, v'e, v'f, v'g, v'h));",
     "flags": Set {},
     "name": "$C$_load",
     "signature": "(slice, ((cell, cell, slice, slice, int, int, int, slice))) $C$_load(slice sc_0)",
+  },
+  {
+    "code": {
+      "code": "return sc_0~$C$_load();",
+      "kind": "generic",
+    },
+    "comment": null,
+    "context": "type:C",
+    "depends": Set {
+      "$C$_load",
+    },
+    "flags": Set {},
+    "name": "$C$_load_not_mut",
+    "signature": "((cell, cell, slice, slice, int, int, int, slice)) $C$_load_not_mut(slice sc_0)",
   },
 ]
 `;

--- a/src/generator/writers/ops.ts
+++ b/src/generator/writers/ops.ts
@@ -16,6 +16,8 @@ export const ops = {
     writerCellOpt: (type: string, ctx: WriterContext) =>
         used(`$${type}$_store_opt`, ctx),
     reader: (type: string, ctx: WriterContext) => used(`$${type}$_load`, ctx),
+    readerNonModifying: (type: string, ctx: WriterContext) =>
+        used(`$${type}$_load_not_mut`, ctx),
     readerBounced: (type: string, ctx: WriterContext) =>
         used(`$${type}$_load_bounced`, ctx),
     readerOpt: (type: string, ctx: WriterContext) =>

--- a/src/generator/writers/writeSerialization.ts
+++ b/src/generator/writers/writeSerialization.ts
@@ -341,6 +341,24 @@ export function writeParser(
             }
         });
     });
+
+    // Write non-modifying variant
+
+    ctx.fun(ops.readerNonModifying(name, ctx), () => {
+        ctx.signature(
+            `(${resolveFuncTypeFromAbi(
+                allocation.ops.map((v) => v.type),
+                ctx,
+            )}) ${ops.readerNonModifying(name, ctx)}(slice sc_0)`,
+        );
+        if (forceInline || isSmall) {
+            ctx.flag("inline");
+        }
+        ctx.context("type:" + name);
+        ctx.body(() => {
+            ctx.append(`return sc_0~${ops.reader(name, ctx)}();`);
+        });
+    });
 }
 
 export function writeBouncedParser(

--- a/src/generator/writers/writeSerialization.ts
+++ b/src/generator/writers/writeSerialization.ts
@@ -356,7 +356,9 @@ export function writeParser(
         }
         ctx.context("type:" + name);
         ctx.body(() => {
-            ctx.append(`return sc_0~${ops.reader(name, ctx)}();`);
+            ctx.append(`var r = sc_0~${ops.reader(name, ctx)}();`);
+            ctx.append(`sc_0.end_parse();`);
+            ctx.append(`return r;`);
         });
     });
 }

--- a/src/test/e2e-emulated/__snapshots__/structs.spec.ts.snap
+++ b/src/test/e2e-emulated/__snapshots__/structs.spec.ts.snap
@@ -1,0 +1,87 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`structs should implement structs parsing and writing correctly 1`] = `
+{
+  "$$type": "MyStruct2",
+  "m": Dictionary {
+    "_key": {
+      "bits": 257,
+      "parse": [Function],
+      "serialize": [Function],
+    },
+    "_map": Map {},
+    "_value": {
+      "parse": [Function],
+      "serialize": [Function],
+    },
+  },
+  "s": {
+    "$$type": "MyStruct1",
+    "a": 1n,
+    "b": 2n,
+    "c": 3n,
+  },
+}
+`;
+
+exports[`structs should implement structs parsing and writing correctly 2`] = `
+{
+  "$$type": "MyStruct2",
+  "m": Dictionary {
+    "_key": {
+      "bits": 257,
+      "parse": [Function],
+      "serialize": [Function],
+    },
+    "_map": Map {},
+    "_value": {
+      "parse": [Function],
+      "serialize": [Function],
+    },
+  },
+  "s": null,
+}
+`;
+
+exports[`structs should implement structs parsing and writing correctly 3`] = `
+{
+  "$$type": "MyStruct2",
+  "m": Dictionary {
+    "_key": {
+      "bits": 257,
+      "parse": [Function],
+      "serialize": [Function],
+    },
+    "_map": Map {},
+    "_value": {
+      "parse": [Function],
+      "serialize": [Function],
+    },
+  },
+  "s": {
+    "$$type": "MyStruct1",
+    "a": 1n,
+    "b": 2n,
+    "c": 3n,
+  },
+}
+`;
+
+exports[`structs should implement structs parsing and writing correctly 4`] = `
+{
+  "$$type": "MyStruct2",
+  "m": Dictionary {
+    "_key": {
+      "bits": 257,
+      "parse": [Function],
+      "serialize": [Function],
+    },
+    "_map": Map {},
+    "_value": {
+      "parse": [Function],
+      "serialize": [Function],
+    },
+  },
+  "s": null,
+}
+`;

--- a/src/test/e2e-emulated/__snapshots__/structs.spec.ts.snap
+++ b/src/test/e2e-emulated/__snapshots__/structs.spec.ts.snap
@@ -85,3 +85,46 @@ exports[`structs should implement structs parsing and writing correctly 4`] = `
   "s": null,
 }
 `;
+
+exports[`structs should implement structs parsing and writing correctly 5`] = `
+{
+  "$$type": "MyStruct2",
+  "m": Dictionary {
+    "_key": {
+      "bits": 257,
+      "parse": [Function],
+      "serialize": [Function],
+    },
+    "_map": Map {},
+    "_value": {
+      "parse": [Function],
+      "serialize": [Function],
+    },
+  },
+  "s": {
+    "$$type": "MyStruct1",
+    "a": 1n,
+    "b": 2n,
+    "c": 3n,
+  },
+}
+`;
+
+exports[`structs should implement structs parsing and writing correctly 6`] = `
+{
+  "$$type": "MyStruct2",
+  "m": Dictionary {
+    "_key": {
+      "bits": 257,
+      "parse": [Function],
+      "serialize": [Function],
+    },
+    "_map": Map {},
+    "_value": {
+      "parse": [Function],
+      "serialize": [Function],
+    },
+  },
+  "s": null,
+}
+`;

--- a/src/test/e2e-emulated/__snapshots__/structs.spec.ts.snap
+++ b/src/test/e2e-emulated/__snapshots__/structs.spec.ts.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`structs should implement structs parsing and writing correctly 1`] = `
+exports[`structs should implement structs correctly 1`] = `
 {
   "$$type": "MyStruct2",
   "m": Dictionary {
@@ -24,7 +24,7 @@ exports[`structs should implement structs parsing and writing correctly 1`] = `
 }
 `;
 
-exports[`structs should implement structs parsing and writing correctly 2`] = `
+exports[`structs should implement structs correctly 2`] = `
 {
   "$$type": "MyStruct2",
   "m": Dictionary {
@@ -43,7 +43,7 @@ exports[`structs should implement structs parsing and writing correctly 2`] = `
 }
 `;
 
-exports[`structs should implement structs parsing and writing correctly 3`] = `
+exports[`structs should implement structs correctly 3`] = `
 {
   "$$type": "MyStruct2",
   "m": Dictionary {
@@ -67,7 +67,7 @@ exports[`structs should implement structs parsing and writing correctly 3`] = `
 }
 `;
 
-exports[`structs should implement structs parsing and writing correctly 4`] = `
+exports[`structs should implement structs correctly 4`] = `
 {
   "$$type": "MyStruct2",
   "m": Dictionary {
@@ -86,7 +86,7 @@ exports[`structs should implement structs parsing and writing correctly 4`] = `
 }
 `;
 
-exports[`structs should implement structs parsing and writing correctly 5`] = `
+exports[`structs should implement structs correctly 5`] = `
 {
   "$$type": "MyStruct2",
   "m": Dictionary {
@@ -110,7 +110,7 @@ exports[`structs should implement structs parsing and writing correctly 5`] = `
 }
 `;
 
-exports[`structs should implement structs parsing and writing correctly 6`] = `
+exports[`structs should implement structs correctly 6`] = `
 {
   "$$type": "MyStruct2",
   "m": Dictionary {

--- a/src/test/e2e-emulated/contracts/structs.tact
+++ b/src/test/e2e-emulated/contracts/structs.tact
@@ -44,13 +44,12 @@ contract StructsTester {
     }
 
     get fun fromCell1(src: Cell): MyStruct1 {
-        let s: MyStruct1 = MyStruct1.fromCell(src);
+        let s = MyStruct1.fromCell(src);
         return s;
     }
 
     get fun fromSlice1(src: Slice): MyStruct1 {
-        let s: MyStruct1 = MyStruct1.fromSlice(src);
-        return s;
+        return MyStruct1.fromSlice(src);
     }
 
     get fun toCell2(s: MyStruct2): Cell {

--- a/src/test/e2e-emulated/contracts/structs.tact
+++ b/src/test/e2e-emulated/contracts/structs.tact
@@ -8,6 +8,17 @@ struct T {
     s: S;
 }
 
+struct MyStruct1 {
+    a: Int;
+    b: Int as uint32;
+    c: Int?;
+}
+
+struct MyStruct2 {
+    m: map<Int, Int as uint64>;
+    s: MyStruct1?;
+}
+
 contract StructsTester {
     s1: S = S {a: false, b: 21 + 21};
     s2: S;
@@ -26,5 +37,41 @@ contract StructsTester {
         return self.s1.a == self.s2.a && self.s1.b == self.s2.b &&
                self.t1.a == self.t2.a &&
                self.t1.s.a == self.t2.s.a && self.t1.s.b == self.t2.s.b;
+    }
+
+     get fun toCell1(s: MyStruct1): Cell {
+        return s.toCell();
+    }
+
+    get fun fromCell1(src: Cell): MyStruct1 {
+        let s: MyStruct1 = MyStruct1.fromCell(src);
+        return s;
+    }
+
+    get fun fromSlice1(src: Slice): MyStruct1 {
+        let s: MyStruct1 = MyStruct1.fromSlice(src);
+        return s;
+    }
+
+    get fun toCell2(s: MyStruct2): Cell {
+        return s.toCell();
+    }
+
+    get fun fromCell2(src: Cell): MyStruct2 {
+        let s: MyStruct2 = MyStruct2.fromCell(src);
+        return s;
+    }
+
+    get fun fromSlice2(src: Slice): MyStruct2 {
+        let s: MyStruct2 = MyStruct2.fromSlice(src);
+        return s;
+    }
+
+    get fun test1(s1: MyStruct1, s2: MyStruct2): Cell {
+        let c: Cell = beginCell().storeRef(s1.toCell()).storeRef(s2.toCell()).endCell();
+        let s: Slice = c.beginParse();
+        let s1_: MyStruct1 = MyStruct1.fromCell(s.loadRef());
+        let s2_: MyStruct2 = MyStruct2.fromSlice(s.loadRef().beginParse());
+        return beginCell().storeRef(s1_.toCell()).storeRef(s2_.toCell()).endCell();
     }
 }

--- a/src/test/e2e-emulated/structs.spec.ts
+++ b/src/test/e2e-emulated/structs.spec.ts
@@ -15,7 +15,7 @@ describe("structs", () => {
     beforeEach(() => {
         __DANGER_resetNodeId();
     });
-    it("should implement structs parsing and writing correctly", async () => {
+    it("should implement structs correctly", async () => {
         // Init
         const system = await ContractSystem.create();
         const treasure = system.treasure("treasure");

--- a/src/test/e2e-emulated/structs.spec.ts
+++ b/src/test/e2e-emulated/structs.spec.ts
@@ -1,13 +1,17 @@
-import { toNano } from "@ton/core";
+import { Dictionary, beginCell, toNano } from "@ton/core";
 import { ContractSystem } from "@tact-lang/emulator";
 import { __DANGER_resetNodeId } from "../../grammar/ast";
-import { StructsTester } from "./contracts/output/structs_StructsTester";
+import {
+    MyStruct1,
+    MyStruct2,
+    StructsTester,
+} from "./contracts/output/structs_StructsTester";
 
-describe("strings", () => {
+describe("structs", () => {
     beforeEach(() => {
         __DANGER_resetNodeId();
     });
-    it("should implement structs correctly", async () => {
+    it("should implement structs parsing and writing correctly", async () => {
         // Init
         const system = await ContractSystem.create();
         const treasure = system.treasure("treasure");
@@ -16,5 +20,94 @@ describe("strings", () => {
         await system.run();
 
         expect(await contract.getStructInitializerTest()).toEqual(true);
+
+        // Prepare test values
+        const s1: MyStruct1 = {
+            $$type: "MyStruct1",
+            a: 1n,
+            b: 2n,
+            c: 3n,
+        };
+        const s2: MyStruct1 = {
+            $$type: "MyStruct1",
+            a: 1n,
+            b: 2n,
+            c: null,
+        };
+        const s3: MyStruct2 = {
+            $$type: "MyStruct2",
+            m: Dictionary.empty(
+                Dictionary.Keys.BigInt(257),
+                Dictionary.Values.BigUint(64),
+            ),
+            s: s1,
+        };
+        const s4: MyStruct2 = {
+            $$type: "MyStruct2",
+            m: Dictionary.empty(
+                Dictionary.Keys.BigInt(257),
+                Dictionary.Values.BigUint(64),
+            ),
+            s: null,
+        };
+
+        const c1 = beginCell()
+            .storeInt(1, 257)
+            .storeUint(2, 32)
+            .storeBit(true) // has c
+            .storeInt(3, 257)
+            .endCell();
+        const c2 = beginCell()
+            .storeInt(1, 257)
+            .storeUint(2, 32)
+            .storeBit(false) // no c
+            .endCell();
+        const c3 = beginCell()
+            .storeBit(false) // empty dict
+            .storeBit(true) // has struct
+            .storeSlice(c1.asSlice())
+            .endCell();
+        const c4 = beginCell()
+            .storeBit(false) // empty dict
+            .storeBit(false) // no struct
+            .endCell();
+
+        // Test smart contract
+
+        expect((await contract.getToCell1(s1)).toString()).toEqual(
+            c1.toString(),
+        );
+        expect((await contract.getToCell1(s2)).toString()).toEqual(
+            c2.toString(),
+        );
+        expect((await contract.getToCell2(s3)).toString()).toEqual(
+            c3.toString(),
+        );
+        expect((await contract.getToCell2(s4)).toString()).toEqual(
+            c4.toString(),
+        );
+
+        expect(await contract.getFromCell1(c1)).toMatchObject<MyStruct1>(s1);
+        expect(await contract.getFromCell1(c2)).toMatchObject<MyStruct1>(s2);
+        expect(await contract.getFromCell2(c3)).toMatchSnapshot();
+        expect(await contract.getFromCell2(c4)).toMatchSnapshot();
+
+        expect(await contract.getFromSlice1(c1)).toMatchObject<MyStruct1>(s1);
+        expect(await contract.getFromSlice1(c2)).toMatchObject<MyStruct1>(s2);
+        expect(await contract.getFromSlice2(c3)).toMatchSnapshot();
+        expect(await contract.getFromSlice2(c4)).toMatchSnapshot();
+
+        expect((await contract.getTest1(s1, s3)).toString()).toEqual(
+            beginCell().storeRef(c1).storeRef(c3).endCell().toString(),
+        );
+        expect((await contract.getTest1(s2, s4)).toString()).toEqual(
+            beginCell().storeRef(c2).storeRef(c4).endCell().toString(),
+        );
+        expect((await contract.getTest1(s1, s4)).toString()).toEqual(
+            beginCell().storeRef(c1).storeRef(c4).endCell().toString(),
+        );
+        expect((await contract.getTest1(s2, s3)).toString()).toEqual(
+            beginCell().storeRef(c2).storeRef(c3).endCell().toString(),
+        );
     });
 });

--- a/src/test/e2e-emulated/structs.spec.ts
+++ b/src/test/e2e-emulated/structs.spec.ts
@@ -5,6 +5,10 @@ import {
     MyStruct1,
     MyStruct2,
     StructsTester,
+    loadMyStruct1,
+    loadMyStruct2,
+    storeMyStruct1,
+    storeMyStruct2,
 } from "./contracts/output/structs_StructsTester";
 
 describe("structs", () => {
@@ -109,5 +113,44 @@ describe("structs", () => {
         expect((await contract.getTest1(s2, s3)).toString()).toEqual(
             beginCell().storeRef(c2).storeRef(c3).endCell().toString(),
         );
+
+        // Test wrappers
+
+        expect(loadMyStruct1(c1.asSlice())).toMatchObject<MyStruct1>(s1);
+        expect(loadMyStruct1(c2.asSlice())).toMatchObject<MyStruct1>(s2);
+        expect(loadMyStruct2(c3.asSlice())).toMatchSnapshot();
+        expect(loadMyStruct2(c4.asSlice())).toMatchSnapshot();
+        expect(
+            beginCell().store(storeMyStruct1(s1)).endCell().toString(),
+        ).toEqual(c1.toString());
+        expect(
+            beginCell().store(storeMyStruct1(s2)).endCell().toString(),
+        ).toEqual(c2.toString());
+        expect(
+            beginCell().store(storeMyStruct2(s3)).endCell().toString(),
+        ).toEqual(c3.toString());
+        expect(
+            beginCell().store(storeMyStruct2(s4)).endCell().toString(),
+        ).toEqual(c4.toString());
+
+        // Negative parsing tests
+
+        await expect(
+            contract.getFromCell1(beginCell().storeUint(0, 123).endCell()),
+        ).rejects.toThrow("Cell underflow");
+
+        await expect(
+            contract.getFromCell1(
+                beginCell()
+                    .storeStringTail(
+                        "a long string a long string a long string a long string a long string a long string a long string a long string a long string",
+                    )
+                    .endCell(),
+            ),
+        ).rejects.toThrow("Cell underflow");
+
+        expect(() =>
+            loadMyStruct1(beginCell().storeUint(0, 123).endCell().asSlice()),
+        ).toThrow();
     });
 });

--- a/src/types/resolveExpression.ts
+++ b/src/types/resolveExpression.ts
@@ -771,6 +771,20 @@ export function resolveExpression(
                         exp.ref,
                     );
                 }
+                // Handle struct calls
+                try {
+                    const t = getType(ctx, exp.value);
+                    if (t.kind === "struct") {
+                        return registerExpType(ctx, exp, {
+                            kind: "ref",
+                            name: t.name,
+                            optional: false,
+                        });
+                    }
+                } catch {
+                    // Ignore
+                }
+
                 throwSyntaxError("Unable to resolve id " + exp.value, exp.ref);
             } else {
                 const cc = getStaticConstant(ctx, exp.value);

--- a/src/types/resolveExpression.ts
+++ b/src/types/resolveExpression.ts
@@ -771,7 +771,7 @@ export function resolveExpression(
                         exp.ref,
                     );
                 }
-                // Handle struct calls
+                // Handle static struct method calls
                 try {
                     const t = getType(ctx, exp.value);
                     if (t.kind === "struct") {

--- a/tact.config.json
+++ b/tact.config.json
@@ -149,11 +149,6 @@
       }
     },
     {
-      "name": "structs",
-      "path": "./src/test/e2e-emulated/contracts/structs.tact",
-      "output": "./src/test/e2e-emulated/contracts/output"
-    },
-    {
       "name": "constants",
       "path": "./src/test/e2e-emulated/contracts/constants.tact",
       "output": "./src/test/e2e-emulated/contracts/output",

--- a/tact.config.json
+++ b/tact.config.json
@@ -149,6 +149,11 @@
       }
     },
     {
+      "name": "structs",
+      "path": "./src/test/e2e-emulated/contracts/structs.tact",
+      "output": "./src/test/e2e-emulated/contracts/output"
+    },
+    {
       "name": "constants",
       "path": "./src/test/e2e-emulated/contracts/constants.tact",
       "output": "./src/test/e2e-emulated/contracts/output",


### PR DESCRIPTION
Closes #344 

- [x] I have updated CHANGELOG.md
- [x] I have added tests to demonstrate the contribution is correctly implemented: this usually includes both positive and negative tests, showing the happy path(s) and featuring intentionally broken cases
- [x] I have run all the tests locally and no test failure was reported
- [x] I have run the linter, formatter and spellchecker
- [x] I did not do unrelated and/or undiscussed refactorings
