### PR TITLE
Forbid `void` type inference in let statements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - External fallback receivers now work properly: PR [#408](https://github.com/tact-lang/tact/pull/408)
 - `Int as coins` as a value type of a map in persistent storage does not throw compilation error anymore: PR [#413](https://github.com/tact-lang/tact/pull/413)
 - The semantics of the Tact arithmetic operations in the constant evaluator to perform rounding towards negative infinity: PR [#432](https://github.com/tact-lang/tact/pull/432)
+- Inferring `void` type in let statements is now forbidden: PR [#438](https://github.com/tact-lang/tact/pull/438)
 
 ## [1.3.1] - 2024-06-08
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Trailing semicolons in struct and message declarations are optional now: PR [#395](https://github.com/tact-lang/tact/pull/395)
 - Tests are refactored and renamed to convey the sense of what is being tested and to reduce the amount of merge conflicts during development: PR [#402](https://github.com/tact-lang/tact/pull/402)
-- `let` statements can now be used without an explicit type declaration and determine the type automatically if it was not specified: PR [#198](https://github.com/tact-lang/tact/pull/198)
+- `let` statements can now be used without an explicit type declaration and determine the type automatically if it was not specified: PR [#198](https://github.com/tact-lang/tact/pull/198) and PR [#438](https://github.com/tact-lang/tact/pull/438)
 - The outdated TextMate-style grammar files for text editors have been removed (the most recent grammar files can be found in the [tact-sublime](https://github.com/tact-lang/tact-sublime) repo): PR [#404](https://github.com/tact-lang/tact/pull/404)
 - The JSON schema for `tact.config.json` has been moved to the `json-schemas` project folder: PR [#404](https://github.com/tact-lang/tact/pull/404)
 - Allow underscores as unused variable identifiers: PR [#338](https://github.com/tact-lang/tact/pull/338)

--- a/src/types/__snapshots__/resolveStatements.spec.ts.snap
+++ b/src/types/__snapshots__/resolveStatements.spec.ts.snap
@@ -471,7 +471,7 @@ Line 8, col 5:
 `;
 
 exports[`resolveStatements should fail statements for stmt-let-void-inference 1`] = `
-"<unknown>:12:9: Cannot infer type for "voidVar"
+"<unknown>:12:9: Cannot assign void to "voidVar"
 Line 12, col 9:
   11 |     get fun foo(): Int {
 > 12 |         let voidVar = foo();

--- a/src/types/__snapshots__/resolveStatements.spec.ts.snap
+++ b/src/types/__snapshots__/resolveStatements.spec.ts.snap
@@ -470,6 +470,16 @@ Line 8, col 5:
 "
 `;
 
+exports[`resolveStatements should fail statements for stmt-let-void-inference 1`] = `
+"<unknown>:12:9: Cannot infer type for "voidVar"
+Line 12, col 9:
+  11 |     get fun foo(): Int {
+> 12 |         let voidVar = foo();
+               ^~~~~~~~~~~~~~~~~~~~
+  13 |         return 42;
+"
+`;
+
 exports[`resolveStatements should fail statements for stmt-let-wrong-rhs 1`] = `
 "<unknown>:10:5: Type mismatch: "Int" is not assignable to "Bool"
 Line 10, col 5:

--- a/src/types/__snapshots__/resolveStatements.spec.ts.snap
+++ b/src/types/__snapshots__/resolveStatements.spec.ts.snap
@@ -471,7 +471,7 @@ Line 8, col 5:
 `;
 
 exports[`resolveStatements should fail statements for stmt-let-void-inference 1`] = `
-"<unknown>:12:9: Cannot assign void to "voidVar"
+"<unknown>:12:9: The inferred type of variable "voidVar" is "void", which is not allowed
 Line 12, col 9:
   11 |     get fun foo(): Int {
 > 12 |         let voidVar = foo();

--- a/src/types/resolveStatements.ts
+++ b/src/types/resolveStatements.ts
@@ -201,7 +201,10 @@ function processStatements(
                 }
                 sctx = addVariable(s.name, variableType, sctx);
             } else {
-                if (expressionType.kind === "null") {
+                if (
+                    expressionType.kind === "null" ||
+                    expressionType.kind === "void"
+                ) {
                     throwSyntaxError(
                         `Cannot infer type for "${s.name}"`,
                         s.ref,

--- a/src/types/resolveStatements.ts
+++ b/src/types/resolveStatements.ts
@@ -201,12 +201,15 @@ function processStatements(
                 }
                 sctx = addVariable(s.name, variableType, sctx);
             } else {
-                if (
-                    expressionType.kind === "null" ||
-                    expressionType.kind === "void"
-                ) {
+                if (expressionType.kind === "null") {
                     throwSyntaxError(
                         `Cannot infer type for "${s.name}"`,
+                        s.ref,
+                    );
+                }
+                if (expressionType.kind === "void") {
+                    throwSyntaxError(
+                        `Cannot assign void to "${s.name}"`,
                         s.ref,
                     );
                 }

--- a/src/types/resolveStatements.ts
+++ b/src/types/resolveStatements.ts
@@ -209,7 +209,7 @@ function processStatements(
                 }
                 if (expressionType.kind === "void") {
                     throwSyntaxError(
-                        `Cannot assign void to "${s.name}"`,
+                        `The inferred type of variable "${s.name}" is "void", which is not allowed`,
                         s.ref,
                     );
                 }

--- a/src/types/stmts-failed/stmt-let-void-inference.tact
+++ b/src/types/stmts-failed/stmt-let-void-inference.tact
@@ -1,0 +1,15 @@
+primitive Int;
+
+trait BaseTrait {
+    
+}
+
+fun foo() { return }
+
+contract Foo {
+
+    get fun foo(): Int {
+        let voidVar = foo();
+        return 42;
+    }
+}


### PR DESCRIPTION
Closes #436 

- [x] I have updated CHANGELOG.md
- [x] I have added tests to demonstrate the contribution is correctly implemented: this usually includes both positive and negative tests, showing the happy path(s) and featuring intentionally broken cases
- [x] I have run all the tests locally and no test failure was reported
- [x] I have run the linter, formatter and spellchecker
- [x] I did not do unrelated and/or undiscussed refactorings
