### PR TITLE
refactor(grammar): parameters, arguments and trait lists

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - The JSON schema for `tact.config.json` has been moved to the `json-schemas` project folder: PR [#404](https://github.com/tact-lang/tact/pull/404)
 - Allow underscores as unused variable identifiers: PR [#338](https://github.com/tact-lang/tact/pull/338)
 - The default compilation mode does decompile BoC files anymore, to additionally perform decompilation at the end of the pipeline, set the `fullWithDecompilation` mode in the `mode` project properties of `tact.config.json`: PR [#417](https://github.com/tact-lang/tact/pull/417)
+- Trait lists, parameters and arguments in the Tact grammar were assigned their own names in the grammar for better readability and code deduplication: PR [#422](https://github.com/tact-lang/tact/pull/422)
 
 ### Fixed
 

--- a/src/grammar/__snapshots__/grammar.spec.ts.snap
+++ b/src/grammar/__snapshots__/grammar.spec.ts.snap
@@ -29,7 +29,7 @@ Line 1, col 19:
 `;
 
 exports[`grammar should fail expr-fun-call-trailing-comma-no-args 1`] = `
-"<unknown>:6:14: Empty parameter list should not have a dangling comma.
+"<unknown>:6:14: Empty argument list should not have a dangling comma.
 Line 6, col 14:
   5 | fun b(): Int {
 > 6 |     return a(,);
@@ -39,7 +39,7 @@ Line 6, col 14:
 `;
 
 exports[`grammar should fail expr-method-call-trailing-comma-no-args 1`] = `
-"<unknown>:2:24: Empty parameter list should not have a dangling comma.
+"<unknown>:2:24: Empty argument list should not have a dangling comma.
 Line 2, col 24:
   1 | fun another() {
 > 2 |     return 42.toString(,);

--- a/src/grammar/grammar.ohm
+++ b/src/grammar/grammar.ohm
@@ -19,7 +19,7 @@ Tact {
 
     ModuleConstant = ConstantDefinition
 
-    NativeFunctionDecl = "@name" "(" funcId ")" FunctionAttribute* native id "(" ListOf<Parameter,","> ","? ")" (":" Type)? ";"
+    NativeFunctionDecl = "@name" "(" funcId ")" FunctionAttribute* native id Parameters (":" Type)? ";"
 
     Type = typeId "?" --optional
          | typeId --regular
@@ -42,7 +42,7 @@ Tact {
     StructField = FieldDecl
     StructFields = ListOf<StructField, ";"> ";"?
 
-    Contract = ContractAttribute* contract id (with NonemptyListOf<id,","> ","?)? "{" ContractItemDecl* "}"
+    Contract = ContractAttribute* contract id (with InheritedTraits)? "{" ContractItemDecl* "}"
 
     ContractItemDecl = ContractInit
                      | StorageVar
@@ -50,7 +50,9 @@ Tact {
                      | FunctionDefinition
                      | ConstantDefinition
 
-    Trait = ContractAttribute* trait id (with NonemptyListOf<id,","> ","?)? "{" TraitItemDecl* "}"
+    Trait = ContractAttribute* trait id (with InheritedTraits)? "{" TraitItemDecl* "}"
+
+    InheritedTraits = NonemptyListOf<id,","> ","?
 
     TraitItemDecl = StorageVar
                   | Receiver
@@ -61,7 +63,7 @@ Tact {
 
     StorageVar = FieldDecl ";"
 
-    ContractInit = "init" "(" ListOf<Parameter,","> ","? ")" "{" Statement* "}"
+    ContractInit = "init" Parameters "{" Statement* "}"
 
     ContractAttribute = "@interface" "(" stringLiteral ")" --interface
 
@@ -73,9 +75,11 @@ Tact {
                       | inline    --inline
                       | abstract  --abstract
 
-    FunctionDefinition = FunctionAttribute* fun id "(" ListOf<Parameter,","> ","? ")" (":" Type)? "{" Statement* "}"
+    FunctionDefinition = FunctionAttribute* fun id Parameters (":" Type)? "{" Statement* "}"
 
-    FunctionDeclaration = FunctionAttribute* fun id "(" ListOf<Parameter,","> ","? ")" (":" Type)? ";"
+    FunctionDeclaration = FunctionAttribute* fun id Parameters (":" Type)? ";"
+
+    Parameters = "(" ListOf<Parameter,","> ","? ")"
 
     Parameter = id ":" Type
 
@@ -198,16 +202,18 @@ Tact {
 
     ExpressionFieldAccess = ExpressionPrimary "." id ~"("
 
-    ExpressionMethodCall = ExpressionPrimary "." id "(" ListOf<Expression, ","> ","? ")"
+    ExpressionMethodCall = ExpressionPrimary "." id Arguments
 
     ExpressionStructInstance = typeId "{" ListOf<StructFieldInitializer, ","> ","? "}"
 
-    ExpressionStaticCall = id "(" ListOf<Expression, ","> ","? ")"
+    ExpressionStaticCall = id Arguments
 
-    ExpressionInitOf = initOf id "(" ListOf<Expression, ","> ","? ")"
+    ExpressionInitOf = initOf id Arguments
 
     StructFieldInitializer = id ":" Expression --full
                            | id --punned   // shorthand for `id: id`
+
+    Arguments = "(" ListOf<Expression, ","> ","? ")"
 
     // Type identifiers
     typeId = letterAsciiUC typeIdPart*

--- a/src/grammar/grammar.ts
+++ b/src/grammar/grammar.ts
@@ -76,23 +76,11 @@ semantics.addOperation<ASTNode>("astOfModuleItem", {
         funAttributes,
         _nativeKwd,
         tactId,
-        _lparen2,
         params,
-        optTrailingComma,
-        _rparen2,
         _optColon,
         optReturnType,
         _semicolon,
     ) {
-        if (
-            params.source.contents === "" &&
-            optTrailingComma.sourceString === ","
-        ) {
-            throwError(
-                "Empty parameter list should not have a dangling comma.",
-                createRef(optTrailingComma),
-            );
-        }
         checkVariableName(tactId.sourceString, createRef(tactId));
         return createNode({
             kind: "def_native_function",
@@ -103,9 +91,7 @@ semantics.addOperation<ASTNode>("astOfModuleItem", {
             name: tactId.sourceString,
             nativeName: funcId.sourceString,
             return: unwrapOptNode(optReturnType, (t) => t.astOfType()),
-            args: params
-                .asIteration()
-                .children.map((p) => p.astOfDeclaration()),
+            args: params.astsOfList(),
             ref: createRef(this),
         });
     },
@@ -115,9 +101,7 @@ semantics.addOperation<ASTNode>("astOfModuleItem", {
             kind: "def_struct",
             origin: ctx!.origin,
             name: typeId.sourceString,
-            fields: fields.children[0]
-                .asIteration()
-                .children.map((field, _semicolon) => field.astOfDeclaration()),
+            fields: fields.astsOfList(),
             prefix: null,
             message: false,
             ref: createRef(this),
@@ -138,10 +122,7 @@ semantics.addOperation<ASTNode>("astOfModuleItem", {
             kind: "def_struct",
             origin: ctx!.origin,
             name: typeId.sourceString,
-            //            fields: fields.children.map((f) => f.astOfDeclaration()),
-            fields: fields.children[0]
-                .asIteration()
-                .children.map((field, _semicolon) => field.astOfDeclaration()),
+            fields: fields.astsOfList(),
             prefix: unwrapOptNode(optId, (id) => parseInt(id.sourceString)),
             message: true,
             ref: createRef(this),
@@ -153,7 +134,6 @@ semantics.addOperation<ASTNode>("astOfModuleItem", {
         contractId,
         _optWithKwd,
         optInheritedTraits,
-        _optTrailingComma,
         _lbrace,
         contractItems,
         _rbrace,
@@ -169,10 +149,7 @@ semantics.addOperation<ASTNode>("astOfModuleItem", {
             declarations: contractItems.children.map((item) =>
                 item.astOfItem(),
             ),
-            traits:
-                optInheritedTraits.children[0]
-                    ?.asIteration()
-                    .children.map((e) => e.astOfExpression()) ?? [],
+            traits: optInheritedTraits.children[0]?.astsOfList() ?? [],
             ref: createRef(this),
         });
     },
@@ -182,7 +159,6 @@ semantics.addOperation<ASTNode>("astOfModuleItem", {
         traitId,
         _optWithKwd,
         optInheritedTraits,
-        _optTrailingComma,
         _lbrace,
         traitItems,
         _rbrace,
@@ -196,10 +172,7 @@ semantics.addOperation<ASTNode>("astOfModuleItem", {
                 ca.astOfContractAttributes(),
             ),
             declarations: traitItems.children.map((item) => item.astOfItem()),
-            traits:
-                optInheritedTraits.children[0]
-                    ?.asIteration()
-                    .children.map((e) => e.astOfExpression()) ?? [],
+            traits: optInheritedTraits.children[0]?.astsOfList() ?? [],
             ref: createRef(this),
         });
     },
@@ -266,26 +239,13 @@ semantics.addOperation<ASTNode>("astOfItem", {
         funAttributes,
         _funKwd,
         funId,
-        _lparen,
         funParameters,
-        optTrailingComma,
-        _rparen,
         _optColon,
         optReturnType,
         _lbrace,
         funBody,
         _rbrace,
     ) {
-        if (
-            funParameters.source.contents === "" &&
-            optTrailingComma.sourceString === ","
-        ) {
-            throwError(
-                "Empty parameter list should not have a dangling comma.",
-                createRef(optTrailingComma),
-            );
-        }
-
         const attributes = funAttributes.children.map((a) =>
             a.astOfFunctionAttributes(),
         ) as ASTFunctionAttribute[];
@@ -297,9 +257,7 @@ semantics.addOperation<ASTNode>("astOfItem", {
             attributes,
             name: funId.sourceString,
             return: unwrapOptNode(optReturnType, (t) => t.astOfType()),
-            args: funParameters
-                .asIteration()
-                .children.map((p) => p.astOfDeclaration()),
+            args: funParameters.astsOfList(),
             statements: funBody.children.map((s) => s.astOfStatement()),
             ref: createRef(this),
         });
@@ -308,24 +266,11 @@ semantics.addOperation<ASTNode>("astOfItem", {
         funAttributes,
         _funKwd,
         funId,
-        _lparen,
         funParameters,
-        optTrailingComma,
-        _rparen,
         _optColon,
         optReturnType,
         _semicolon,
     ) {
-        if (
-            funParameters.source.contents === "" &&
-            optTrailingComma.sourceString === ","
-        ) {
-            throwError(
-                "Empty parameter list should not have a dangling comma.",
-                createRef(optTrailingComma),
-            );
-        }
-
         const attributes = funAttributes.children.map((a) =>
             a.astOfFunctionAttributes(),
         ) as ASTFunctionAttribute[];
@@ -337,38 +282,15 @@ semantics.addOperation<ASTNode>("astOfItem", {
             attributes,
             name: funId.sourceString,
             return: unwrapOptNode(optReturnType, (t) => t.astOfType()),
-            args: funParameters
-                .asIteration()
-                .children.map((p) => p.astOfDeclaration()),
+            args: funParameters.astsOfList(),
             statements: null,
             ref: createRef(this),
         });
     },
-    ContractInit(
-        _initKwd,
-        _lparen,
-        initParameters,
-        optTrailingComma,
-        _rparen,
-        _lbrace,
-        initBody,
-        _rbrace,
-    ) {
-        if (
-            initParameters.source.contents === "" &&
-            optTrailingComma.sourceString === ","
-        ) {
-            throwError(
-                "Empty parameter list should not have a dangling comma.",
-                createRef(optTrailingComma),
-            );
-        }
-
+    ContractInit(_initKwd, initParameters, _lbrace, initBody, _rbrace) {
         return createNode({
             kind: "def_init_function",
-            args: initParameters
-                .asIteration()
-                .children.map((p) => p.astOfDeclaration()),
+            args: initParameters.astsOfList(),
             statements: initBody.children.map((s) => s.astOfStatement()),
             ref: createRef(this),
         });
@@ -508,6 +430,43 @@ semantics.addOperation<ASTConstantAttribute>("astOfConstAttribute", {
     },
     ConstantAttribute_abstract(_) {
         return { type: "abstract", ref: createRef(this) };
+    },
+});
+
+semantics.addOperation<ASTNode[]>("astsOfList", {
+    InheritedTraits(traits, _optTrailingComma) {
+        return traits
+            .asIteration()
+            .children.map((id, _comma) => id.astOfExpression());
+    },
+    StructFields(fields, _optSemicolon) {
+        return fields
+            .asIteration()
+            .children.map((field, _semicolon) => field.astOfDeclaration());
+    },
+    Parameters(_lparen, params, optTrailingComma, _rparen) {
+        if (
+            params.source.contents === "" &&
+            optTrailingComma.sourceString === ","
+        ) {
+            throwError(
+                "Empty parameter list should not have a dangling comma.",
+                createRef(optTrailingComma),
+            );
+        }
+        return params.asIteration().children.map((p) => p.astOfDeclaration());
+    },
+    Arguments(_lparen, args, optTrailingComma, _rparen) {
+        if (
+            args.source.contents === "" &&
+            optTrailingComma.sourceString === ","
+        ) {
+            throwError(
+                "Empty argument list should not have a dangling comma.",
+                createRef(optTrailingComma),
+            );
+        }
+        return args.asIteration().children.map((arg) => arg.astOfExpression());
     },
 });
 
@@ -1135,58 +1094,20 @@ semantics.addOperation<ASTNode>("astOfExpression", {
             ref: createRef(this),
         });
     },
-    ExpressionMethodCall(
-        source,
-        _dot,
-        methodId,
-        _lparen,
-        methodArguments,
-        optTrailingComma,
-        _rparen,
-    ) {
-        if (
-            methodArguments.source.contents === "" &&
-            optTrailingComma.sourceString === ","
-        ) {
-            throwError(
-                "Empty parameter list should not have a dangling comma.",
-                createRef(optTrailingComma),
-            );
-        }
-
+    ExpressionMethodCall(source, _dot, methodId, methodArguments) {
         return createNode({
             kind: "op_call",
             src: source.astOfExpression(),
             name: methodId.sourceString,
-            args: methodArguments
-                .asIteration()
-                .children.map((s) => s.astOfExpression()),
+            args: methodArguments.astsOfList(),
             ref: createRef(this),
         });
     },
-    ExpressionStaticCall(
-        functionId,
-        _lparen,
-        functionArguments,
-        optTrailingComma,
-        _rparen,
-    ) {
-        if (
-            functionArguments.source.contents === "" &&
-            optTrailingComma.sourceString === ","
-        ) {
-            throwError(
-                "Empty parameter list should not have a dangling comma.",
-                createRef(optTrailingComma),
-            );
-        }
-
+    ExpressionStaticCall(functionId, functionArguments) {
         return createNode({
             kind: "op_static_call",
             name: functionId.sourceString,
-            args: functionArguments
-                .asIteration()
-                .children.map((e) => e.astOfExpression()),
+            args: functionArguments.astsOfList(),
             ref: createRef(this),
         });
     },
@@ -1216,30 +1137,11 @@ semantics.addOperation<ASTNode>("astOfExpression", {
             ref: createRef(this),
         });
     },
-    ExpressionInitOf(
-        _initOfKwd,
-        contractId,
-        _lparen,
-        initArguments,
-        optTrailingComma,
-        _rparen,
-    ) {
-        if (
-            initArguments.source.contents === "" &&
-            optTrailingComma.sourceString === ","
-        ) {
-            throwError(
-                "Empty parameter list should not have a dangling comma.",
-                createRef(optTrailingComma),
-            );
-        }
-
+    ExpressionInitOf(_initOfKwd, contractId, initArguments) {
         return createNode({
             kind: "init_of",
             name: contractId.sourceString,
-            args: initArguments
-                .asIteration()
-                .children.map((a) => a.astOfExpression()),
+            args: initArguments.astsOfList(),
             ref: createRef(this),
         });
     },


### PR DESCRIPTION
get their own named categories

Closes #397

<!--
IMPORTANT:
If your PR doesn't close a particular issue, please, create the issue first and describe the whole context: what you're adding/changing and why you're doing so. And only then open the Pull Request, which would close that issue!
-->

- [x] I have updated CHANGELOG.md
- [x] I have added tests to demonstrate the contribution is correctly implemented: this usually includes both positive and negative tests, showing the happy path(s) and featuring intentionally broken cases
- [x] I have run all the tests locally and no test failure was reported
- [x] I have run the linter, formatter and spellchecker
- [x] I did not do unrelated and/or undiscussed refactorings
