### PR TITLE
chore: relative file paths in error messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Update JSON Schema to inform about usage in Blueprint: PR [#330](https://github.com/tact-lang/tact/pull/330)
 - All identifiers in error messages are now quoted for consistency: PR [#363](https://github.com/tact-lang/tact/pull/363)
 - The Tact grammar has been refactored for better readability: PR [#365](https://github.com/tact-lang/tact/pull/365)
+- Error messages now use relative file paths: PR [#456](https://github.com/tact-lang/tact/pull/456)
 
 ### Fixed
 

--- a/src/abi/global.ts
+++ b/src/abi/global.ts
@@ -2,7 +2,7 @@ import { Address, Cell, toNano } from "@ton/core";
 import { enabledDebug, enabledMasterchain } from "../config/features";
 import { writeAddress, writeCell } from "../generator/writers/writeConstant";
 import { writeExpression } from "../generator/writers/writeExpression";
-import { throwSyntaxError } from "../errors";
+import { throwCompilationError } from "../errors";
 import { evalConstantExpression } from "../constEval";
 import { getErrorId } from "../types/resolveErrors";
 import { AbiFunction } from "./AbiFunction";
@@ -17,19 +17,19 @@ export const GlobalFunctions: Map<string, AbiFunction> = new Map([
             name: "ton",
             resolve: (ctx, args, ref) => {
                 if (args.length !== 1) {
-                    throwSyntaxError(
+                    throwCompilationError(
                         "ton() expects single string argument",
                         ref,
                     );
                 }
                 if (args[0].kind !== "ref") {
-                    throwSyntaxError(
+                    throwCompilationError(
                         "ton() expects single string argument",
                         ref,
                     );
                 }
                 if (args[0].name !== "String") {
-                    throwSyntaxError(
+                    throwCompilationError(
                         "ton() expects single string argument",
                         ref,
                     );
@@ -38,7 +38,7 @@ export const GlobalFunctions: Map<string, AbiFunction> = new Map([
             },
             generate: (ctx, args, resolved, ref) => {
                 if (resolved.length !== 1) {
-                    throwSyntaxError(
+                    throwCompilationError(
                         "ton() expects single string argument",
                         ref,
                     );
@@ -57,28 +57,31 @@ export const GlobalFunctions: Map<string, AbiFunction> = new Map([
             name: "require",
             resolve: (ctx, args, ref) => {
                 if (args.length !== 2) {
-                    throwSyntaxError("require() expects two arguments", ref);
+                    throwCompilationError(
+                        "require() expects two arguments",
+                        ref,
+                    );
                 }
                 if (args[0].kind !== "ref") {
-                    throwSyntaxError(
+                    throwCompilationError(
                         "require() expects first Bool argument",
                         ref,
                     );
                 }
                 if (args[0].name !== "Bool") {
-                    throwSyntaxError(
+                    throwCompilationError(
                         "require() expects first Bool argument",
                         ref,
                     );
                 }
                 if (args[1].kind !== "ref") {
-                    throwSyntaxError(
+                    throwCompilationError(
                         "require() expects second string argument",
                         ref,
                     );
                 }
                 if (args[1].name !== "String") {
-                    throwSyntaxError(
+                    throwCompilationError(
                         "require() expects second string argument",
                         ref,
                     );
@@ -87,7 +90,10 @@ export const GlobalFunctions: Map<string, AbiFunction> = new Map([
             },
             generate: (ctx, args, resolved, ref) => {
                 if (resolved.length !== 2) {
-                    throwSyntaxError("require() expects two arguments", ref);
+                    throwCompilationError(
+                        "require() expects two arguments",
+                        ref,
+                    );
                 }
                 const str = evalConstantExpression(
                     resolved[1],
@@ -103,19 +109,31 @@ export const GlobalFunctions: Map<string, AbiFunction> = new Map([
             name: "address",
             resolve: (ctx, args, ref) => {
                 if (args.length !== 1) {
-                    throwSyntaxError("address() expects one argument", ref);
+                    throwCompilationError(
+                        "address() expects one argument",
+                        ref,
+                    );
                 }
                 if (args[0].kind !== "ref") {
-                    throwSyntaxError("address() expects string argument", ref);
+                    throwCompilationError(
+                        "address() expects string argument",
+                        ref,
+                    );
                 }
                 if (args[0].name !== "String") {
-                    throwSyntaxError("address() expects string argument", ref);
+                    throwCompilationError(
+                        "address() expects string argument",
+                        ref,
+                    );
                 }
                 return { kind: "ref", name: "Address", optional: false };
             },
             generate: (ctx, args, resolved, ref) => {
                 if (resolved.length !== 1) {
-                    throwSyntaxError("address() expects one argument", ref);
+                    throwCompilationError(
+                        "address() expects one argument",
+                        ref,
+                    );
                 }
                 const str = evalConstantExpression(
                     resolved[0],
@@ -125,14 +143,17 @@ export const GlobalFunctions: Map<string, AbiFunction> = new Map([
                 try {
                     address = Address.parse(str);
                 } catch {
-                    throwSyntaxError(`${str} is not a valid address`, ref);
+                    throwCompilationError(`${str} is not a valid address`, ref);
                 }
                 if (address.workChain !== 0 && address.workChain !== -1) {
-                    throwSyntaxError(`Address ${str} invalid address`, ref);
+                    throwCompilationError(
+                        `Address ${str} invalid address`,
+                        ref,
+                    );
                 }
                 if (!enabledMasterchain(ctx.ctx)) {
                     if (address.workChain !== 0) {
-                        throwSyntaxError(
+                        throwCompilationError(
                             `Address ${str} from masterchain are not enabled for this contract`,
                             ref,
                         );
@@ -152,19 +173,25 @@ export const GlobalFunctions: Map<string, AbiFunction> = new Map([
             name: "cell",
             resolve: (ctx, args, ref) => {
                 if (args.length !== 1) {
-                    throwSyntaxError("cell() expects one argument", ref);
+                    throwCompilationError("cell() expects one argument", ref);
                 }
                 if (args[0].kind !== "ref") {
-                    throwSyntaxError("cell() expects string argument", ref);
+                    throwCompilationError(
+                        "cell() expects string argument",
+                        ref,
+                    );
                 }
                 if (args[0].name !== "String") {
-                    throwSyntaxError("cell() expects string argument", ref);
+                    throwCompilationError(
+                        "cell() expects string argument",
+                        ref,
+                    );
                 }
                 return { kind: "ref", name: "Cell", optional: false };
             },
             generate: (ctx, args, resolved, ref) => {
                 if (resolved.length !== 1) {
-                    throwSyntaxError("cell() expects one argument", ref);
+                    throwCompilationError("cell() expects one argument", ref);
                 }
 
                 // Load cell data
@@ -176,7 +203,7 @@ export const GlobalFunctions: Map<string, AbiFunction> = new Map([
                 try {
                     c = Cell.fromBase64(str);
                 } catch (e) {
-                    throwSyntaxError(`Invalid cell ${str}`, ref);
+                    throwCompilationError(`Invalid cell ${str}`, ref);
                 }
 
                 // Generate address
@@ -192,7 +219,7 @@ export const GlobalFunctions: Map<string, AbiFunction> = new Map([
             name: "dump",
             resolve: (ctx, args, ref) => {
                 if (args.length !== 1) {
-                    throwSyntaxError("dump expects 1 argument", ref);
+                    throwCompilationError("dump expects 1 argument", ref);
                 }
                 return { kind: "void" };
             },
@@ -236,12 +263,15 @@ export const GlobalFunctions: Map<string, AbiFunction> = new Map([
                         const exp = writeExpression(resolved[0], ctx);
                         return `${ctx.used(`__tact_debug`)}(${exp}, "${debugPrint}")`;
                     }
-                    throwSyntaxError(
+                    throwCompilationError(
                         "dump() not supported for type: " + arg.name,
                         ref,
                     );
                 } else {
-                    throwSyntaxError("dump() not supported for argument", ref);
+                    throwCompilationError(
+                        "dump() not supported for argument",
+                        ref,
+                    );
                 }
             },
         },
@@ -252,7 +282,10 @@ export const GlobalFunctions: Map<string, AbiFunction> = new Map([
             name: "dumpStack",
             resolve: (_ctx, args, ref) => {
                 if (args.length !== 0) {
-                    throwSyntaxError("dumpStack expects no arguments", ref);
+                    throwCompilationError(
+                        "dumpStack expects no arguments",
+                        ref,
+                    );
                 }
                 return { kind: "void" };
             },
@@ -275,7 +308,7 @@ export const GlobalFunctions: Map<string, AbiFunction> = new Map([
             name: "emptyMap",
             resolve: (ctx, args, ref) => {
                 if (args.length !== 0) {
-                    throwSyntaxError("emptyMap expects no arguments", ref);
+                    throwCompilationError("emptyMap expects no arguments", ref);
                 }
                 return { kind: "null" };
             },
@@ -290,13 +323,16 @@ export const GlobalFunctions: Map<string, AbiFunction> = new Map([
             name: "sha256",
             resolve: (ctx, args, ref) => {
                 if (args.length !== 1) {
-                    throwSyntaxError("sha256 expects 1 argument", ref);
+                    throwCompilationError("sha256 expects 1 argument", ref);
                 }
                 if (args[0].kind !== "ref") {
-                    throwSyntaxError("sha256 expects string argument", ref);
+                    throwCompilationError(
+                        "sha256 expects string argument",
+                        ref,
+                    );
                 }
                 if (args[0].name !== "String" && args[0].name !== "Slice") {
-                    throwSyntaxError(
+                    throwCompilationError(
                         "sha256 expects string or slice argument",
                         ref,
                     );
@@ -305,10 +341,13 @@ export const GlobalFunctions: Map<string, AbiFunction> = new Map([
             },
             generate: (ctx, args, resolved, ref) => {
                 if (args.length !== 1) {
-                    throwSyntaxError("sha256 expects 1 argument", ref);
+                    throwCompilationError("sha256 expects 1 argument", ref);
                 }
                 if (args[0].kind !== "ref") {
-                    throwSyntaxError("sha256 expects string argument", ref);
+                    throwCompilationError(
+                        "sha256 expects string argument",
+                        ref,
+                    );
                 }
 
                 // String case
@@ -319,7 +358,7 @@ export const GlobalFunctions: Map<string, AbiFunction> = new Map([
                             ctx.ctx,
                         ) as string;
                         if (Buffer.from(str).length > 128) {
-                            throwSyntaxError(
+                            throwCompilationError(
                                 "sha256 expects string argument with byte length <= 128",
                                 ref,
                             );
@@ -340,7 +379,7 @@ export const GlobalFunctions: Map<string, AbiFunction> = new Map([
                     return `string_hash(${exp})`;
                 }
 
-                throwSyntaxError(
+                throwCompilationError(
                     "sha256 expects string or slice argument",
                     ref,
                 );

--- a/src/abi/map.ts
+++ b/src/abi/map.ts
@@ -1,6 +1,6 @@
 import { ops } from "../generator/writers/ops";
 import { writeExpression } from "../generator/writers/writeExpression";
-import { throwSyntaxError } from "../errors";
+import { throwCompilationError } from "../errors";
 import { getType } from "../types/resolveDescriptors";
 import { AbiFunction } from "./AbiFunction";
 
@@ -12,16 +12,19 @@ export const MapFunctions: Map<string, AbiFunction> = new Map([
             resolve(ctx, args, ref) {
                 // Check arguments
                 if (args.length !== 3) {
-                    throwSyntaxError("set expects two arguments", ref); // Should not happen
+                    throwCompilationError("set expects two arguments", ref); // Should not happen
                 }
                 const self = args[0];
                 if (!self || self.kind !== "map") {
-                    throwSyntaxError("set expects a map as self argument", ref); // Should not happen
+                    throwCompilationError(
+                        "set expects a map as self argument",
+                        ref,
+                    ); // Should not happen
                 }
 
                 // Resolve map types
                 if (self.key !== "Int" && self.key !== "Address") {
-                    throwSyntaxError(
+                    throwCompilationError(
                         "set expects a map with Int or Address keys",
                         ref,
                     );
@@ -29,13 +32,13 @@ export const MapFunctions: Map<string, AbiFunction> = new Map([
 
                 // Check key type
                 if (args[1].kind !== "ref" || args[1].optional) {
-                    throwSyntaxError(
+                    throwCompilationError(
                         "set expects a direct type as first argument",
                         ref,
                     );
                 }
                 if (args[1].name !== self.key) {
-                    throwSyntaxError(
+                    throwCompilationError(
                         `set expects a "${self.key}" as first argument`,
                         ref,
                     );
@@ -43,13 +46,13 @@ export const MapFunctions: Map<string, AbiFunction> = new Map([
 
                 // Check value type
                 if (args[2].kind !== "null" && args[2].kind !== "ref") {
-                    throwSyntaxError(
+                    throwCompilationError(
                         "set expects a direct type as second argument",
                         ref,
                     );
                 }
                 if (args[2].kind !== "null" && args[2].name !== self.value) {
-                    throwSyntaxError(
+                    throwCompilationError(
                         `set expects a "${self.value}" as second argument`,
                         ref,
                     );
@@ -61,11 +64,14 @@ export const MapFunctions: Map<string, AbiFunction> = new Map([
             generate: (ctx, args, exprs, ref) => {
                 // Check arguments
                 if (args.length !== 3) {
-                    throwSyntaxError("set expects two arguments", ref); // Ignore self argument
+                    throwCompilationError("set expects two arguments", ref); // Ignore self argument
                 }
                 const self = args[0];
                 if (!self || self.kind !== "map") {
-                    throwSyntaxError("set expects a map as self argument", ref); // Should not happen
+                    throwCompilationError(
+                        "set expects a map as self argument",
+                        ref,
+                    ); // Should not happen
                 }
 
                 // Render expressions
@@ -107,13 +113,13 @@ export const MapFunctions: Map<string, AbiFunction> = new Map([
                     } else {
                         const t = getType(ctx.ctx, self.value);
                         if (t.kind === "contract") {
-                            throwSyntaxError(
+                            throwCompilationError(
                                 `Contract can't be value of a map`,
                                 ref,
                             );
                         }
                         if (t.kind === "trait") {
-                            throwSyntaxError(
+                            throwCompilationError(
                                 `Trait can't be value of a map`,
                                 ref,
                             );
@@ -126,7 +132,7 @@ export const MapFunctions: Map<string, AbiFunction> = new Map([
                                 return `${resolved[0]}~__tact_dict_set_${kind}_cell(${bits}, ${resolved[1]}, ${ops.writerCellOpt(t.name, ctx)}(${resolved[2]}))`;
                             }
                         } else {
-                            throwSyntaxError(
+                            throwCompilationError(
                                 `"${t.name}" can't be value of a map`,
                                 ref,
                             );
@@ -162,13 +168,13 @@ export const MapFunctions: Map<string, AbiFunction> = new Map([
                     } else {
                         const t = getType(ctx.ctx, self.value);
                         if (t.kind === "contract") {
-                            throwSyntaxError(
+                            throwCompilationError(
                                 `Contract can't be value of a map`,
                                 ref,
                             );
                         }
                         if (t.kind === "trait") {
-                            throwSyntaxError(
+                            throwCompilationError(
                                 `Trait can't be value of a map`,
                                 ref,
                             );
@@ -181,7 +187,7 @@ export const MapFunctions: Map<string, AbiFunction> = new Map([
                                 return `${resolved[0]}~__tact_dict_set_slice_cell(267, ${resolved[1]}, ${ops.writerCellOpt(t.name, ctx)}(${resolved[2]}))`;
                             }
                         } else {
-                            throwSyntaxError(
+                            throwCompilationError(
                                 `"${t.name}" can't be value of a map`,
                                 ref,
                             );
@@ -189,7 +195,7 @@ export const MapFunctions: Map<string, AbiFunction> = new Map([
                     }
                 }
 
-                throwSyntaxError(
+                throwCompilationError(
                     `set expects a map with Int or Address keys`,
                     ref,
                 );
@@ -203,22 +209,25 @@ export const MapFunctions: Map<string, AbiFunction> = new Map([
             resolve(ctx, args, ref) {
                 // Check arguments
                 if (args.length !== 2) {
-                    throwSyntaxError("set expects one argument", ref); // Ignore self argument
+                    throwCompilationError("set expects one argument", ref); // Ignore self argument
                 }
                 const self = args[0];
                 if (!self || self.kind !== "map") {
-                    throwSyntaxError("set expects a map as self argument", ref); // Should not happen
+                    throwCompilationError(
+                        "set expects a map as self argument",
+                        ref,
+                    ); // Should not happen
                 }
 
                 // Check key type
                 if (args[1].kind !== "ref" || args[1].optional) {
-                    throwSyntaxError(
+                    throwCompilationError(
                         "set expects a direct type as first argument",
                         ref,
                     );
                 }
                 if (args[1].name !== self.key) {
-                    throwSyntaxError(
+                    throwCompilationError(
                         `set expects a "${self.key}" as first argument`,
                         ref,
                     );
@@ -228,11 +237,14 @@ export const MapFunctions: Map<string, AbiFunction> = new Map([
             },
             generate: (ctx, args, exprs, ref) => {
                 if (args.length !== 2) {
-                    throwSyntaxError("set expects one argument", ref); // Ignore self argument
+                    throwCompilationError("set expects one argument", ref); // Ignore self argument
                 }
                 const self = args[0];
                 if (!self || self.kind !== "map") {
-                    throwSyntaxError("set expects a map as self argument", ref); // Should not happen
+                    throwCompilationError(
+                        "set expects a map as self argument",
+                        ref,
+                    ); // Should not happen
                 }
 
                 // Render expressions
@@ -274,13 +286,13 @@ export const MapFunctions: Map<string, AbiFunction> = new Map([
                     } else {
                         const t = getType(ctx.ctx, self.value);
                         if (t.kind === "contract") {
-                            throwSyntaxError(
+                            throwCompilationError(
                                 `Contract can't be value of a map`,
                                 ref,
                             );
                         }
                         if (t.kind === "trait") {
-                            throwSyntaxError(
+                            throwCompilationError(
                                 `Trait can't be value of a map`,
                                 ref,
                             );
@@ -289,7 +301,7 @@ export const MapFunctions: Map<string, AbiFunction> = new Map([
                             ctx.used(`__tact_dict_get_${kind}_cell`);
                             return `${ops.readerOpt(t.name, ctx)}(__tact_dict_get_${kind}_cell(${resolved[0]}, ${bits}, ${resolved[1]}))`;
                         } else {
-                            throwSyntaxError(
+                            throwCompilationError(
                                 `"${t.name}" can't be value of a map`,
                                 ref,
                             );
@@ -325,13 +337,13 @@ export const MapFunctions: Map<string, AbiFunction> = new Map([
                     } else {
                         const t = getType(ctx.ctx, self.value);
                         if (t.kind === "contract") {
-                            throwSyntaxError(
+                            throwCompilationError(
                                 `Contract can't be value of a map`,
                                 ref,
                             );
                         }
                         if (t.kind === "trait") {
-                            throwSyntaxError(
+                            throwCompilationError(
                                 `Trait can't be value of a map`,
                                 ref,
                             );
@@ -340,7 +352,7 @@ export const MapFunctions: Map<string, AbiFunction> = new Map([
                             ctx.used(`__tact_dict_get_slice_cell`);
                             return `${ops.readerOpt(t.name, ctx)}(__tact_dict_get_slice_cell(${resolved[0]}, 267, ${resolved[1]}))`;
                         } else {
-                            throwSyntaxError(
+                            throwCompilationError(
                                 `"${t.name}" can't be value of a map`,
                                 ref,
                             );
@@ -348,7 +360,7 @@ export const MapFunctions: Map<string, AbiFunction> = new Map([
                     }
                 }
 
-                throwSyntaxError(`set expects a map with Int keys`, ref);
+                throwCompilationError(`set expects a map with Int keys`, ref);
             },
         },
     ],
@@ -359,22 +371,25 @@ export const MapFunctions: Map<string, AbiFunction> = new Map([
             resolve(ctx, args, ref) {
                 // Check arguments
                 if (args.length !== 2) {
-                    throwSyntaxError("del expects one argument", ref); // Ignore self argument
+                    throwCompilationError("del expects one argument", ref); // Ignore self argument
                 }
                 const self = args[0];
                 if (!self || self.kind !== "map") {
-                    throwSyntaxError("del expects a map as self argument", ref); // Should not happen
+                    throwCompilationError(
+                        "del expects a map as self argument",
+                        ref,
+                    ); // Should not happen
                 }
 
                 // Check key type
                 if (args[1].kind !== "ref" || args[1].optional) {
-                    throwSyntaxError(
+                    throwCompilationError(
                         "del expects a direct type as first argument",
                         ref,
                     );
                 }
                 if (args[1].name !== self.key) {
-                    throwSyntaxError(
+                    throwCompilationError(
                         `del expects a "${self.key}" as first argument`,
                         ref,
                     );
@@ -385,11 +400,14 @@ export const MapFunctions: Map<string, AbiFunction> = new Map([
             },
             generate: (ctx, args, exprs, ref) => {
                 if (args.length !== 2) {
-                    throwSyntaxError("del expects one argument", ref); // Ignore self argument
+                    throwCompilationError("del expects one argument", ref); // Ignore self argument
                 }
                 const self = args[0];
                 if (!self || self.kind !== "map") {
-                    throwSyntaxError("del expects a map as self argument", ref); // Should not happen
+                    throwCompilationError(
+                        "del expects a map as self argument",
+                        ref,
+                    ); // Should not happen
                 }
 
                 // Render expressions
@@ -415,7 +433,7 @@ export const MapFunctions: Map<string, AbiFunction> = new Map([
                     return `${resolved[0]}~__tact_dict_delete(267, ${resolved[1]})`;
                 }
 
-                throwSyntaxError(`del expects a map with Int keys`, ref);
+                throwCompilationError(`del expects a map with Int keys`, ref);
             },
         },
     ],
@@ -426,11 +444,11 @@ export const MapFunctions: Map<string, AbiFunction> = new Map([
             resolve(ctx, args, ref) {
                 // Check arguments
                 if (args.length !== 1) {
-                    throwSyntaxError("asCell expects one argument", ref); // Ignore self argument
+                    throwCompilationError("asCell expects one argument", ref); // Ignore self argument
                 }
                 const self = args[0];
                 if (!self || self.kind !== "map") {
-                    throwSyntaxError(
+                    throwCompilationError(
                         "asCell expects a map as self argument",
                         ref,
                     ); // Should not happen
@@ -440,11 +458,11 @@ export const MapFunctions: Map<string, AbiFunction> = new Map([
             },
             generate: (ctx, args, exprs, ref) => {
                 if (args.length !== 1) {
-                    throwSyntaxError("asCell expects one argument", ref); // Ignore self argument
+                    throwCompilationError("asCell expects one argument", ref); // Ignore self argument
                 }
                 const self = args[0];
                 if (!self || self.kind !== "map") {
-                    throwSyntaxError(
+                    throwCompilationError(
                         "asCell expects a map as self argument",
                         ref,
                     ); // Should not happen
@@ -461,11 +479,11 @@ export const MapFunctions: Map<string, AbiFunction> = new Map([
             resolve(ctx, args, ref) {
                 // Check arguments
                 if (args.length !== 1) {
-                    throwSyntaxError("isEmpty expects one argument", ref); // Ignore self argument
+                    throwCompilationError("isEmpty expects one argument", ref); // Ignore self argument
                 }
                 const self = args[0];
                 if (!self || self.kind !== "map") {
-                    throwSyntaxError(
+                    throwCompilationError(
                         "isEmpty expects a map as self argument",
                         ref,
                     ); // Should not happen
@@ -475,11 +493,11 @@ export const MapFunctions: Map<string, AbiFunction> = new Map([
             },
             generate: (ctx, args, exprs, ref) => {
                 if (args.length !== 1) {
-                    throwSyntaxError("isEmpty expects one argument", ref); // Ignore self argument
+                    throwCompilationError("isEmpty expects one argument", ref); // Ignore self argument
                 }
                 const self = args[0];
                 if (!self || self.kind !== "map") {
-                    throwSyntaxError(
+                    throwCompilationError(
                         "isEmpty expects a map as self argument",
                         ref,
                     ); // Should not happen

--- a/src/abi/struct.ts
+++ b/src/abi/struct.ts
@@ -1,6 +1,6 @@
 import { ops } from "../generator/writers/ops";
 import { writeExpression } from "../generator/writers/writeExpression";
-import { throwSyntaxError } from "../errors";
+import { throwCompilationError } from "../errors";
 import { getType } from "../types/resolveDescriptors";
 import { AbiFunction } from "./AbiFunction";
 
@@ -11,17 +11,17 @@ export const StructFunctions: Map<string, AbiFunction> = new Map([
             name: "toCell",
             resolve: (ctx, args, ref) => {
                 if (args.length !== 1) {
-                    throwSyntaxError("toCell() expects no arguments", ref);
+                    throwCompilationError("toCell() expects no arguments", ref);
                 }
                 if (args[0].kind !== "ref") {
-                    throwSyntaxError(
+                    throwCompilationError(
                         "toCell() is implemented only a struct type",
                         ref,
                     );
                 }
                 const tp = getType(ctx, args[0].name);
                 if (tp.kind !== "struct") {
-                    throwSyntaxError(
+                    throwCompilationError(
                         "toCell() is implemented only a struct type",
                         ref,
                     );
@@ -30,10 +30,10 @@ export const StructFunctions: Map<string, AbiFunction> = new Map([
             },
             generate: (ctx, args, resolved, ref) => {
                 if (resolved.length !== 1) {
-                    throwSyntaxError("toCell() expects no arguments", ref);
+                    throwCompilationError("toCell() expects no arguments", ref);
                 }
                 if (args[0].kind !== "ref") {
-                    throwSyntaxError(
+                    throwCompilationError(
                         "toCell() is implemented only a struct type",
                         ref,
                     );
@@ -48,23 +48,26 @@ export const StructFunctions: Map<string, AbiFunction> = new Map([
             name: "fromCell",
             resolve: (ctx, args, ref) => {
                 if (args.length !== 2) {
-                    throwSyntaxError("fromCell() expects one argument", ref);
+                    throwCompilationError(
+                        "fromCell() expects one argument",
+                        ref,
+                    );
                 }
                 if (args[0].kind !== "ref") {
-                    throwSyntaxError(
+                    throwCompilationError(
                         "fromCell() is implemented only for struct types",
                         ref,
                     );
                 }
                 const tp = getType(ctx, args[0].name);
                 if (tp.kind !== "struct") {
-                    throwSyntaxError(
+                    throwCompilationError(
                         "fromCell() is implemented only for struct types",
                         ref,
                     );
                 }
                 if (args[1].kind !== "ref" || args[1].name !== "Cell") {
-                    throwSyntaxError(
+                    throwCompilationError(
                         "fromCell() expects a Cell as an argument",
                         ref,
                     );
@@ -73,16 +76,19 @@ export const StructFunctions: Map<string, AbiFunction> = new Map([
             },
             generate: (ctx, args, resolved, ref) => {
                 if (resolved.length !== 2) {
-                    throwSyntaxError("fromCell() expects one argument", ref);
+                    throwCompilationError(
+                        "fromCell() expects one argument",
+                        ref,
+                    );
                 }
                 if (args[0].kind !== "ref") {
-                    throwSyntaxError(
+                    throwCompilationError(
                         "fromCell() is implemented only for struct types",
                         ref,
                     );
                 }
                 if (args[1].kind !== "ref" || args[1].name !== "Cell") {
-                    throwSyntaxError(
+                    throwCompilationError(
                         "fromCell() expects a Cell as an argument",
                         ref,
                     );
@@ -97,23 +103,26 @@ export const StructFunctions: Map<string, AbiFunction> = new Map([
             name: "fromSlice",
             resolve: (ctx, args, ref) => {
                 if (args.length !== 2) {
-                    throwSyntaxError("fromSlice() expects one argument", ref);
+                    throwCompilationError(
+                        "fromSlice() expects one argument",
+                        ref,
+                    );
                 }
                 if (args[0].kind !== "ref") {
-                    throwSyntaxError(
+                    throwCompilationError(
                         "fromSlice() is implemented only for struct types",
                         ref,
                     );
                 }
                 const tp = getType(ctx, args[0].name);
                 if (tp.kind !== "struct") {
-                    throwSyntaxError(
+                    throwCompilationError(
                         "fromSlice() is implemented only for struct types",
                         ref,
                     );
                 }
                 if (args[1].kind !== "ref" || args[1].name !== "Slice") {
-                    throwSyntaxError(
+                    throwCompilationError(
                         "fromSlice() expects a Slice as an argument",
                         ref,
                     );
@@ -122,16 +131,19 @@ export const StructFunctions: Map<string, AbiFunction> = new Map([
             },
             generate: (ctx, args, resolved, ref) => {
                 if (resolved.length !== 2) {
-                    throwSyntaxError("fromSlice() expects one argument", ref);
+                    throwCompilationError(
+                        "fromSlice() expects one argument",
+                        ref,
+                    );
                 }
                 if (args[0].kind !== "ref") {
-                    throwSyntaxError(
+                    throwCompilationError(
                         "fromSlice() is implemented only for struct types",
                         ref,
                     );
                 }
                 if (args[1].kind !== "ref" || args[1].name !== "Slice") {
-                    throwSyntaxError(
+                    throwCompilationError(
                         "fromSlice() expects a Slice as an argument",
                         ref,
                     );

--- a/src/check.ts
+++ b/src/check.ts
@@ -1,11 +1,7 @@
 import { featureEnable } from "./config/features";
 import { CompilerContext } from "./context";
 import files from "./imports/stdlib";
-import {
-    createVirtualFileSystem,
-    TactSourceError,
-    VirtualFileSystem,
-} from "./main";
+import { createVirtualFileSystem, TactError, VirtualFileSystem } from "./main";
 import { precompile } from "./pipeline/precompile";
 
 export type CheckResultItem = {
@@ -44,7 +40,7 @@ export function check(args: {
     try {
         precompile(ctx, args.project, stdlib, args.entrypoint);
     } catch (e) {
-        if (e instanceof TactSourceError) {
+        if (e instanceof TactError) {
             items.push({
                 type: "error",
                 message: e.message,

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -1,6 +1,9 @@
+import { MatchResult } from "ohm-js";
+import path from "path";
+import { cwd } from "process";
 import { ASTRef } from "./grammar/ast";
 
-export class TactSourceError extends Error {
+export class TactError extends Error {
     readonly ref: ASTRef;
     constructor(message: string, ref: ASTRef) {
         super(message);
@@ -8,13 +11,20 @@ export class TactSourceError extends Error {
     }
 }
 
-export class TactSyntaxError extends TactSourceError {
+export class TactParseError extends TactError {
     constructor(message: string, ref: ASTRef) {
         super(message, ref);
     }
 }
 
-export class TactConstEvalError extends TactSyntaxError {
+/// This will be split at least into two categories: typechecking and codegen errors
+export class TactCompilationError extends TactError {
+    constructor(message: string, ref: ASTRef) {
+        super(message, ref);
+    }
+}
+
+export class TactConstEvalError extends TactCompilationError {
     fatal: boolean = false;
     constructor(message: string, fatal: boolean, ref: ASTRef) {
         super(message, ref);
@@ -28,14 +38,26 @@ function locationStr(sourceInfo: ASTRef): string {
             lineNum: number;
             colNum: number;
         };
-        return `${sourceInfo.file}:${loc.lineNum}:${loc.colNum}: `;
+        const file = path.relative(cwd(), sourceInfo.file);
+        return `${file}:${loc.lineNum}:${loc.colNum}: `;
     } else {
         return "";
     }
 }
 
-export function throwSyntaxError(message: string, source: ASTRef): never {
-    throw new TactSyntaxError(
+export function throwParseError(matchResult: MatchResult, path: string): never {
+    const interval = matchResult.getInterval();
+    const source = new ASTRef(interval, path);
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const message = `Parse error: expected ${(matchResult as any).getExpectedText()}\n`;
+    throw new TactParseError(
+        `${locationStr(source)}${message}\n${interval.getLineAndColumnMessage()}`,
+        source,
+    );
+}
+
+export function throwCompilationError(message: string, source: ASTRef): never {
+    throw new TactCompilationError(
         `${locationStr(source)}${message}\n${source.interval.getLineAndColumnMessage()}`,
         source,
     );

--- a/src/generator/writers/writeExpression.ts
+++ b/src/generator/writers/writeExpression.ts
@@ -1,5 +1,5 @@
 import { ASTExpression } from "../../grammar/ast";
-import { TactConstEvalError, throwSyntaxError } from "../../errors";
+import { TactConstEvalError, throwCompilationError } from "../../errors";
 import { getExpType } from "../../types/resolveExpression";
 import {
     getStaticConstant,
@@ -378,7 +378,7 @@ export function writeExpression(f: ASTExpression, wCtx: WriterContext): string {
         } else if (f.op === "^") {
             op = "^";
         } else {
-            throwSyntaxError("Unknown binary operator: " + f.op, f.ref);
+            throwCompilationError("Unknown binary operator: " + f.op, f.ref);
         }
         return (
             "(" +
@@ -428,7 +428,7 @@ export function writeExpression(f: ASTExpression, wCtx: WriterContext): string {
             return `${wCtx.used("__tact_not_null")}(${writeExpression(f.right, wCtx)})`;
         }
 
-        throwSyntaxError("Unknown unary operator: " + f.op, f.ref);
+        throwCompilationError("Unknown unary operator: " + f.op, f.ref);
     }
 
     //
@@ -443,7 +443,7 @@ export function writeExpression(f: ASTExpression, wCtx: WriterContext): string {
             src === null ||
             ((src.kind !== "ref" || src.optional) && src.kind !== "ref_bounced")
         ) {
-            throwSyntaxError(
+            throwCompilationError(
                 `Cannot access field of non-struct type: "${printTypeRef(src)}"`,
                 f.ref,
             );
@@ -461,7 +461,7 @@ export function writeExpression(f: ASTExpression, wCtx: WriterContext): string {
         const field = fields.find((v) => v.name === f.name)!;
         const cst = srcT.constants.find((v) => v.name === f.name)!;
         if (!field && !cst) {
-            throwSyntaxError(
+            throwCompilationError(
                 `Cannot find field "${f.name}" in struct "${srcT.name}"`,
                 f.ref,
             );
@@ -566,7 +566,7 @@ export function writeExpression(f: ASTExpression, wCtx: WriterContext): string {
         // Resolve source type
         const src = getExpType(wCtx.ctx, f.src);
         if (src === null) {
-            throwSyntaxError(
+            throwCompilationError(
                 `Cannot call function of non - direct type: "${printTypeRef(src)}"`,
                 f.ref,
             );
@@ -575,7 +575,7 @@ export function writeExpression(f: ASTExpression, wCtx: WriterContext): string {
         // Reference type
         if (src.kind === "ref") {
             if (src.optional) {
-                throwSyntaxError(
+                throwCompilationError(
                     `Cannot call function of non - direct type: "${printTypeRef(src)}"`,
                     f.ref,
                 );
@@ -650,7 +650,10 @@ export function writeExpression(f: ASTExpression, wCtx: WriterContext): string {
         // Map types
         if (src.kind === "map") {
             if (!MapFunctions.has(f.name)) {
-                throwSyntaxError(`Map function "${f.name}" not found`, f.ref);
+                throwCompilationError(
+                    `Map function "${f.name}" not found`,
+                    f.ref,
+                );
             }
             const abf = MapFunctions.get(f.name)!;
             return abf.generate(
@@ -665,7 +668,7 @@ export function writeExpression(f: ASTExpression, wCtx: WriterContext): string {
             throw Error("Unimplemented");
         }
 
-        throwSyntaxError(
+        throwCompilationError(
             `Cannot call function of non - direct type: "${printTypeRef(src)}"`,
             f.ref,
         );

--- a/src/grammar/__snapshots__/grammar.spec.ts.snap
+++ b/src/grammar/__snapshots__/grammar.spec.ts.snap
@@ -1,7 +1,8 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`grammar should fail contract-empty-traits-list-with-keyword 1`] = `
-"<unknown>:1:20: Syntax error: expected "_", "A".."Z", or "a".."z" 
+"<unknown>:1:20: Parse error: expected "_", "A".."Z", or "a".."z"
+
 Line 1, col 20:
 > 1 | contract Name with {}
                          ^
@@ -20,7 +21,8 @@ Line 2, col 10:
 `;
 
 exports[`grammar should fail contract-trailing-comma-empty-traits-list 1`] = `
-"<unknown>:1:19: Syntax error: expected "_", "A".."Z", or "a".."z" 
+"<unknown>:1:19: Parse error: expected "_", "A".."Z", or "a".."z"
+
 Line 1, col 19:
 > 1 | contract Name with, {}
                         ^
@@ -49,7 +51,8 @@ Line 2, col 24:
 `;
 
 exports[`grammar should fail ident-cannot-be-if-reserved-word 1`] = `
-"<unknown>:2:9: Syntax error: expected not a reservedWord 
+"<unknown>:2:9: Parse error: expected not a reservedWord
+
 Line 2, col 9:
   1 | fun hello(): Int {
 > 2 |     let if: Int = 0;
@@ -126,7 +129,8 @@ Line 2, col 9:
 `;
 
 exports[`grammar should fail ident-struct-cannot-start-with-__gen 1`] = `
-"<unknown>:1:8: Syntax error: expected "A".."Z" 
+"<unknown>:1:8: Parse error: expected "A".."Z"
+
 Line 1, col 8:
 > 1 | struct __genA {
              ^
@@ -153,7 +157,8 @@ Line 1, col 14:
 `;
 
 exports[`grammar should fail item-fun-without-body 1`] = `
-"<unknown>:1:20: Syntax error: expected "{" 
+"<unknown>:1:20: Parse error: expected "{"
+
 Line 1, col 20:
 > 1 | fun testFunc(): Int;
                          ^
@@ -179,7 +184,8 @@ Line 2, col 23:
 `;
 
 exports[`grammar should fail literal-dec-trailing-underscore 1`] = `
-"<unknown>:2:16: Syntax error: expected a digit 
+"<unknown>:2:16: Parse error: expected a digit
+
 Line 2, col 16:
   1 | fun test_fun(): Int {
 > 2 |     return 123_;
@@ -189,7 +195,8 @@ Line 2, col 16:
 `;
 
 exports[`grammar should fail literal-double-underscore 1`] = `
-"<unknown>:2:20: Syntax error: expected a digit 
+"<unknown>:2:20: Parse error: expected a digit
+
 Line 2, col 20:
   1 | fun test_fun(): Int {
 > 2 |     return 123_123__123;
@@ -199,7 +206,8 @@ Line 2, col 20:
 `;
 
 exports[`grammar should fail literal-hex-trailing-underscore 1`] = `
-"<unknown>:2:18: Syntax error: expected a hexadecimal digit 
+"<unknown>:2:18: Parse error: expected a hexadecimal digit
+
 Line 2, col 18:
   1 | fun test_fun(): Int {
 > 2 |     return 0x123_;
@@ -209,7 +217,8 @@ Line 2, col 18:
 `;
 
 exports[`grammar should fail literal-no-underscore-after-0b 1`] = `
-"<unknown>:2:14: Syntax error: expected "1" or "0" 
+"<unknown>:2:14: Parse error: expected "1" or "0"
+
 Line 2, col 14:
   1 | fun test_fun(): Int {
 > 2 |     return 0b_00101010;
@@ -219,7 +228,8 @@ Line 2, col 14:
 `;
 
 exports[`grammar should fail literal-no-underscores-if-leading-zero 1`] = `
-"<unknown>:2:15: Syntax error: expected "}" or ";" 
+"<unknown>:2:15: Parse error: expected "}" or ";"
+
 Line 2, col 15:
   1 | fun test_fun(): Int {
 > 2 |     return 012_3;
@@ -229,7 +239,8 @@ Line 2, col 15:
 `;
 
 exports[`grammar should fail literal-non-binary-digits 1`] = `
-"<unknown>:2:15: Syntax error: expected "}" or ";" 
+"<unknown>:2:15: Parse error: expected "}" or ";"
+
 Line 2, col 15:
   1 | fun test_fun(): Int {
 > 2 |     return 0b123;
@@ -239,7 +250,8 @@ Line 2, col 15:
 `;
 
 exports[`grammar should fail literal-underscore-after-leading-zero 1`] = `
-"<unknown>:2:13: Syntax error: expected "}" or ";" 
+"<unknown>:2:13: Parse error: expected "}" or ";"
+
 Line 2, col 13:
   1 | fun test_fun(): Int {
 > 2 |     return 0_123;
@@ -249,7 +261,8 @@ Line 2, col 13:
 `;
 
 exports[`grammar should fail struct-double-semicolon 1`] = `
-"<unknown>:2:19: Syntax error: expected "}" 
+"<unknown>:2:19: Parse error: expected "}"
+
 Line 2, col 19:
   1 | // too many semicolons
 > 2 | struct A { x: Int;; }
@@ -259,7 +272,8 @@ Line 2, col 19:
 `;
 
 exports[`grammar should fail struct-missing-semicolon-between-fields 1`] = `
-"<unknown>:2:19: Syntax error: expected "}", ";", "=", "as", or "?" 
+"<unknown>:2:19: Parse error: expected "}", ";", "=", "as", or "?"
+
 Line 2, col 19:
   1 | // missing ; between fields
 > 2 | struct B { x: Int y: Int }
@@ -269,7 +283,8 @@ Line 2, col 19:
 `;
 
 exports[`grammar should fail struct-missing-semicolon-between-fields-with-initializer 1`] = `
-"<unknown>:2:24: Syntax error: expected "}", ";", ".", "!!", "%", "/", "*", ">>", "<<", "-", "+", "==", "!=", "<=", "<", ">=", ">", "^", "&", "&&", "|", "?", or "||" 
+"<unknown>:2:24: Parse error: expected "}", ";", ".", "!!", "%", "/", "*", ">>", "<<", "-", "+", "==", "!=", "<=", "<", ">=", ">", "^", "&", "&&", "|", "?", or "||"
+
 Line 2, col 24:
   1 | // missing ; between fields
 > 2 | struct B { x: Int = 42 y: Int }
@@ -279,7 +294,8 @@ Line 2, col 24:
 `;
 
 exports[`grammar should fail trait-empty-traits-list-with-keyword 1`] = `
-"<unknown>:1:17: Syntax error: expected "_", "A".."Z", or "a".."z" 
+"<unknown>:1:17: Parse error: expected "_", "A".."Z", or "a".."z"
+
 Line 1, col 17:
 > 1 | trait Name with {}
                       ^
@@ -308,7 +324,8 @@ Line 2, col 31:
 `;
 
 exports[`grammar should fail trait-trailing-comma-empty-traits-list 1`] = `
-"<unknown>:1:16: Syntax error: expected "_", "A".."Z", or "a".."z" 
+"<unknown>:1:16: Parse error: expected "_", "A".."Z", or "a".."z"
+
 Line 1, col 16:
 > 1 | trait Name with, {}
                      ^
@@ -317,7 +334,8 @@ Line 1, col 16:
 `;
 
 exports[`grammar should fail type-ident-msg-should-be-capitalized 1`] = `
-"<unknown>:1:14: Syntax error: expected "A".."Z" 
+"<unknown>:1:14: Parse error: expected "A".."Z"
+
 Line 1, col 14:
 > 1 | message(123) foo {
                    ^
@@ -326,7 +344,8 @@ Line 1, col 14:
 `;
 
 exports[`grammar should fail type-ident-struct-should-be-capitalized 1`] = `
-"<unknown>:1:8: Syntax error: expected "A".."Z" 
+"<unknown>:1:8: Parse error: expected "A".."Z"
+
 Line 1, col 8:
 > 1 | struct lowercaseIdForType {
              ^

--- a/src/grammar/checkConstAttributes.ts
+++ b/src/grammar/checkConstAttributes.ts
@@ -1,5 +1,5 @@
 import { ASTConstantAttribute, ASTRef } from "./ast";
-import { throwSyntaxError } from "../errors";
+import { throwCompilationError } from "../errors";
 
 export function checkConstAttributes(
     isAbstract: boolean,
@@ -9,20 +9,23 @@ export function checkConstAttributes(
     const k = new Set<string>();
     for (const a of attributes) {
         if (k.has(a.type)) {
-            throwSyntaxError(`Duplicate function attribute "${a.type}"`, a.ref);
+            throwCompilationError(
+                `Duplicate function attribute "${a.type}"`,
+                a.ref,
+            );
         }
         k.add(a.type);
     }
     if (isAbstract) {
         if (!k.has("abstract")) {
-            throwSyntaxError(
+            throwCompilationError(
                 `Abstract function doesn't have abstract modifier`,
                 ref,
             );
         }
     } else {
         if (k.has("abstract")) {
-            throwSyntaxError(
+            throwCompilationError(
                 `Non abstract function have abstract modifier`,
                 ref,
             );

--- a/src/grammar/checkFunctionAttributes.ts
+++ b/src/grammar/checkFunctionAttributes.ts
@@ -1,5 +1,5 @@
 import { ASTFunctionAttribute, ASTRef } from "./ast";
-import { throwSyntaxError } from "../errors";
+import { throwCompilationError } from "../errors";
 
 export function checkFunctionAttributes(
     isAbstract: boolean,
@@ -9,20 +9,23 @@ export function checkFunctionAttributes(
     const k = new Set<string>();
     for (const a of attrs) {
         if (k.has(a.type)) {
-            throwSyntaxError(`Duplicate function attribute "${a.type}"`, a.ref);
+            throwCompilationError(
+                `Duplicate function attribute "${a.type}"`,
+                a.ref,
+            );
         }
         k.add(a.type);
     }
     if (isAbstract) {
         if (!k.has("abstract")) {
-            throwSyntaxError(
+            throwCompilationError(
                 `Abstract function doesn't have abstract modifier`,
                 ref,
             );
         }
     } else {
         if (k.has("abstract")) {
-            throwSyntaxError(
+            throwCompilationError(
                 `Non abstract function have abstract modifier`,
                 ref,
             );

--- a/src/grammar/checkVariableName.ts
+++ b/src/grammar/checkVariableName.ts
@@ -1,11 +1,11 @@
 import { ASTRef } from "./ast";
-import { throwSyntaxError } from "../errors";
+import { throwCompilationError } from "../errors";
 
 export function checkVariableName(name: string, ref: ASTRef) {
     if (name.startsWith("__gen")) {
-        throwSyntaxError(`Variable name cannot start with "__gen"`, ref);
+        throwCompilationError(`Variable name cannot start with "__gen"`, ref);
     }
     if (name.startsWith("__tact")) {
-        throwSyntaxError(`Variable name cannot start with "__tact"`, ref);
+        throwCompilationError(`Variable name cannot start with "__tact"`, ref);
     }
 }

--- a/src/types/resolveABITypeRef.ts
+++ b/src/types/resolveABITypeRef.ts
@@ -1,6 +1,6 @@
 import { ABITypeRef } from "@ton/core";
 import { ASTField, ASTRef } from "../grammar/ast";
-import { throwSyntaxError } from "../errors";
+import { throwCompilationError } from "../errors";
 import { TypeRef } from "./types";
 
 type FormatDef = { [key: string]: { type: string; format: string | number } };
@@ -67,7 +67,10 @@ export function resolveABIType(src: ASTField): ABITypeRef {
             if (src.as) {
                 const fmt = intFormats[src.as];
                 if (!fmt) {
-                    throwSyntaxError(`Unsupported format ${src.as}`, src.ref);
+                    throwCompilationError(
+                        `Unsupported format ${src.as}`,
+                        src.ref,
+                    );
                 }
                 return {
                     kind: "simple",
@@ -85,7 +88,7 @@ export function resolveABIType(src: ASTField): ABITypeRef {
         }
         if (src.type.name === "Bool") {
             if (src.as) {
-                throwSyntaxError(`Unsupported format ${src.as}`, src.ref);
+                throwCompilationError(`Unsupported format ${src.as}`, src.ref);
             }
             return {
                 kind: "simple",
@@ -97,7 +100,10 @@ export function resolveABIType(src: ASTField): ABITypeRef {
             if (src.as) {
                 const fmt = cellFormats[src.as];
                 if (!fmt) {
-                    throwSyntaxError(`Unsupported format ${src.as}`, src.ref);
+                    throwCompilationError(
+                        `Unsupported format ${src.as}`,
+                        src.ref,
+                    );
                 }
                 return {
                     kind: "simple",
@@ -117,7 +123,7 @@ export function resolveABIType(src: ASTField): ABITypeRef {
                 if (src.as) {
                     const fmt = sliceFormats[src.as];
                     if (!fmt) {
-                        throwSyntaxError(
+                        throwCompilationError(
                             `Unsupported format ${src.as}`,
                             src.ref,
                         );
@@ -141,7 +147,7 @@ export function resolveABIType(src: ASTField): ABITypeRef {
                 if (src.as) {
                     const fmt = builderFormats[src.as];
                     if (!fmt) {
-                        throwSyntaxError(
+                        throwCompilationError(
                             `Unsupported format ${src.as}`,
                             src.ref,
                         );
@@ -162,7 +168,7 @@ export function resolveABIType(src: ASTField): ABITypeRef {
         }
         if (src.type.name === "Address") {
             if (src.as) {
-                throwSyntaxError(`Unsupported format ${src.as}`, src.ref);
+                throwCompilationError(`Unsupported format ${src.as}`, src.ref);
             }
             return {
                 kind: "simple",
@@ -172,7 +178,7 @@ export function resolveABIType(src: ASTField): ABITypeRef {
         }
         if (src.type.name === "String") {
             if (src.as) {
-                throwSyntaxError(`Unsupported format ${src.as}`, src.ref);
+                throwCompilationError(`Unsupported format ${src.as}`, src.ref);
             }
             return {
                 kind: "simple",
@@ -181,7 +187,10 @@ export function resolveABIType(src: ASTField): ABITypeRef {
             };
         }
         if (src.type.name === "StringBuilder") {
-            throwSyntaxError(`Unsupported type "${src.type.name}"`, src.ref);
+            throwCompilationError(
+                `Unsupported type "${src.type.name}"`,
+                src.ref,
+            );
         }
 
         //
@@ -197,7 +206,7 @@ export function resolveABIType(src: ASTField): ABITypeRef {
                     format: "ref",
                 };
             } else {
-                throwSyntaxError(`Unsupported format ${src.as}`, src.ref);
+                throwCompilationError(`Unsupported format ${src.as}`, src.ref);
             }
         }
         return {
@@ -223,7 +232,7 @@ export function resolveABIType(src: ASTField): ABITypeRef {
             if (src.type.keyAs) {
                 const format = intMapFormats[src.type.keyAs];
                 if (!format) {
-                    throwSyntaxError(
+                    throwCompilationError(
                         `Unsupported format ${src.type.keyAs} for map key`,
                         src.ref,
                     );
@@ -234,13 +243,13 @@ export function resolveABIType(src: ASTField): ABITypeRef {
         } else if (src.type.key === "Address") {
             key = "address";
             if (src.type.keyAs) {
-                throwSyntaxError(
+                throwCompilationError(
                     `Unsupported format ${src.type.keyAs} for map key`,
                     src.ref,
                 );
             }
         } else {
-            throwSyntaxError(
+            throwCompilationError(
                 `Unsupported map key type "${src.type.key}"`,
                 src.ref,
             );
@@ -252,7 +261,7 @@ export function resolveABIType(src: ASTField): ABITypeRef {
             if (src.type.valueAs) {
                 const format = intMapFormats[src.type.valueAs];
                 if (!format) {
-                    throwSyntaxError(
+                    throwCompilationError(
                         `Unsupported format ${src.type.valueAs} for map value`,
                         src.ref,
                     );
@@ -263,7 +272,7 @@ export function resolveABIType(src: ASTField): ABITypeRef {
         } else if (src.type.value === "Bool") {
             value = "bool";
             if (src.type.valueAs) {
-                throwSyntaxError(
+                throwCompilationError(
                     `Unsupported format ${src.type.valueAs} for map value`,
                     src.ref,
                 );
@@ -272,26 +281,26 @@ export function resolveABIType(src: ASTField): ABITypeRef {
             value = "cell";
             valueFormat = "ref";
             if (src.type.valueAs && src.type.valueAs !== "reference") {
-                throwSyntaxError(
+                throwCompilationError(
                     `Unsupported format ${src.type.valueAs} for map value`,
                     src.ref,
                 );
             }
         } else if (src.type.value === "Slice") {
-            throwSyntaxError(
+            throwCompilationError(
                 `Unsupported map value type "${src.type.value}"`,
                 src.ref,
             );
         } else if (src.type.value === "Address") {
             value = "address";
             if (src.type.valueAs) {
-                throwSyntaxError(
+                throwCompilationError(
                     `Unsupported format ${src.type.valueAs} for map value`,
                     src.ref,
                 );
             }
         } else if (src.type.value === "String") {
-            throwSyntaxError(
+            throwCompilationError(
                 `Unsupported map value type "${src.type.value}"`,
                 src.ref,
             );
@@ -299,7 +308,7 @@ export function resolveABIType(src: ASTField): ABITypeRef {
             src.type.value === "StringBuilder" ||
             src.type.value === "Builder"
         ) {
-            throwSyntaxError(
+            throwCompilationError(
                 `Unsupported map value type "${src.type.value}"`,
                 src.ref,
             );
@@ -307,7 +316,7 @@ export function resolveABIType(src: ASTField): ABITypeRef {
             value = src.type.value;
             valueFormat = "ref";
             if (src.type.valueAs && src.type.valueAs !== "reference") {
-                throwSyntaxError(
+                throwCompilationError(
                     `Unsupported format ${src.type.valueAs} for map value`,
                     src.ref,
                 );
@@ -317,7 +326,7 @@ export function resolveABIType(src: ASTField): ABITypeRef {
         return { kind: "dict", key, keyFormat, value, valueFormat };
     }
 
-    throwSyntaxError(`Unsupported type`, src.ref);
+    throwCompilationError(`Unsupported type`, src.ref);
 }
 
 export function createABITypeRefFromTypeRef(
@@ -372,7 +381,7 @@ export function createABITypeRefFromTypeRef(
             if (src.keyAs) {
                 const format = intMapFormats[src.keyAs];
                 if (!format) {
-                    throwSyntaxError(
+                    throwCompilationError(
                         `Unsupported format ${src.keyAs} for map key`,
                         ref,
                     );
@@ -383,7 +392,7 @@ export function createABITypeRefFromTypeRef(
         } else if (src.key === "Address") {
             key = "address";
             if (src.keyAs) {
-                throwSyntaxError(
+                throwCompilationError(
                     `Unsupported format ${src.keyAs} for map key`,
                     ref,
                 );
@@ -398,7 +407,7 @@ export function createABITypeRefFromTypeRef(
             if (src.valueAs) {
                 const format = intMapFormats[src.valueAs];
                 if (!format) {
-                    throwSyntaxError(
+                    throwCompilationError(
                         `Unsupported format ${src.valueAs} for map value`,
                         ref,
                     );
@@ -409,7 +418,7 @@ export function createABITypeRefFromTypeRef(
         } else if (src.value === "Bool") {
             value = "bool";
             if (src.valueAs) {
-                throwSyntaxError(
+                throwCompilationError(
                     `Unsupported format ${src.valueAs} for map value`,
                     ref,
                 );
@@ -418,7 +427,7 @@ export function createABITypeRefFromTypeRef(
             value = "cell";
             valueFormat = "ref";
             if (src.valueAs && src.valueAs !== "reference") {
-                throwSyntaxError(
+                throwCompilationError(
                     `Unsupported format ${src.valueAs} for map value`,
                     ref,
                 );
@@ -428,7 +437,7 @@ export function createABITypeRefFromTypeRef(
         } else if (src.value === "Address") {
             value = "address";
             if (src.valueAs) {
-                throwSyntaxError(
+                throwCompilationError(
                     `Unsupported format ${src.valueAs} for map value`,
                     ref,
                 );
@@ -441,7 +450,7 @@ export function createABITypeRefFromTypeRef(
             value = src.value;
             valueFormat = "ref";
             if (src.valueAs && src.valueAs !== "reference") {
-                throwSyntaxError(
+                throwCompilationError(
                     `Unsupported format ${src.valueAs} for map value`,
                     ref,
                 );

--- a/src/types/resolveDescriptors.ts
+++ b/src/types/resolveDescriptors.ts
@@ -10,7 +10,7 @@ import {
     createNode,
     traverse,
 } from "../grammar/ast";
-import { throwSyntaxError } from "../errors";
+import { throwCompilationError } from "../errors";
 import { CompilerContext, createContextStore } from "../context";
 import {
     ConstantDescription,
@@ -70,10 +70,10 @@ function verifyMapType(
                     "uint256",
                 ].includes(keyAs)
             ) {
-                throwSyntaxError("Invalid key type for map", ref);
+                throwCompilationError("Invalid key type for map", ref);
             }
         } else {
-            throwSyntaxError("Invalid key type for map", ref);
+            throwCompilationError("Invalid key type for map", ref);
         }
     }
 
@@ -98,10 +98,10 @@ function verifyMapType(
                     "coins",
                 ].includes(valueAs)
             ) {
-                throwSyntaxError("Invalid value type for map", ref);
+                throwCompilationError("Invalid value type for map", ref);
             }
         } else {
-            throwSyntaxError("Invalid value type for map", ref);
+            throwCompilationError("Invalid value type for map", ref);
         }
     }
 }
@@ -145,7 +145,7 @@ function buildTypeRef(
 ): TypeRef {
     if (src.kind === "type_ref_simple") {
         if (!types.has(src.name)) {
-            throwSyntaxError("Type " + src.name + " not found", src.ref);
+            throwCompilationError("Type " + src.name + " not found", src.ref);
         }
         return {
             kind: "ref",
@@ -155,10 +155,10 @@ function buildTypeRef(
     }
     if (src.kind === "type_ref_map") {
         if (!types.has(src.key)) {
-            throwSyntaxError("Type " + src.key + " not found", src.ref);
+            throwCompilationError("Type " + src.key + " not found", src.ref);
         }
         if (!types.has(src.value)) {
-            throwSyntaxError("Type " + src.value + " not found", src.ref);
+            throwCompilationError("Type " + src.value + " not found", src.ref);
         }
         return {
             kind: "map",
@@ -199,7 +199,7 @@ export function resolveDescriptors(ctx: CompilerContext) {
 
     for (const a of ast.types) {
         if (types.has(a.name)) {
-            throwSyntaxError(`Type "${a.name}" already exists`, a.ref);
+            throwCompilationError(`Type "${a.name}" already exists`, a.ref);
         }
 
         const uid = uidForName(a.name, types);
@@ -303,7 +303,7 @@ export function resolveDescriptors(ctx: CompilerContext) {
 
         // Check if field is runtime type
         if (isRuntimeType(tr)) {
-            throwSyntaxError(
+            throwCompilationError(
                 printTypeRef(tr) +
                     " is a runtime only type and can't be used as field",
                 src.ref,
@@ -343,7 +343,7 @@ export function resolveDescriptors(ctx: CompilerContext) {
                     if (
                         types.get(a.name)!.fields.find((v) => v.name === f.name)
                     ) {
-                        throwSyntaxError(
+                        throwCompilationError(
                             `Field "${f.name}" already exists`,
                             f.ref,
                         );
@@ -353,7 +353,7 @@ export function resolveDescriptors(ctx: CompilerContext) {
                             .get(a.name)!
                             .constants.find((v) => v.name === f.name)
                     ) {
-                        throwSyntaxError(
+                        throwCompilationError(
                             `Constant "${f.name}" already exists`,
                             f.ref,
                         );
@@ -370,7 +370,7 @@ export function resolveDescriptors(ctx: CompilerContext) {
                     if (
                         types.get(a.name)!.fields.find((v) => v.name === f.name)
                     ) {
-                        throwSyntaxError(
+                        throwCompilationError(
                             `Field "${f.name}" already exists`,
                             f.ref,
                         );
@@ -380,13 +380,13 @@ export function resolveDescriptors(ctx: CompilerContext) {
                             .get(a.name)!
                             .constants.find((v) => v.name === f.name)
                     ) {
-                        throwSyntaxError(
+                        throwCompilationError(
                             `Constant "${f.name}" already exists`,
                             f.ref,
                         );
                     }
                     if (f.attributes.find((v) => v.type !== "overrides")) {
-                        throwSyntaxError(
+                        throwCompilationError(
                             `Constant can be only overridden`,
                             f.ref,
                         );
@@ -402,7 +402,10 @@ export function resolveDescriptors(ctx: CompilerContext) {
         if (a.kind === "def_struct") {
             for (const f of a.fields) {
                 if (types.get(a.name)!.fields.find((v) => v.name === f.name)) {
-                    throwSyntaxError(`Field "${f.name}" already exists`, f.ref);
+                    throwCompilationError(
+                        `Field "${f.name}" already exists`,
+                        f.ref,
+                    );
                 }
                 types
                     .get(a.name)!
@@ -414,7 +417,7 @@ export function resolveDescriptors(ctx: CompilerContext) {
                     );
             }
             if (a.fields.length === 0 && !a.message) {
-                throwSyntaxError(
+                throwCompilationError(
                     `Struct "${a.name}" must have at least one field`,
                     a.ref,
                 );
@@ -428,13 +431,13 @@ export function resolveDescriptors(ctx: CompilerContext) {
                     if (
                         types.get(a.name)!.fields.find((v) => v.name === f.name)
                     ) {
-                        throwSyntaxError(
+                        throwCompilationError(
                             `Field "${f.name}" already exists`,
                             f.ref,
                         );
                     }
                     if (f.as) {
-                        throwSyntaxError(
+                        throwCompilationError(
                             `Trait field cannot have serialization specifier`,
                             f.ref,
                         );
@@ -451,7 +454,7 @@ export function resolveDescriptors(ctx: CompilerContext) {
                     if (
                         types.get(a.name)!.fields.find((v) => v.name === f.name)
                     ) {
-                        throwSyntaxError(
+                        throwCompilationError(
                             `Field "${f.name}" already exists`,
                             f.ref,
                         );
@@ -461,13 +464,13 @@ export function resolveDescriptors(ctx: CompilerContext) {
                             .get(a.name)!
                             .constants.find((v) => v.name === f.name)
                     ) {
-                        throwSyntaxError(
+                        throwCompilationError(
                             `Constant "${f.name}" already exists`,
                             f.ref,
                         );
                     }
                     if (f.attributes.find((v) => v.type === "overrides")) {
-                        throwSyntaxError(
+                        throwCompilationError(
                             `Trait constant cannot be overridden`,
                             f.ref,
                         );
@@ -530,25 +533,25 @@ export function resolveDescriptors(ctx: CompilerContext) {
         // Check for native
         if (a.kind === "def_native_function") {
             if (isGetter) {
-                throwSyntaxError(
+                throwCompilationError(
                     "Native functions cannot be getters",
                     isGetter.ref,
                 );
             }
             if (self) {
-                throwSyntaxError(
+                throwCompilationError(
                     "Native functions cannot be defined within a contract",
                     a.ref,
                 );
             }
             if (isVirtual) {
-                throwSyntaxError(
+                throwCompilationError(
                     "Native functions cannot be virtual",
                     isVirtual.ref,
                 );
             }
             if (isOverrides) {
-                throwSyntaxError(
+                throwCompilationError(
                     "Native functions cannot be overrides",
                     isOverrides.ref,
                 );
@@ -557,55 +560,55 @@ export function resolveDescriptors(ctx: CompilerContext) {
 
         // Check virtual and overrides
         if (isVirtual && isExtends) {
-            throwSyntaxError(
+            throwCompilationError(
                 "Extend functions cannot be virtual",
                 isVirtual.ref,
             );
         }
         if (isOverrides && isExtends) {
-            throwSyntaxError(
+            throwCompilationError(
                 "Extend functions cannot be overrides",
                 isOverrides.ref,
             );
         }
         if (isAbstract && isExtends) {
-            throwSyntaxError(
+            throwCompilationError(
                 "Extend functions cannot be abstract",
                 isAbstract.ref,
             );
         }
         if (!self && isVirtual) {
-            throwSyntaxError(
+            throwCompilationError(
                 "Virtual functions must be defined within a contract or a trait",
                 isVirtual.ref,
             );
         }
         if (!self && isOverrides) {
-            throwSyntaxError(
+            throwCompilationError(
                 "Overrides functions must be defined within a contract or a trait",
                 isOverrides.ref,
             );
         }
         if (!self && isAbstract) {
-            throwSyntaxError(
+            throwCompilationError(
                 "Abstract functions must be defined within a trait",
                 isAbstract.ref,
             );
         }
         if (isVirtual && isAbstract) {
-            throwSyntaxError(
+            throwCompilationError(
                 "Abstract functions cannot be virtual",
                 isAbstract.ref,
             );
         }
         if (isVirtual && isOverrides) {
-            throwSyntaxError(
+            throwCompilationError(
                 "Overrides functions cannot be virtual",
                 isOverrides.ref,
             );
         }
         if (isAbstract && isOverrides) {
-            throwSyntaxError(
+            throwCompilationError(
                 "Overrides functions cannot be abstract",
                 isOverrides.ref,
             );
@@ -615,7 +618,7 @@ export function resolveDescriptors(ctx: CompilerContext) {
         if (isVirtual) {
             const t = types.get(self!)!;
             if (t.kind !== "trait") {
-                throwSyntaxError(
+                throwCompilationError(
                     "Virtual functions must be defined within a trait",
                     isVirtual.ref,
                 );
@@ -626,7 +629,7 @@ export function resolveDescriptors(ctx: CompilerContext) {
         if (isAbstract) {
             const t = types.get(self!)!;
             if (t.kind !== "trait") {
-                throwSyntaxError(
+                throwCompilationError(
                     "Abstract functions must be defined within a trait",
                     isAbstract.ref,
                 );
@@ -637,7 +640,7 @@ export function resolveDescriptors(ctx: CompilerContext) {
         if (isOverrides) {
             const t = types.get(self!)!;
             if (t.kind !== "contract") {
-                throwSyntaxError(
+                throwCompilationError(
                     "Overrides functions must be defined within a contract",
                     isOverrides.ref,
                 );
@@ -647,7 +650,7 @@ export function resolveDescriptors(ctx: CompilerContext) {
         // Check for common
         if (a.kind === "def_function") {
             if (isGetter && !self) {
-                throwSyntaxError(
+                throwCompilationError(
                     "Getters must be defined within a contract",
                     isGetter.ref,
                 );
@@ -656,44 +659,44 @@ export function resolveDescriptors(ctx: CompilerContext) {
 
         // Check for getter
         if (isInline && isGetter) {
-            throwSyntaxError("Getters cannot be inline", isInline.ref);
+            throwCompilationError("Getters cannot be inline", isInline.ref);
         }
 
         // Validate mutating
         if (isExtends) {
             // Validate arguments
             if (self) {
-                throwSyntaxError(
+                throwCompilationError(
                     "Extend functions cannot be defined within a contract",
                     isExtends.ref,
                 );
             }
             if (args.length === 0) {
-                throwSyntaxError(
+                throwCompilationError(
                     "Extend functions must have at least one argument",
                     isExtends.ref,
                 );
             }
             if (args[0].name !== "self") {
-                throwSyntaxError(
+                throwCompilationError(
                     'Extend function must have first argument named "self"',
                     args[0].ref,
                 );
             }
             if (args[0].type.kind !== "ref") {
-                throwSyntaxError(
+                throwCompilationError(
                     "Extend functions must have a reference type as the first argument",
                     args[0].ref,
                 );
             }
             if (args[0].type.optional) {
-                throwSyntaxError(
+                throwCompilationError(
                     "Extend functions must have a non-optional type as the first argument",
                     args[0].ref,
                 );
             }
             if (!types.has(args[0].type.name)) {
-                throwSyntaxError(
+                throwCompilationError(
                     "Type " + args[0].type.name + " not found",
                     args[0].ref,
                 );
@@ -706,7 +709,7 @@ export function resolveDescriptors(ctx: CompilerContext) {
 
         // Check for mutating and extends
         if (isMutating && !isExtends) {
-            throwSyntaxError(
+            throwCompilationError(
                 "Mutating functions must be extend functions",
                 isMutating.ref,
             );
@@ -716,10 +719,13 @@ export function resolveDescriptors(ctx: CompilerContext) {
         const exNames = new Set<string>();
         for (const arg of args) {
             if (arg.name === "self") {
-                throwSyntaxError('Argument name "self" is reserved', arg.ref);
+                throwCompilationError(
+                    'Argument name "self" is reserved',
+                    arg.ref,
+                );
             }
             if (exNames.has(arg.name)) {
-                throwSyntaxError(
+                throwCompilationError(
                     'Argument name "' + arg.name + '" is already used',
                     arg.ref,
                 );
@@ -731,7 +737,7 @@ export function resolveDescriptors(ctx: CompilerContext) {
         if (isGetter) {
             for (const arg of args) {
                 if (isRuntimeType(arg.type)) {
-                    throwSyntaxError(
+                    throwCompilationError(
                         printTypeRef(arg.type) +
                             " is a runtime-only type and can't be used as a getter argument",
                         arg.ref,
@@ -739,7 +745,7 @@ export function resolveDescriptors(ctx: CompilerContext) {
                 }
             }
             if (isRuntimeType(returns)) {
-                throwSyntaxError(
+                throwCompilationError(
                     printTypeRef(returns) +
                         " is a runtime-only type and can't be used as getter return type",
                     a.ref,
@@ -778,7 +784,7 @@ export function resolveDescriptors(ctx: CompilerContext) {
         // Check if runtime types are used
         for (const a of args) {
             if (isRuntimeType(a.type)) {
-                throwSyntaxError(
+                throwCompilationError(
                     printTypeRef(a.type) +
                         " is a runtime-only type and can't be used as a init function argument",
                     a.ref,
@@ -802,7 +808,7 @@ export function resolveDescriptors(ctx: CompilerContext) {
                         throw Error("Function self must be " + s.name); // Impossible
                     }
                     if (s.functions.has(f.name)) {
-                        throwSyntaxError(
+                        throwCompilationError(
                             `Function "${f.name}" already exists in type "${s.name}"`,
                             s.ast.ref,
                         );
@@ -811,7 +817,10 @@ export function resolveDescriptors(ctx: CompilerContext) {
                 }
                 if (d.kind === "def_init_function") {
                     if (s.init) {
-                        throwSyntaxError("Init function already exists", d.ref);
+                        throwCompilationError(
+                            "Init function already exists",
+                            d.ref,
+                        );
                     }
                     s.init = resolveInitFunction(d);
                 }
@@ -821,7 +830,7 @@ export function resolveDescriptors(ctx: CompilerContext) {
                         d.selector.kind.startsWith("external-") &&
                         !enabledExternals(ctx)
                     ) {
-                        throwSyntaxError(
+                        throwCompilationError(
                             "External functions are not enabled",
                             d.ref,
                         );
@@ -836,13 +845,13 @@ export function resolveDescriptors(ctx: CompilerContext) {
 
                         // Check argument type
                         if (arg.type.kind !== "type_ref_simple") {
-                            throwSyntaxError(
+                            throwCompilationError(
                                 "Receive function can only accept message",
                                 d.ref,
                             );
                         }
                         if (arg.type.optional) {
-                            throwSyntaxError(
+                            throwCompilationError(
                                 "Receive function cannot have optional argument",
                                 d.ref,
                             );
@@ -851,7 +860,7 @@ export function resolveDescriptors(ctx: CompilerContext) {
                         // Check resolved argument type
                         const t = types.get(arg.type.name);
                         if (!t) {
-                            throwSyntaxError(
+                            throwCompilationError(
                                 "Type " + arg.type.name + " not found",
                                 d.ref,
                             );
@@ -870,7 +879,7 @@ export function resolveDescriptors(ctx: CompilerContext) {
                                                 : "external-fallback"),
                                     )
                                 ) {
-                                    throwSyntaxError(
+                                    throwCompilationError(
                                         `Fallback receive function already exists`,
                                         d.ref,
                                     );
@@ -897,7 +906,7 @@ export function resolveDescriptors(ctx: CompilerContext) {
                                                 : "external-comment-fallback"),
                                     )
                                 ) {
-                                    throwSyntaxError(
+                                    throwCompilationError(
                                         "Comment fallback receive function already exists",
                                         d.ref,
                                     );
@@ -914,7 +923,7 @@ export function resolveDescriptors(ctx: CompilerContext) {
                                     ast: d,
                                 });
                             } else {
-                                throwSyntaxError(
+                                throwCompilationError(
                                     "Receive function can only accept message, Slice or String",
                                     d.ref,
                                 );
@@ -922,19 +931,19 @@ export function resolveDescriptors(ctx: CompilerContext) {
                         } else {
                             // Check type
                             if (t.kind !== "struct") {
-                                throwSyntaxError(
+                                throwCompilationError(
                                     "Receive function can only accept message",
                                     d.ref,
                                 );
                             }
                             if (t.ast.kind !== "def_struct") {
-                                throwSyntaxError(
+                                throwCompilationError(
                                     "Receive function can only accept message",
                                     d.ref,
                                 );
                             }
                             if (!t.ast.message) {
-                                throwSyntaxError(
+                                throwCompilationError(
                                     "Receive function can only accept message",
                                     d.ref,
                                 );
@@ -952,7 +961,7 @@ export function resolveDescriptors(ctx: CompilerContext) {
                                         v.selector.name === n,
                                 )
                             ) {
-                                throwSyntaxError(
+                                throwCompilationError(
                                     `Receive function for "${arg.type.name}" already exists`,
                                     d.ref,
                                 );
@@ -976,7 +985,7 @@ export function resolveDescriptors(ctx: CompilerContext) {
                     ) {
                         const internal = d.selector.kind === "internal-comment";
                         if (d.selector.comment.value === "") {
-                            throwSyntaxError(
+                            throwCompilationError(
                                 "To use empty comment receiver, just remove argument instead of passing empty string",
                                 d.ref,
                             );
@@ -992,7 +1001,7 @@ export function resolveDescriptors(ctx: CompilerContext) {
                                     v.selector.comment === c,
                             )
                         ) {
-                            throwSyntaxError(
+                            throwCompilationError(
                                 `Receive function for "${c}" already exists`,
                                 d.ref,
                             );
@@ -1022,7 +1031,7 @@ export function resolveDescriptors(ctx: CompilerContext) {
                                         : "external-empty"),
                             )
                         ) {
-                            throwSyntaxError(
+                            throwCompilationError(
                                 "Empty receive function already exists",
                                 d.ref,
                             );
@@ -1041,7 +1050,7 @@ export function resolveDescriptors(ctx: CompilerContext) {
                         // If argument is a direct reference
                         if (arg.type.kind === "type_ref_simple") {
                             if (arg.type.optional) {
-                                throwSyntaxError(
+                                throwCompilationError(
                                     "Bounce receive function cannot have optional argument",
                                     d.ref,
                                 );
@@ -1055,7 +1064,7 @@ export function resolveDescriptors(ctx: CompilerContext) {
                                             "bounce-fallback",
                                     )
                                 ) {
-                                    throwSyntaxError(
+                                    throwCompilationError(
                                         `Fallback bounce receive function already exists`,
                                         d.ref,
                                     );
@@ -1074,7 +1083,7 @@ export function resolveDescriptors(ctx: CompilerContext) {
                                     type.ast.kind !== "def_struct" ||
                                     !type.ast.message
                                 ) {
-                                    throwSyntaxError(
+                                    throwCompilationError(
                                         "Bounce receive function can only accept bounced message, message or Slice",
                                         d.ref,
                                     );
@@ -1083,7 +1092,7 @@ export function resolveDescriptors(ctx: CompilerContext) {
                                     type.fields.length !==
                                     type.partialFieldCount
                                 ) {
-                                    throwSyntaxError(
+                                    throwCompilationError(
                                         "This message is too big for bounce receiver, you need to wrap it to a bounced<" +
                                             arg.type.name +
                                             ">.",
@@ -1098,7 +1107,7 @@ export function resolveDescriptors(ctx: CompilerContext) {
                                             v.selector.name === type.name,
                                     )
                                 ) {
-                                    throwSyntaxError(
+                                    throwCompilationError(
                                         `Bounce receive function for "${arg.type.name}" already exists`,
                                         d.ref,
                                     );
@@ -1116,19 +1125,19 @@ export function resolveDescriptors(ctx: CompilerContext) {
                         } else if (arg.type.kind === "type_ref_bounced") {
                             const t = types.get(arg.type.name)!;
                             if (t.kind !== "struct") {
-                                throwSyntaxError(
+                                throwCompilationError(
                                     "Bounce receive function can only accept bounced<T> struct types",
                                     d.ref,
                                 );
                             }
                             if (t.ast.kind !== "def_struct") {
-                                throwSyntaxError(
+                                throwCompilationError(
                                     "Bounce receive function can only accept bounced<T> struct types",
                                     d.ref,
                                 );
                             }
                             if (!t.ast.message) {
-                                throwSyntaxError(
+                                throwCompilationError(
                                     "Bounce receive function can only accept bounced message, message or Slice",
                                     d.ref,
                                 );
@@ -1140,13 +1149,13 @@ export function resolveDescriptors(ctx: CompilerContext) {
                                         v.selector.type === t.name,
                                 )
                             ) {
-                                throwSyntaxError(
+                                throwCompilationError(
                                     `Bounce receive function for "${t.name}" already exists`,
                                     d.ref,
                                 );
                             }
                             if (t.fields.length === t.partialFieldCount) {
-                                throwSyntaxError(
+                                throwCompilationError(
                                     "This message is small enough for bounce receiver, you need to remove bounced modifier.",
                                     d.ref,
                                 );
@@ -1161,13 +1170,13 @@ export function resolveDescriptors(ctx: CompilerContext) {
                                 ast: d,
                             });
                         } else {
-                            throwSyntaxError(
+                            throwCompilationError(
                                 "Bounce receive function can only accept bounced<T> struct args or Slice",
                                 d.ref,
                             );
                         }
                     } else {
-                        throwSyntaxError(
+                        throwCompilationError(
                             "Invalid receive function selector",
                             d.ref,
                         );
@@ -1214,7 +1223,10 @@ export function resolveDescriptors(ctx: CompilerContext) {
                 }
                 const tt = types.get(name);
                 if (!tt) {
-                    throwSyntaxError("Trait " + name + " not found", t.ast.ref);
+                    throwCompilationError(
+                        "Trait " + name + " not found",
+                        t.ast.ref,
+                    );
                 }
                 visited.add(name);
                 traits.push(tt);
@@ -1226,7 +1238,7 @@ export function resolveDescriptors(ctx: CompilerContext) {
                         visit(f.name);
                     }
                 } else {
-                    throwSyntaxError(
+                    throwCompilationError(
                         "Type " + name + " is not a trait",
                         t.ast.ref,
                     );
@@ -1250,10 +1262,13 @@ export function resolveDescriptors(ctx: CompilerContext) {
         for (const tr of t.traits) {
             // Check that trait is valid
             if (!types.has(tr.name)) {
-                throwSyntaxError("Trait " + tr.name + " not found", t.ast.ref);
+                throwCompilationError(
+                    "Trait " + tr.name + " not found",
+                    t.ast.ref,
+                );
             }
             if (types.get(tr.name)!.kind !== "trait") {
-                throwSyntaxError(
+                throwCompilationError(
                     "Type " + tr.name + " is not a trait",
                     t.ast.ref,
                 );
@@ -1265,7 +1280,7 @@ export function resolveDescriptors(ctx: CompilerContext) {
                 // Check if field exists
                 const ex = t.fields.find((v) => v.name === f.name);
                 if (!ex) {
-                    throwSyntaxError(
+                    throwCompilationError(
                         `Trait "${tr.name}" requires field "${f.name}"`,
                         t.ast.ref,
                     );
@@ -1273,7 +1288,7 @@ export function resolveDescriptors(ctx: CompilerContext) {
 
                 // Check type
                 if (!typeRefEquals(f.type, ex.type)) {
-                    throwSyntaxError(
+                    throwCompilationError(
                         `Trait "${tr.name}" requires field "${f.name}" of type "${printTypeRef(f.type)}"`,
                         t.ast.ref,
                     );
@@ -1292,7 +1307,7 @@ export function resolveDescriptors(ctx: CompilerContext) {
             for (const f of tr.functions.values()) {
                 const ex = t.functions.get(f.name);
                 if (!ex && f.isAbstract) {
-                    throwSyntaxError(
+                    throwCompilationError(
                         `Trait "${tr.name}" requires function "${f.name}"`,
                         t.ast.ref,
                     );
@@ -1301,25 +1316,25 @@ export function resolveDescriptors(ctx: CompilerContext) {
                 // Check overrides
                 if (ex && ex.isOverrides) {
                     if (f.isGetter) {
-                        throwSyntaxError(
+                        throwCompilationError(
                             `Overridden function "${f.name}" can not be a getter`,
                             ex.ast.ref,
                         );
                     }
                     if (f.isMutating !== ex.isMutating) {
-                        throwSyntaxError(
+                        throwCompilationError(
                             `Overridden function "${f.name}" should have same mutability`,
                             ex.ast.ref,
                         );
                     }
                     if (!typeRefEquals(f.returns, ex.returns)) {
-                        throwSyntaxError(
+                        throwCompilationError(
                             `Overridden function "${f.name}" should have same return type`,
                             ex.ast.ref,
                         );
                     }
                     if (f.args.length !== ex.args.length) {
-                        throwSyntaxError(
+                        throwCompilationError(
                             `Overridden function "${f.name}" should have same number of arguments`,
                             ex.ast.ref,
                         );
@@ -1328,7 +1343,7 @@ export function resolveDescriptors(ctx: CompilerContext) {
                         const a = ex.args[i];
                         const b = f.args[i];
                         if (!typeRefEquals(a.type, b.type)) {
-                            throwSyntaxError(
+                            throwCompilationError(
                                 `Overridden function "${f.name}" should have same argument types`,
                                 ex.ast.ref,
                             );
@@ -1339,7 +1354,7 @@ export function resolveDescriptors(ctx: CompilerContext) {
 
                 // Check duplicates
                 if (ex) {
-                    throwSyntaxError(
+                    throwCompilationError(
                         `Function "${f.name}" already exist in "${t.name}"`,
                         t.ast.ref,
                     );
@@ -1360,7 +1375,7 @@ export function resolveDescriptors(ctx: CompilerContext) {
                     !ex &&
                     f.ast.attributes.find((v) => v.type === "abstract")
                 ) {
-                    throwSyntaxError(
+                    throwCompilationError(
                         `Trait "${tr.name}" requires constant "${f.name}"`,
                         t.ast.ref,
                     );
@@ -1372,7 +1387,7 @@ export function resolveDescriptors(ctx: CompilerContext) {
                     ex.ast.attributes.find((v) => v.type === "overrides")
                 ) {
                     if (!typeRefEquals(f.type, ex.type)) {
-                        throwSyntaxError(
+                        throwCompilationError(
                             `Overridden constant "${f.name}" should have same type`,
                             ex.ast.ref,
                         );
@@ -1382,7 +1397,7 @@ export function resolveDescriptors(ctx: CompilerContext) {
 
                 // Check duplicates
                 if (ex) {
-                    throwSyntaxError(
+                    throwCompilationError(
                         `Constant "${f.name}" already exist in "${t.name}"`,
                         t.ast.ref,
                     );
@@ -1451,7 +1466,7 @@ export function resolveDescriptors(ctx: CompilerContext) {
                         sameReceiver(v.selector, f.selector),
                     )
                 ) {
-                    throwSyntaxError(
+                    throwCompilationError(
                         `Receive function for "${f.selector}" already exists`,
                         t.ast.ref,
                     );
@@ -1482,7 +1497,7 @@ export function resolveDescriptors(ctx: CompilerContext) {
             return;
         }
         if (processing.has(name)) {
-            throwSyntaxError(
+            throwCompilationError(
                 `Circular dependency detected for type "${name}"`,
                 types.get(name)!.ast.ref,
             );
@@ -1517,7 +1532,10 @@ export function resolveDescriptors(ctx: CompilerContext) {
         const handler = (src: ASTNode) => {
             if (src.kind === "init_of") {
                 if (!types.has(src.name)) {
-                    throwSyntaxError(`Type "${src.name}" not found`, src.ref);
+                    throwCompilationError(
+                        `Type "${src.name}" not found`,
+                        src.ref,
+                    );
                 }
                 dependsOn.add(src.name);
             }
@@ -1572,7 +1590,7 @@ export function resolveDescriptors(ctx: CompilerContext) {
         const r = resolveFunctionDescriptor(null, a, a.origin);
         if (r.self) {
             if (types.get(r.self)!.functions.has(r.name)) {
-                throwSyntaxError(
+                throwCompilationError(
                     `Function "${r.name}" already exists in type "${r.self}"`,
                     r.ast.ref,
                 );
@@ -1580,13 +1598,13 @@ export function resolveDescriptors(ctx: CompilerContext) {
             types.get(r.self)!.functions.set(r.name, r);
         } else {
             if (staticFunctions.has(r.name) || GlobalFunctions.has(r.name)) {
-                throwSyntaxError(
+                throwCompilationError(
                     `Static function "${r.name}" already exists`,
                     r.ast.ref,
                 );
             }
             if (staticConstants.has(r.name)) {
-                throwSyntaxError(
+                throwCompilationError(
                     `Static constant "${r.name}" already exists`,
                     a.ref,
                 );
@@ -1601,13 +1619,13 @@ export function resolveDescriptors(ctx: CompilerContext) {
 
     for (const a of ast.constants) {
         if (staticConstants.has(a.name)) {
-            throwSyntaxError(
+            throwCompilationError(
                 `Static constant "${a.name}" already exists`,
                 a.ref,
             );
         }
         if (staticFunctions.has(a.name) || GlobalFunctions.has(a.name)) {
-            throwSyntaxError(
+            throwCompilationError(
                 `Static function "${a.name}" already exists`,
                 a.ref,
             );


### PR DESCRIPTION
Closes #406

<!--
IMPORTANT:
If your PR doesn't close a particular issue, please, create the issue first and describe the whole context: what you're adding/changing and why you're doing so. And only then open the Pull Request, which would close that issue!
-->

- [x] I have updated CHANGELOG.md
- ~[ ] I have added tests to demonstrate the contribution is correctly implemented: this usually includes both positive and negative tests, showing the happy path(s) and featuring intentionally broken cases~ I didn't add tests, just checked it works locally and it should be observable in CI in [this check](https://github.com/tact-lang/tact/blob/b75468f75324310352f5e489cee1f2ce549bb936/.github/workflows/tact.yml#L111C71-L111C82)'s error message. To properly test everything we should fix issue #315
- [x] I have run all the tests locally and no test failure was reported
- [x] I have run the linter, formatter and spellchecker
- [x] I did not do unrelated and/or undiscussed refactorings -- had to rename some errors because of introducing a parse error category
