### PR TITLE
refactor(grammar): remove LValue category and replace it with Expression

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,9 +13,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Removed the `LValue` grammatical category and replaced it with `Expression`: PR [#479](https://github.com/tact-lang/tact/pull/479)
+
 ### Fixed
 
 - Name clashes with FunC keywords in struct constructor function parameters: PR [#467](https://github.com/tact-lang/tact/issues/467)
+- Error messages for traversing non-path-expressions in `foreach`-loops : PR [#479](https://github.com/tact-lang/tact/pull/479)
 
 ## [1.4.0] - 2024-06-21
 

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -24,6 +24,12 @@ export class TactCompilationError extends TactError {
     }
 }
 
+export class TactInternalCompilerError extends TactError {
+    constructor(message: string, ref: ASTRef) {
+        super(message, ref);
+    }
+}
+
 export class TactConstEvalError extends TactCompilationError {
     fatal: boolean = false;
     constructor(message: string, fatal: boolean, ref: ASTRef) {
@@ -59,6 +65,16 @@ export function throwParseError(matchResult: MatchResult, path: string): never {
 export function throwCompilationError(message: string, source: ASTRef): never {
     throw new TactCompilationError(
         `${locationStr(source)}${message}\n${source.interval.getLineAndColumnMessage()}`,
+        source,
+    );
+}
+
+export function throwInternalCompilerError(
+    message: string,
+    source: ASTRef,
+): never {
+    throw new TactInternalCompilerError(
+        `${locationStr(source)}\n[INTERNAL COMPILER ERROR]: ${message}\nPlease report at https://github.com/tact-lang/tact/issues\n${source.interval.getLineAndColumnMessage()}`,
         source,
     );
 }

--- a/src/grammar/__snapshots__/grammar.spec.ts.snap
+++ b/src/grammar/__snapshots__/grammar.spec.ts.snap
@@ -465,7 +465,7 @@ exports[`grammar should parse contract-with-init 1`] = `
               },
             },
           ],
-          "id": 17,
+          "id": 19,
           "kind": "def_init_function",
           "ref": init(a: Int, b: Int) {
         self.a = a;
@@ -474,58 +474,64 @@ exports[`grammar should parse contract-with-init 1`] = `
           "statements": [
             {
               "expression": {
-                "id": 11,
+                "id": 12,
                 "kind": "id",
                 "ref": a,
                 "value": "a",
               },
-              "id": 12,
+              "id": 13,
               "kind": "statement_assign",
-              "path": [
-                {
-                  "id": 9,
-                  "kind": "lvalue_ref",
-                  "name": "self",
-                  "ref": self.,
-                },
-                {
+              "path": {
+                "id": 11,
+                "kind": "op_field",
+                "name": {
                   "id": 10,
-                  "kind": "lvalue_ref",
-                  "name": "a",
+                  "kind": "id",
                   "ref": a,
+                  "value": "a",
                 },
-              ],
+                "ref": self.a,
+                "src": {
+                  "id": 9,
+                  "kind": "id",
+                  "ref": self,
+                  "value": "self",
+                },
+              },
               "ref": self.a = a;,
             },
             {
               "expression": {
-                "id": 15,
+                "id": 17,
                 "kind": "id",
                 "ref": b,
                 "value": "b",
               },
-              "id": 16,
+              "id": 18,
               "kind": "statement_assign",
-              "path": [
-                {
-                  "id": 13,
-                  "kind": "lvalue_ref",
-                  "name": "self",
-                  "ref": self.,
-                },
-                {
-                  "id": 14,
-                  "kind": "lvalue_ref",
-                  "name": "b",
+              "path": {
+                "id": 16,
+                "kind": "op_field",
+                "name": {
+                  "id": 15,
+                  "kind": "id",
                   "ref": b,
+                  "value": "b",
                 },
-              ],
+                "ref": self.b,
+                "src": {
+                  "id": 14,
+                  "kind": "id",
+                  "ref": self,
+                  "value": "self",
+                },
+              },
               "ref": self.b = b;,
             },
           ],
         },
       ],
-      "id": 18,
+      "id": 20,
       "kind": "def_contract",
       "name": "Sample",
       "origin": "user",
@@ -541,7 +547,7 @@ exports[`grammar should parse contract-with-init 1`] = `
       "traits": [],
     },
   ],
-  "id": 19,
+  "id": 21,
   "kind": "program",
 }
 `;
@@ -4003,14 +4009,12 @@ exports[`grammar should parse stmt-augmented-assign-arith 1`] = `
           "id": 10,
           "kind": "statement_augmentedassign",
           "op": "+",
-          "path": [
-            {
-              "id": 8,
-              "kind": "lvalue_ref",
-              "name": "a",
-              "ref": a,
-            },
-          ],
+          "path": {
+            "id": 8,
+            "kind": "id",
+            "ref": a,
+            "value": "a",
+          },
           "ref": a += b;,
         },
         {
@@ -4023,14 +4027,12 @@ exports[`grammar should parse stmt-augmented-assign-arith 1`] = `
           "id": 13,
           "kind": "statement_augmentedassign",
           "op": "+",
-          "path": [
-            {
-              "id": 11,
-              "kind": "lvalue_ref",
-              "name": "b",
-              "ref": b,
-            },
-          ],
+          "path": {
+            "id": 11,
+            "kind": "id",
+            "ref": b,
+            "value": "b",
+          },
           "ref": b += a;,
         },
         {
@@ -4043,14 +4045,12 @@ exports[`grammar should parse stmt-augmented-assign-arith 1`] = `
           "id": 16,
           "kind": "statement_augmentedassign",
           "op": "+",
-          "path": [
-            {
-              "id": 14,
-              "kind": "lvalue_ref",
-              "name": "a",
-              "ref": a,
-            },
-          ],
+          "path": {
+            "id": 14,
+            "kind": "id",
+            "ref": a,
+            "value": "a",
+          },
           "ref": a += 3;,
         },
         {
@@ -4075,14 +4075,12 @@ exports[`grammar should parse stmt-augmented-assign-arith 1`] = `
           "id": 21,
           "kind": "statement_augmentedassign",
           "op": "+",
-          "path": [
-            {
-              "id": 17,
-              "kind": "lvalue_ref",
-              "name": "a",
-              "ref": a,
-            },
-          ],
+          "path": {
+            "id": 17,
+            "kind": "id",
+            "ref": a,
+            "value": "a",
+          },
           "ref": a += b + 4;,
         },
         {
@@ -4095,14 +4093,12 @@ exports[`grammar should parse stmt-augmented-assign-arith 1`] = `
           "id": 24,
           "kind": "statement_augmentedassign",
           "op": "-",
-          "path": [
-            {
-              "id": 22,
-              "kind": "lvalue_ref",
-              "name": "b",
-              "ref": b,
-            },
-          ],
+          "path": {
+            "id": 22,
+            "kind": "id",
+            "ref": b,
+            "value": "b",
+          },
           "ref": b -= 1;,
         },
         {
@@ -4115,14 +4111,12 @@ exports[`grammar should parse stmt-augmented-assign-arith 1`] = `
           "id": 27,
           "kind": "statement_augmentedassign",
           "op": "-",
-          "path": [
-            {
-              "id": 25,
-              "kind": "lvalue_ref",
-              "name": "a",
-              "ref": a,
-            },
-          ],
+          "path": {
+            "id": 25,
+            "kind": "id",
+            "ref": a,
+            "value": "a",
+          },
           "ref": a -= b;,
         },
         {
@@ -4147,14 +4141,12 @@ exports[`grammar should parse stmt-augmented-assign-arith 1`] = `
           "id": 32,
           "kind": "statement_augmentedassign",
           "op": "-",
-          "path": [
-            {
-              "id": 28,
-              "kind": "lvalue_ref",
-              "name": "a",
-              "ref": a,
-            },
-          ],
+          "path": {
+            "id": 28,
+            "kind": "id",
+            "ref": a,
+            "value": "a",
+          },
           "ref": a -= b - 1;,
         },
         {
@@ -4167,14 +4159,12 @@ exports[`grammar should parse stmt-augmented-assign-arith 1`] = `
           "id": 35,
           "kind": "statement_augmentedassign",
           "op": "*",
-          "path": [
-            {
-              "id": 33,
-              "kind": "lvalue_ref",
-              "name": "b",
-              "ref": b,
-            },
-          ],
+          "path": {
+            "id": 33,
+            "kind": "id",
+            "ref": b,
+            "value": "b",
+          },
           "ref": b *= 2;,
         },
         {
@@ -4187,14 +4177,12 @@ exports[`grammar should parse stmt-augmented-assign-arith 1`] = `
           "id": 38,
           "kind": "statement_augmentedassign",
           "op": "*",
-          "path": [
-            {
-              "id": 36,
-              "kind": "lvalue_ref",
-              "name": "a",
-              "ref": a,
-            },
-          ],
+          "path": {
+            "id": 36,
+            "kind": "id",
+            "ref": a,
+            "value": "a",
+          },
           "ref": a *= b;,
         },
         {
@@ -4219,14 +4207,12 @@ exports[`grammar should parse stmt-augmented-assign-arith 1`] = `
           "id": 43,
           "kind": "statement_augmentedassign",
           "op": "*",
-          "path": [
-            {
-              "id": 39,
-              "kind": "lvalue_ref",
-              "name": "a",
-              "ref": a,
-            },
-          ],
+          "path": {
+            "id": 39,
+            "kind": "id",
+            "ref": a,
+            "value": "a",
+          },
           "ref": a *= b * 2;,
         },
         {
@@ -4239,14 +4225,12 @@ exports[`grammar should parse stmt-augmented-assign-arith 1`] = `
           "id": 46,
           "kind": "statement_augmentedassign",
           "op": "/",
-          "path": [
-            {
-              "id": 44,
-              "kind": "lvalue_ref",
-              "name": "b",
-              "ref": b,
-            },
-          ],
+          "path": {
+            "id": 44,
+            "kind": "id",
+            "ref": b,
+            "value": "b",
+          },
           "ref": b /= 2;,
         },
         {
@@ -4259,14 +4243,12 @@ exports[`grammar should parse stmt-augmented-assign-arith 1`] = `
           "id": 49,
           "kind": "statement_augmentedassign",
           "op": "/",
-          "path": [
-            {
-              "id": 47,
-              "kind": "lvalue_ref",
-              "name": "a",
-              "ref": a,
-            },
-          ],
+          "path": {
+            "id": 47,
+            "kind": "id",
+            "ref": a,
+            "value": "a",
+          },
           "ref": a /= b;,
         },
         {
@@ -4291,14 +4273,12 @@ exports[`grammar should parse stmt-augmented-assign-arith 1`] = `
           "id": 54,
           "kind": "statement_augmentedassign",
           "op": "/",
-          "path": [
-            {
-              "id": 50,
-              "kind": "lvalue_ref",
-              "name": "a",
-              "ref": a,
-            },
-          ],
+          "path": {
+            "id": 50,
+            "kind": "id",
+            "ref": a,
+            "value": "a",
+          },
           "ref": a /= b / 2;,
         },
         {
@@ -4311,14 +4291,12 @@ exports[`grammar should parse stmt-augmented-assign-arith 1`] = `
           "id": 57,
           "kind": "statement_augmentedassign",
           "op": "%",
-          "path": [
-            {
-              "id": 55,
-              "kind": "lvalue_ref",
-              "name": "a",
-              "ref": a,
-            },
-          ],
+          "path": {
+            "id": 55,
+            "kind": "id",
+            "ref": a,
+            "value": "a",
+          },
           "ref": a %= 2;,
         },
         {
@@ -4331,14 +4309,12 @@ exports[`grammar should parse stmt-augmented-assign-arith 1`] = `
           "id": 60,
           "kind": "statement_augmentedassign",
           "op": "%",
-          "path": [
-            {
-              "id": 58,
-              "kind": "lvalue_ref",
-              "name": "a",
-              "ref": a,
-            },
-          ],
+          "path": {
+            "id": 58,
+            "kind": "id",
+            "ref": a,
+            "value": "a",
+          },
           "ref": a %= b;,
         },
         {
@@ -4363,14 +4339,12 @@ exports[`grammar should parse stmt-augmented-assign-arith 1`] = `
           "id": 65,
           "kind": "statement_augmentedassign",
           "op": "%",
-          "path": [
-            {
-              "id": 61,
-              "kind": "lvalue_ref",
-              "name": "a",
-              "ref": a,
-            },
-          ],
+          "path": {
+            "id": 61,
+            "kind": "id",
+            "ref": a,
+            "value": "a",
+          },
           "ref": a %= b % 2;,
         },
         {
@@ -4475,14 +4449,12 @@ exports[`grammar should parse stmt-augmented-assign-bitwise 1`] = `
           "id": 10,
           "kind": "statement_augmentedassign",
           "op": "|",
-          "path": [
-            {
-              "id": 8,
-              "kind": "lvalue_ref",
-              "name": "a",
-              "ref": a,
-            },
-          ],
+          "path": {
+            "id": 8,
+            "kind": "id",
+            "ref": a,
+            "value": "a",
+          },
           "ref": a |= b;,
         },
         {
@@ -4495,14 +4467,12 @@ exports[`grammar should parse stmt-augmented-assign-bitwise 1`] = `
           "id": 13,
           "kind": "statement_augmentedassign",
           "op": "|",
-          "path": [
-            {
-              "id": 11,
-              "kind": "lvalue_ref",
-              "name": "b",
-              "ref": b,
-            },
-          ],
+          "path": {
+            "id": 11,
+            "kind": "id",
+            "ref": b,
+            "value": "b",
+          },
           "ref": b |= a;,
         },
         {
@@ -4515,14 +4485,12 @@ exports[`grammar should parse stmt-augmented-assign-bitwise 1`] = `
           "id": 16,
           "kind": "statement_augmentedassign",
           "op": "|",
-          "path": [
-            {
-              "id": 14,
-              "kind": "lvalue_ref",
-              "name": "a",
-              "ref": a,
-            },
-          ],
+          "path": {
+            "id": 14,
+            "kind": "id",
+            "ref": a,
+            "value": "a",
+          },
           "ref": a |= 3;,
         },
         {
@@ -4547,14 +4515,12 @@ exports[`grammar should parse stmt-augmented-assign-bitwise 1`] = `
           "id": 21,
           "kind": "statement_augmentedassign",
           "op": "|",
-          "path": [
-            {
-              "id": 17,
-              "kind": "lvalue_ref",
-              "name": "a",
-              "ref": a,
-            },
-          ],
+          "path": {
+            "id": 17,
+            "kind": "id",
+            "ref": a,
+            "value": "a",
+          },
           "ref": a |= b | 4;,
         },
         {
@@ -4567,14 +4533,12 @@ exports[`grammar should parse stmt-augmented-assign-bitwise 1`] = `
           "id": 24,
           "kind": "statement_augmentedassign",
           "op": "&",
-          "path": [
-            {
-              "id": 22,
-              "kind": "lvalue_ref",
-              "name": "b",
-              "ref": b,
-            },
-          ],
+          "path": {
+            "id": 22,
+            "kind": "id",
+            "ref": b,
+            "value": "b",
+          },
           "ref": b &= 1;,
         },
         {
@@ -4587,14 +4551,12 @@ exports[`grammar should parse stmt-augmented-assign-bitwise 1`] = `
           "id": 27,
           "kind": "statement_augmentedassign",
           "op": "&",
-          "path": [
-            {
-              "id": 25,
-              "kind": "lvalue_ref",
-              "name": "a",
-              "ref": a,
-            },
-          ],
+          "path": {
+            "id": 25,
+            "kind": "id",
+            "ref": a,
+            "value": "a",
+          },
           "ref": a &= b;,
         },
         {
@@ -4607,14 +4569,12 @@ exports[`grammar should parse stmt-augmented-assign-bitwise 1`] = `
           "id": 30,
           "kind": "statement_augmentedassign",
           "op": "&",
-          "path": [
-            {
-              "id": 28,
-              "kind": "lvalue_ref",
-              "name": "b",
-              "ref": b,
-            },
-          ],
+          "path": {
+            "id": 28,
+            "kind": "id",
+            "ref": b,
+            "value": "b",
+          },
           "ref": b &= a;,
         },
         {
@@ -4639,14 +4599,12 @@ exports[`grammar should parse stmt-augmented-assign-bitwise 1`] = `
           "id": 35,
           "kind": "statement_augmentedassign",
           "op": "&",
-          "path": [
-            {
-              "id": 31,
-              "kind": "lvalue_ref",
-              "name": "a",
-              "ref": a,
-            },
-          ],
+          "path": {
+            "id": 31,
+            "kind": "id",
+            "ref": a,
+            "value": "a",
+          },
           "ref": a &= b & 1;,
         },
         {
@@ -4659,14 +4617,12 @@ exports[`grammar should parse stmt-augmented-assign-bitwise 1`] = `
           "id": 38,
           "kind": "statement_augmentedassign",
           "op": "^",
-          "path": [
-            {
-              "id": 36,
-              "kind": "lvalue_ref",
-              "name": "b",
-              "ref": b,
-            },
-          ],
+          "path": {
+            "id": 36,
+            "kind": "id",
+            "ref": b,
+            "value": "b",
+          },
           "ref": b ^= 2;,
         },
         {
@@ -4679,14 +4635,12 @@ exports[`grammar should parse stmt-augmented-assign-bitwise 1`] = `
           "id": 41,
           "kind": "statement_augmentedassign",
           "op": "^",
-          "path": [
-            {
-              "id": 39,
-              "kind": "lvalue_ref",
-              "name": "a",
-              "ref": a,
-            },
-          ],
+          "path": {
+            "id": 39,
+            "kind": "id",
+            "ref": a,
+            "value": "a",
+          },
           "ref": a ^= b;,
         },
         {
@@ -4699,14 +4653,12 @@ exports[`grammar should parse stmt-augmented-assign-bitwise 1`] = `
           "id": 44,
           "kind": "statement_augmentedassign",
           "op": "^",
-          "path": [
-            {
-              "id": 42,
-              "kind": "lvalue_ref",
-              "name": "b",
-              "ref": b,
-            },
-          ],
+          "path": {
+            "id": 42,
+            "kind": "id",
+            "ref": b,
+            "value": "b",
+          },
           "ref": b ^= a;,
         },
         {
@@ -4731,14 +4683,12 @@ exports[`grammar should parse stmt-augmented-assign-bitwise 1`] = `
           "id": 49,
           "kind": "statement_augmentedassign",
           "op": "^",
-          "path": [
-            {
-              "id": 45,
-              "kind": "lvalue_ref",
-              "name": "a",
-              "ref": a,
-            },
-          ],
+          "path": {
+            "id": 45,
+            "kind": "id",
+            "ref": a,
+            "value": "a",
+          },
           "ref": a ^= b ^ 2;,
         },
         {
@@ -5049,14 +4999,12 @@ exports[`grammar should parse stmt-optional-semicolon-for-last-statement 1`] = `
               "id": 13,
               "kind": "statement_augmentedassign",
               "op": "+",
-              "path": [
-                {
-                  "id": 11,
-                  "kind": "lvalue_ref",
-                  "name": "i",
-                  "ref": i,
-                },
-              ],
+              "path": {
+                "id": 11,
+                "kind": "id",
+                "ref": i,
+                "value": "i",
+              },
               "ref": i += 1,
             },
           ],
@@ -5304,14 +5252,12 @@ exports[`grammar should parse stmt-while-loop 1`] = `
               },
               "id": 15,
               "kind": "statement_assign",
-              "path": [
-                {
-                  "id": 11,
-                  "kind": "lvalue_ref",
-                  "name": "i",
-                  "ref": i,
-                },
-              ],
+              "path": {
+                "id": 11,
+                "kind": "id",
+                "ref": i,
+                "value": "i",
+              },
               "ref": i = i + 1;,
             },
           ],
@@ -5401,14 +5347,12 @@ exports[`grammar should parse stmt-while-repeat-do-loops 1`] = `
               },
               "id": 9,
               "kind": "statement_assign",
-              "path": [
-                {
-                  "id": 5,
-                  "kind": "lvalue_ref",
-                  "name": "i",
-                  "ref": i,
-                },
-              ],
+              "path": {
+                "id": 5,
+                "kind": "id",
+                "ref": i,
+                "value": "i",
+              },
               "ref": i = i + 1;,
             },
           ],
@@ -5447,14 +5391,12 @@ exports[`grammar should parse stmt-while-repeat-do-loops 1`] = `
               },
               "id": 16,
               "kind": "statement_assign",
-              "path": [
-                {
-                  "id": 12,
-                  "kind": "lvalue_ref",
-                  "name": "i",
-                  "ref": i,
-                },
-              ],
+              "path": {
+                "id": 12,
+                "kind": "id",
+                "ref": i,
+                "value": "i",
+              },
               "ref": i = i * 10;,
             },
           ],
@@ -5493,14 +5435,12 @@ exports[`grammar should parse stmt-while-repeat-do-loops 1`] = `
               },
               "id": 23,
               "kind": "statement_assign",
-              "path": [
-                {
-                  "id": 19,
-                  "kind": "lvalue_ref",
-                  "name": "i",
-                  "ref": i,
-                },
-              ],
+              "path": {
+                "id": 19,
+                "kind": "id",
+                "ref": i,
+                "value": "i",
+              },
               "ref": i = i - 1;,
             },
           ],

--- a/src/grammar/clone.ts
+++ b/src/grammar/clone.ts
@@ -11,18 +11,16 @@ export function cloneNode<T extends ASTNode>(src: T): T {
         return cloneASTNode(src);
     } else if (src.kind === "string") {
         return cloneASTNode(src);
-    } else if (src.kind === "lvalue_ref") {
-        return cloneASTNode(src);
     } else if (src.kind === "statement_assign") {
         return cloneASTNode({
             ...src,
-            path: src.path.map(cloneNode),
+            path: cloneNode(src.path),
             expression: cloneNode(src.expression),
         });
     } else if (src.kind === "statement_augmentedassign") {
         return cloneASTNode({
             ...src,
-            path: src.path.map(cloneNode),
+            path: cloneNode(src.path),
             expression: cloneNode(src.expression),
         });
     } else if (src.kind === "statement_let") {

--- a/src/grammar/grammar.ohm
+++ b/src/grammar/grammar.ohm
@@ -111,7 +111,7 @@ Tact {
 
     StatementExpression = Expression (";" | &"}")
 
-    StatementAssign = LValue ("=" | "+=" | "-=" | "*=" | "/=" | "%=" | "|=" | "&=" | "^=") Expression (";" | &"}")
+    StatementAssign = Expression ("=" | "+=" | "-=" | "*=" | "/=" | "%=" | "|=" | "&=" | "^=") Expression (";" | &"}")
 
     StatementCondition = if Expression "{" Statement* "}" ~else --noElse
                        | if Expression "{" Statement* "}" else "{" Statement* "}" --withElse
@@ -129,10 +129,7 @@ Tact {
     StatementTry = try "{" Statement* "}" ~catch --noCatch
                  | try "{" Statement* "}" catch "(" id ")" "{" Statement* "}" --withCatch
 
-    StatementForEach = foreach "(" id "," id "in" LValue ")" "{" Statement* "}"
-
-    LValue = id "." LValue --fieldAccess
-           | id --variable
+    StatementForEach = foreach "(" id "," id "in" Expression ")" "{" Statement* "}"
 
     Expression = ExpressionConditional
 

--- a/src/grammar/grammar.ts
+++ b/src/grammar/grammar.ts
@@ -576,7 +576,7 @@ semantics.addOperation<ASTNode>("astOfStatement", {
         if (operator.sourceString === "=") {
             return createNode({
                 kind: "statement_assign",
-                path: lvalue.astOfLValue(),
+                path: lvalue.astOfExpression(),
                 expression: expression.astOfExpression(),
                 ref: createRef(this),
             });
@@ -612,7 +612,7 @@ semantics.addOperation<ASTNode>("astOfStatement", {
             }
             return createNode({
                 kind: "statement_augmentedassign",
-                path: lvalue.astOfLValue(),
+                path: lvalue.astOfExpression(),
                 op,
                 expression: expression.astOfExpression(),
                 ref: createRef(this),
@@ -764,33 +764,10 @@ semantics.addOperation<ASTNode>("astOfStatement", {
             kind: "statement_foreach",
             keyName: keyId.sourceString,
             valueName: valueId.sourceString,
-            map: mapId.astOfLValue(),
+            map: mapId.astOfExpression(),
             statements: foreachBlock.children.map((s) => s.astOfStatement()),
             ref: createRef(this),
         });
-    },
-});
-
-// LValue
-semantics.addOperation<ASTNode[]>("astOfLValue", {
-    LValue_variable(id) {
-        return [
-            createNode({
-                kind: "lvalue_ref",
-                name: id.sourceString,
-                ref: createRef(this),
-            }),
-        ];
-    },
-    LValue_fieldAccess(id, dot, lvalue) {
-        return [
-            createNode({
-                kind: "lvalue_ref",
-                name: id.sourceString,
-                ref: createRef(id, dot),
-            }),
-            ...lvalue.astOfLValue(),
-        ];
     },
 });
 
@@ -1097,7 +1074,7 @@ semantics.addOperation<ASTNode>("astOfExpression", {
         return createNode({
             kind: "op_field",
             src: source.astOfExpression(),
-            name: fieldId.sourceString,
+            name: fieldId.astOfExpression(),
             ref: createRef(this),
         });
     },

--- a/src/grammar/iterators.ts
+++ b/src/grammar/iterators.ts
@@ -46,7 +46,6 @@ export function forEachExpression(
             case "boolean":
             case "id":
             case "null":
-            case "lvalue_ref":
                 // Primitives and non-composite expressions don't require further traversal
                 break;
             default:
@@ -155,7 +154,6 @@ export function forEachExpression(
             case "boolean":
             case "id":
             case "null":
-            case "lvalue_ref":
                 traverseExpression(node);
                 break;
             case "new_parameter":
@@ -232,7 +230,6 @@ export function foldExpressions<T>(
             case "boolean":
             case "id":
             case "null":
-            case "lvalue_ref":
                 // Primitives and non-composite expressions don't require further traversal
                 break;
             default:
@@ -244,9 +241,12 @@ export function foldExpressions<T>(
     function traverseStatement(acc: T, stmt: ASTStatement): T {
         switch (stmt.kind) {
             case "statement_let":
+            case "statement_expression":
+                acc = traverseExpression(acc, stmt.expression);
+                break;
             case "statement_assign":
             case "statement_augmentedassign":
-            case "statement_expression":
+                acc = traverseExpression(acc, stmt.path);
                 acc = traverseExpression(acc, stmt.expression);
                 break;
             case "statement_return":
@@ -278,7 +278,6 @@ export function foldExpressions<T>(
                 });
                 break;
             case "statement_try":
-            case "statement_foreach":
                 stmt.statements.forEach((st) => {
                     acc = traverseStatement(acc, st);
                 });
@@ -288,6 +287,12 @@ export function foldExpressions<T>(
                     acc = traverseStatement(acc, st);
                 });
                 stmt.catchStatements.forEach((st) => {
+                    acc = traverseStatement(acc, st);
+                });
+                break;
+            case "statement_foreach":
+                acc = traverseExpression(acc, stmt.map);
+                stmt.statements.forEach((st) => {
                     acc = traverseStatement(acc, st);
                 });
                 break;
@@ -364,7 +369,6 @@ export function foldExpressions<T>(
             case "boolean":
             case "id":
             case "null":
-            case "lvalue_ref":
                 acc = traverseExpression(acc, node);
                 break;
             case "new_parameter":
@@ -468,7 +472,6 @@ export function forEachStatement(
             case "boolean":
             case "id":
             case "null":
-            case "lvalue_ref":
             case "new_parameter":
             case "def_argument":
             case "type_ref_simple":
@@ -595,7 +598,6 @@ export function foldStatements<T>(
             case "boolean":
             case "id":
             case "null":
-            case "lvalue_ref":
             case "new_parameter":
             case "def_argument":
             case "type_ref_simple":

--- a/src/types/__snapshots__/resolveDescriptors.spec.ts.snap
+++ b/src/types/__snapshots__/resolveDescriptors.spec.ts.snap
@@ -954,7 +954,7 @@ exports[`resolveDescriptors should resolve descriptors for contract-bounced-too-
           "statements": [],
         },
         {
-          "id": 21,
+          "id": 22,
           "kind": "def_receive",
           "ref": bounced(src: bounced<A>) {
     let x: Int = src.c;
@@ -977,9 +977,14 @@ exports[`resolveDescriptors should resolve descriptors for contract-bounced-too-
           "statements": [
             {
               "expression": {
-                "id": 19,
+                "id": 20,
                 "kind": "op_field",
-                "name": "c",
+                "name": {
+                  "id": 19,
+                  "kind": "id",
+                  "ref": c,
+                  "value": "c",
+                },
                 "ref": src.c,
                 "src": {
                   "id": 18,
@@ -988,7 +993,7 @@ exports[`resolveDescriptors should resolve descriptors for contract-bounced-too-
                   "value": "src",
                 },
               },
-              "id": 20,
+              "id": 21,
               "kind": "statement_let",
               "name": "x",
               "ref": let x: Int = src.c;,
@@ -1003,7 +1008,7 @@ exports[`resolveDescriptors should resolve descriptors for contract-bounced-too-
           ],
         },
       ],
-      "id": 22,
+      "id": 23,
       "kind": "def_contract",
       "name": "Test",
       "origin": "user",
@@ -1073,7 +1078,7 @@ exports[`resolveDescriptors should resolve descriptors for contract-bounced-too-
       },
       {
         "ast": {
-          "id": 21,
+          "id": 22,
           "kind": "def_receive",
           "ref": bounced(src: bounced<A>) {
     let x: Int = src.c;
@@ -1096,9 +1101,14 @@ exports[`resolveDescriptors should resolve descriptors for contract-bounced-too-
           "statements": [
             {
               "expression": {
-                "id": 19,
+                "id": 20,
                 "kind": "op_field",
-                "name": "c",
+                "name": {
+                  "id": 19,
+                  "kind": "id",
+                  "ref": c,
+                  "value": "c",
+                },
                 "ref": src.c,
                 "src": {
                   "id": 18,
@@ -1107,7 +1117,7 @@ exports[`resolveDescriptors should resolve descriptors for contract-bounced-too-
                   "value": "src",
                 },
               },
-              "id": 20,
+              "id": 21,
               "kind": "statement_let",
               "name": "x",
               "ref": let x: Int = src.c;,
@@ -2279,7 +2289,7 @@ exports[`resolveDescriptors should resolve descriptors for item-funs-with-errors
               },
             },
           ],
-          "id": 15,
+          "id": 16,
           "kind": "def_init_function",
           "ref": init(a: Int) {
         self.a = a;
@@ -2287,27 +2297,30 @@ exports[`resolveDescriptors should resolve descriptors for item-funs-with-errors
           "statements": [
             {
               "expression": {
-                "id": 13,
+                "id": 14,
                 "kind": "id",
                 "ref": a,
                 "value": "a",
               },
-              "id": 14,
+              "id": 15,
               "kind": "statement_assign",
-              "path": [
-                {
-                  "id": 11,
-                  "kind": "lvalue_ref",
-                  "name": "self",
-                  "ref": self.,
-                },
-                {
+              "path": {
+                "id": 13,
+                "kind": "op_field",
+                "name": {
                   "id": 12,
-                  "kind": "lvalue_ref",
-                  "name": "a",
+                  "kind": "id",
                   "ref": a,
+                  "value": "a",
                 },
-              ],
+                "ref": self.a,
+                "src": {
+                  "id": 11,
+                  "kind": "id",
+                  "ref": self,
+                  "value": "self",
+                },
+              },
               "ref": self.a = a;,
             },
           ],
@@ -2320,7 +2333,7 @@ exports[`resolveDescriptors should resolve descriptors for item-funs-with-errors
               "type": "get",
             },
           ],
-          "id": 19,
+          "id": 20,
           "kind": "def_function",
           "name": "hello",
           "origin": "user",
@@ -2328,7 +2341,7 @@ exports[`resolveDescriptors should resolve descriptors for item-funs-with-errors
         return 0;
     },
           "return": {
-            "id": 16,
+            "id": 17,
             "kind": "type_ref_simple",
             "name": "Int",
             "optional": false,
@@ -2337,12 +2350,12 @@ exports[`resolveDescriptors should resolve descriptors for item-funs-with-errors
           "statements": [
             {
               "expression": {
-                "id": 17,
+                "id": 18,
                 "kind": "number",
                 "ref": 0,
                 "value": 0n,
               },
-              "id": 18,
+              "id": 19,
               "kind": "statement_return",
               "ref": return 0;,
             },
@@ -2356,7 +2369,7 @@ exports[`resolveDescriptors should resolve descriptors for item-funs-with-errors
               "type": "get",
             },
           ],
-          "id": 23,
+          "id": 24,
           "kind": "def_function",
           "name": "hello2",
           "origin": "user",
@@ -2364,7 +2377,7 @@ exports[`resolveDescriptors should resolve descriptors for item-funs-with-errors
         return 0;
     },
           "return": {
-            "id": 20,
+            "id": 21,
             "kind": "type_ref_simple",
             "name": "Point",
             "optional": false,
@@ -2373,19 +2386,19 @@ exports[`resolveDescriptors should resolve descriptors for item-funs-with-errors
           "statements": [
             {
               "expression": {
-                "id": 21,
+                "id": 22,
                 "kind": "number",
                 "ref": 0,
                 "value": 0n,
               },
-              "id": 22,
+              "id": 23,
               "kind": "statement_return",
               "ref": return 0;,
             },
           ],
         },
       ],
-      "id": 24,
+      "id": 25,
       "kind": "def_contract",
       "name": "Main",
       "origin": "user",
@@ -2455,7 +2468,7 @@ exports[`resolveDescriptors should resolve descriptors for item-funs-with-errors
               "type": "get",
             },
           ],
-          "id": 19,
+          "id": 20,
           "kind": "def_function",
           "name": "hello",
           "origin": "user",
@@ -2463,7 +2476,7 @@ exports[`resolveDescriptors should resolve descriptors for item-funs-with-errors
         return 0;
     },
           "return": {
-            "id": 16,
+            "id": 17,
             "kind": "type_ref_simple",
             "name": "Int",
             "optional": false,
@@ -2472,12 +2485,12 @@ exports[`resolveDescriptors should resolve descriptors for item-funs-with-errors
           "statements": [
             {
               "expression": {
-                "id": 17,
+                "id": 18,
                 "kind": "number",
                 "ref": 0,
                 "value": 0n,
               },
-              "id": 18,
+              "id": 19,
               "kind": "statement_return",
               "ref": return 0;,
             },
@@ -2508,7 +2521,7 @@ exports[`resolveDescriptors should resolve descriptors for item-funs-with-errors
               "type": "get",
             },
           ],
-          "id": 23,
+          "id": 24,
           "kind": "def_function",
           "name": "hello2",
           "origin": "user",
@@ -2516,7 +2529,7 @@ exports[`resolveDescriptors should resolve descriptors for item-funs-with-errors
         return 0;
     },
           "return": {
-            "id": 20,
+            "id": 21,
             "kind": "type_ref_simple",
             "name": "Point",
             "optional": false,
@@ -2525,12 +2538,12 @@ exports[`resolveDescriptors should resolve descriptors for item-funs-with-errors
           "statements": [
             {
               "expression": {
-                "id": 21,
+                "id": 22,
                 "kind": "number",
                 "ref": 0,
                 "value": 0n,
               },
-              "id": 22,
+              "id": 23,
               "kind": "statement_return",
               "ref": return 0;,
             },
@@ -2582,7 +2595,7 @@ exports[`resolveDescriptors should resolve descriptors for item-funs-with-errors
             },
           },
         ],
-        "id": 15,
+        "id": 16,
         "kind": "def_init_function",
         "ref": init(a: Int) {
         self.a = a;
@@ -2590,27 +2603,30 @@ exports[`resolveDescriptors should resolve descriptors for item-funs-with-errors
         "statements": [
           {
             "expression": {
-              "id": 13,
+              "id": 14,
               "kind": "id",
               "ref": a,
               "value": "a",
             },
-            "id": 14,
+            "id": 15,
             "kind": "statement_assign",
-            "path": [
-              {
-                "id": 11,
-                "kind": "lvalue_ref",
-                "name": "self",
-                "ref": self.,
-              },
-              {
+            "path": {
+              "id": 13,
+              "kind": "op_field",
+              "name": {
                 "id": 12,
-                "kind": "lvalue_ref",
-                "name": "a",
+                "kind": "id",
                 "ref": a,
+                "value": "a",
               },
-            ],
+              "ref": self.a,
+              "src": {
+                "id": 11,
+                "kind": "id",
+                "ref": self,
+                "value": "self",
+              },
+            },
             "ref": self.a = a;,
           },
         ],
@@ -3294,7 +3310,7 @@ exports[`resolveDescriptors should resolve descriptors for map-value-as-coins 1`
               "type": "get",
             },
           ],
-          "id": 29,
+          "id": 31,
           "kind": "def_function",
           "name": "test",
           "origin": "user",
@@ -3369,26 +3385,31 @@ exports[`resolveDescriptors should resolve descriptors for map-value-as-coins 1`
               "expression": {
                 "args": [
                   {
-                    "id": 16,
+                    "id": 17,
                     "kind": "number",
                     "ref": 1,
                     "value": 1n,
                   },
                   {
-                    "id": 17,
+                    "id": 18,
                     "kind": "number",
                     "ref": 2,
                     "value": 2n,
                   },
                 ],
-                "id": 18,
+                "id": 19,
                 "kind": "op_call",
                 "name": "set",
                 "ref": self.m.set(1, 2),
                 "src": {
-                  "id": 15,
+                  "id": 16,
                   "kind": "op_field",
-                  "name": "m",
+                  "name": {
+                    "id": 15,
+                    "kind": "id",
+                    "ref": m,
+                    "value": "m",
+                  },
                   "ref": self.m,
                   "src": {
                     "id": 14,
@@ -3398,29 +3419,29 @@ exports[`resolveDescriptors should resolve descriptors for map-value-as-coins 1`
                   },
                 },
               },
-              "id": 19,
+              "id": 20,
               "kind": "statement_expression",
               "ref": self.m.set(1, 2);,
             },
             {
               "expression": {
-                "id": 27,
+                "id": 29,
                 "kind": "op_binary",
                 "left": {
                   "args": [
                     {
-                      "id": 21,
+                      "id": 22,
                       "kind": "number",
                       "ref": 1,
                       "value": 1n,
                     },
                   ],
-                  "id": 22,
+                  "id": 23,
                   "kind": "op_call",
                   "name": "get",
                   "ref": m.get(1),
                   "src": {
-                    "id": 20,
+                    "id": 21,
                     "kind": "id",
                     "ref": m,
                     "value": "m",
@@ -3431,23 +3452,28 @@ exports[`resolveDescriptors should resolve descriptors for map-value-as-coins 1`
                 "right": {
                   "args": [
                     {
-                      "id": 25,
+                      "id": 27,
                       "kind": "number",
                       "ref": 1,
                       "value": 1n,
                     },
                   ],
-                  "id": 26,
+                  "id": 28,
                   "kind": "op_call",
                   "name": "get",
                   "ref": self.m.get(1),
                   "src": {
-                    "id": 24,
+                    "id": 26,
                     "kind": "op_field",
-                    "name": "m",
+                    "name": {
+                      "id": 25,
+                      "kind": "id",
+                      "ref": m,
+                      "value": "m",
+                    },
                     "ref": self.m,
                     "src": {
-                      "id": 23,
+                      "id": 24,
                       "kind": "id",
                       "ref": self,
                       "value": "self",
@@ -3455,14 +3481,14 @@ exports[`resolveDescriptors should resolve descriptors for map-value-as-coins 1`
                   },
                 },
               },
-              "id": 28,
+              "id": 30,
               "kind": "statement_return",
               "ref": return m.get(1) + self.m.get(1);,
             },
           ],
         },
       ],
-      "id": 30,
+      "id": 32,
       "kind": "def_contract",
       "name": "Main",
       "origin": "user",
@@ -3534,7 +3560,7 @@ exports[`resolveDescriptors should resolve descriptors for map-value-as-coins 1`
               "type": "get",
             },
           ],
-          "id": 29,
+          "id": 31,
           "kind": "def_function",
           "name": "test",
           "origin": "user",
@@ -3609,26 +3635,31 @@ exports[`resolveDescriptors should resolve descriptors for map-value-as-coins 1`
               "expression": {
                 "args": [
                   {
-                    "id": 16,
+                    "id": 17,
                     "kind": "number",
                     "ref": 1,
                     "value": 1n,
                   },
                   {
-                    "id": 17,
+                    "id": 18,
                     "kind": "number",
                     "ref": 2,
                     "value": 2n,
                   },
                 ],
-                "id": 18,
+                "id": 19,
                 "kind": "op_call",
                 "name": "set",
                 "ref": self.m.set(1, 2),
                 "src": {
-                  "id": 15,
+                  "id": 16,
                   "kind": "op_field",
-                  "name": "m",
+                  "name": {
+                    "id": 15,
+                    "kind": "id",
+                    "ref": m,
+                    "value": "m",
+                  },
                   "ref": self.m,
                   "src": {
                     "id": 14,
@@ -3638,29 +3669,29 @@ exports[`resolveDescriptors should resolve descriptors for map-value-as-coins 1`
                   },
                 },
               },
-              "id": 19,
+              "id": 20,
               "kind": "statement_expression",
               "ref": self.m.set(1, 2);,
             },
             {
               "expression": {
-                "id": 27,
+                "id": 29,
                 "kind": "op_binary",
                 "left": {
                   "args": [
                     {
-                      "id": 21,
+                      "id": 22,
                       "kind": "number",
                       "ref": 1,
                       "value": 1n,
                     },
                   ],
-                  "id": 22,
+                  "id": 23,
                   "kind": "op_call",
                   "name": "get",
                   "ref": m.get(1),
                   "src": {
-                    "id": 20,
+                    "id": 21,
                     "kind": "id",
                     "ref": m,
                     "value": "m",
@@ -3671,23 +3702,28 @@ exports[`resolveDescriptors should resolve descriptors for map-value-as-coins 1`
                 "right": {
                   "args": [
                     {
-                      "id": 25,
+                      "id": 27,
                       "kind": "number",
                       "ref": 1,
                       "value": 1n,
                     },
                   ],
-                  "id": 26,
+                  "id": 28,
                   "kind": "op_call",
                   "name": "get",
                   "ref": self.m.get(1),
                   "src": {
-                    "id": 24,
+                    "id": 26,
                     "kind": "op_field",
-                    "name": "m",
+                    "name": {
+                      "id": 25,
+                      "kind": "id",
+                      "ref": m,
+                      "value": "m",
+                    },
                     "ref": self.m,
                     "src": {
-                      "id": 23,
+                      "id": 24,
                       "kind": "id",
                       "ref": self,
                       "value": "self",
@@ -3695,7 +3731,7 @@ exports[`resolveDescriptors should resolve descriptors for map-value-as-coins 1`
                   },
                 },
               },
-              "id": 28,
+              "id": 30,
               "kind": "statement_return",
               "ref": return m.get(1) + self.m.get(1);,
             },
@@ -3722,7 +3758,7 @@ exports[`resolveDescriptors should resolve descriptors for map-value-as-coins 1`
       "args": [],
       "ast": {
         "args": [],
-        "id": 32,
+        "id": 34,
         "kind": "def_init_function",
         "ref": contract Main {
     m: map<Int, Int as coins>;

--- a/src/types/__snapshots__/resolveStatements.spec.ts.snap
+++ b/src/types/__snapshots__/resolveStatements.spec.ts.snap
@@ -1,11 +1,11 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`resolveStatements should fail statements for bounced-type-is-smaller 1`] = `
-"<unknown>:23:18: Type bounced<"A"> does not have a field named "c"
-Line 23, col 18:
+"<unknown>:23:22: Type bounced<"A"> does not have a field named "c"
+Line 23, col 22:
   22 |     let y: Bool = src.b;
 > 23 |     let z: Int = src.c;
-                        ^~~~~
+                            ^
   24 |   }
 "
 `;
@@ -281,31 +281,31 @@ Line 15, col 9:
 `;
 
 exports[`resolveStatements should fail statements for init-vars-analysis-used-uninit-storage-struct1 1`] = `
-"<unknown>:17:22: Field "value2" is not initialized
-Line 17, col 22:
+"<unknown>:17:27: Field "value2" is not initialized
+Line 17, col 27:
   16 |     init(arg: Bool) {
 > 17 |         self.value = self.value2.a + 1;
-                            ^~~~~~~~~~~
+                                 ^~~~~~
   18 |         self.value2 = A{ a: 1, b: 2 };
 "
 `;
 
 exports[`resolveStatements should fail statements for init-vars-analysis-used-uninit-storage-struct2 1`] = `
-"<unknown>:17:35: Field "value" is not initialized
-Line 17, col 35:
+"<unknown>:17:40: Field "value" is not initialized
+Line 17, col 40:
   16 |     init(arg: Bool) {
 > 17 |         self.value2 = A{ a: 1, b: self.value };
-                                         ^~~~~~~~~~
+                                              ^~~~~
   18 |         self.value = self.value2.a + 1;
 "
 `;
 
 exports[`resolveStatements should fail statements for init-vars-analysis-used-uninit-storage-var 1`] = `
-"<unknown>:12:22: Field "value2" is not initialized
-Line 12, col 22:
+"<unknown>:12:27: Field "value2" is not initialized
+Line 12, col 27:
   11 |     init(arg: Bool) {
 > 12 |         self.value = self.value2 + 1;
-                            ^~~~~~~~~~~
+                                 ^~~~~~
   13 |         self.value2 = 10;
 "
 `;
@@ -497,6 +497,26 @@ Line 9, col 5:
 >  9 |     do {
            ^~~~
   10 |         x = x + 1;
+"
+`;
+
+exports[`resolveStatements should fail statements for stmt-foreach-non-map 1`] = `
+"<unknown>:8:22: foreach can only be used on maps, but "x" has type "Int"
+Line 8, col 22:
+  7 | fun foo(x: Int) {
+> 8 |     foreach (k, v in x) {
+                           ^
+  9 |         throw(1042);
+"
+`;
+
+exports[`resolveStatements should fail statements for stmt-foreach-non-path-map 1`] = `
+"<unknown>:12:22: foreach is only allowed over maps that are path expressions, i.e. identifiers, or sequences of direct contract/struct/message accesses, like "self.foo" or "self.structure.field"
+Line 12, col 22:
+  11 | fun foo(x: Int) {
+> 12 |     foreach (k, v in mapFun()) {
+                            ^~~~~~~~
+  13 |         throw(1042);
 "
 `;
 
@@ -1192,11 +1212,11 @@ exports[`resolveStatements should resolve statements for init-vars-analysis-with
     "Bool",
   ],
   [
-    "self.",
+    "self",
     "Contract",
   ],
   [
-    "value",
+    "self.value",
     "Int",
   ],
   [
@@ -1212,11 +1232,11 @@ exports[`resolveStatements should resolve statements for init-vars-analysis-with
     "Bool",
   ],
   [
-    "self.",
+    "self",
     "Contract",
   ],
   [
-    "value",
+    "self.value",
     "Int",
   ],
   [
@@ -1224,11 +1244,11 @@ exports[`resolveStatements should resolve statements for init-vars-analysis-with
     "Int",
   ],
   [
-    "self.",
+    "self",
     "Contract",
   ],
   [
-    "value",
+    "self.value",
     "Int",
   ],
   [
@@ -1236,11 +1256,11 @@ exports[`resolveStatements should resolve statements for init-vars-analysis-with
     "Int",
   ],
   [
-    "self.",
+    "self",
     "Contract2",
   ],
   [
-    "value",
+    "self.value",
     "Int",
   ],
   [
@@ -1248,11 +1268,11 @@ exports[`resolveStatements should resolve statements for init-vars-analysis-with
     "Int",
   ],
   [
-    "self.",
+    "self",
     "Contract2",
   ],
   [
-    "value2",
+    "self.value2",
     "S",
   ],
   [
@@ -1272,11 +1292,11 @@ exports[`resolveStatements should resolve statements for init-vars-analysis-with
     "S",
   ],
   [
-    "self.",
+    "self",
     "Contract3",
   ],
   [
-    "value",
+    "self.value",
     "Int",
   ],
   [
@@ -1292,11 +1312,11 @@ exports[`resolveStatements should resolve statements for init-vars-analysis-with
     "<void>",
   ],
   [
-    "self.",
+    "self",
     "Contract3",
   ],
   [
-    "value",
+    "self.value",
     "Int",
   ],
   [

--- a/src/types/stmts-failed/stmt-foreach-non-map.tact
+++ b/src/types/stmts-failed/stmt-foreach-non-map.tact
@@ -1,0 +1,12 @@
+primitive Int;
+
+trait BaseTrait {
+    
+}
+
+fun foo(x: Int) {
+    foreach (k, v in x) {
+        throw(1042);
+    }
+    return;
+}

--- a/src/types/stmts-failed/stmt-foreach-non-path-map.tact
+++ b/src/types/stmts-failed/stmt-foreach-non-path-map.tact
@@ -1,0 +1,16 @@
+primitive Int;
+
+trait BaseTrait {
+    
+}
+
+fun mapFun(): map<Int, Int> {
+    return emptyMap();
+}
+
+fun foo(x: Int) {
+    foreach (k, v in mapFun()) {
+        throw(1042);
+    }
+    return;
+}


### PR DESCRIPTION
This simplifies the grammar and typechecking and makes error messages more user-friendly

Closes #440 (also partially addresses #377, namely field accesses)

<!--
IMPORTANT:
If your PR doesn't close a particular issue, please, create the issue first and describe the whole context: what you're adding/changing and why you're doing so. And only then open the Pull Request, which would close that issue!

In case you are adding a new language feature, a standard library function or introducing other user-facing changes, you need to document them via a new PR to tact-docs.
-->

- [x] I have updated CHANGELOG.md
- [x] I have documented my contribution in Tact Docs: https://github.com/tact-lang/tact-docs/pull/279
- [x] I have added tests to demonstrate the contribution is correctly implemented: this usually includes both positive and negative tests, showing the happy path(s) and featuring intentionally broken cases
- [x] I have run all the tests locally and no test failure was reported
- [x] I have run the linter, formatter and spellchecker
- [x] I did not do unrelated and/or undiscussed refactorings
