### PR TITLE
Refactor compilation-fail tests to make output clearer

### DIFF
--- a/src/node.ts
+++ b/src/node.ts
@@ -100,7 +100,7 @@ export async function run(args: {
         false,
     ); // Improves developer experience
     for (const config of projects) {
-        console.log("💼 Compiling project " + config.name + "...");
+        consoleLogger.log("💼 Compiling project " + config.name + "...");
         let cliConfig = { ...config };
 
         if (

--- a/src/test/compilation-failed/const-eval-failed.spec.ts
+++ b/src/test/compilation-failed/const-eval-failed.spec.ts
@@ -5,6 +5,7 @@ import { itShouldNotCompile } from "./util";
 describe("fail-const-eval", () => {
     beforeAll(() => {
         jest.spyOn(consoleLogger, "error").mockImplementation(() => {});
+        jest.spyOn(consoleLogger, "log").mockImplementation(() => {});
     });
 
     beforeEach(() => {
@@ -12,11 +13,11 @@ describe("fail-const-eval", () => {
     });
 
     afterAll(() => {
-        (consoleLogger.error as jest.Mock).mockRestore();
+        jest.restoreAllMocks();
     });
 
     afterEach(() => {
-        (consoleLogger.error as jest.Mock).mockClear();
+        jest.clearAllMocks();
     });
 
     itShouldNotCompile({

--- a/src/test/compilation-failed/stdlib-bugs.spec.ts
+++ b/src/test/compilation-failed/stdlib-bugs.spec.ts
@@ -5,6 +5,7 @@ import { itShouldNotCompile } from "./util";
 describe("stdlib-bugs", () => {
     beforeAll(() => {
         jest.spyOn(consoleLogger, "error").mockImplementation(() => {});
+        jest.spyOn(consoleLogger, "log").mockImplementation(() => {});
     });
 
     beforeEach(() => {
@@ -12,11 +13,11 @@ describe("stdlib-bugs", () => {
     });
 
     afterAll(() => {
-        (consoleLogger.error as jest.Mock).mockRestore();
+        jest.restoreAllMocks();
     });
 
     afterEach(() => {
-        (consoleLogger.error as jest.Mock).mockClear();
+        jest.clearAllMocks();
     });
 
     itShouldNotCompile({


### PR DESCRIPTION
Closes #416 

- [ ] I have updated CHANGELOG.md
- [ ] I have added tests to demonstrate the contribution is correctly implemented: this usually includes both positive and negative tests, showing the happy path(s) and featuring intentionally broken cases
- [x] I have run all the tests locally and no test failure was reported
- [x] I have run the linter, formatter and spellchecker
- [x] I did not do unrelated and/or undiscussed refactorings
