### PR TITLE
fix: parsing of non-decimal message opcodes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Name clashes with FunC keywords in struct constructor function parameters: PR [#467](https://github.com/tact-lang/tact/issues/467)
 - Error messages for traversing non-path-expressions in `foreach`-loops : PR [#479](https://github.com/tact-lang/tact/pull/479)
 - Shadowing of trait constants by contract storage variables: PR [#480](https://github.com/tact-lang/tact/pull/480)
+- Parsing of non-decimal message opcodes: PR [#481](https://github.com/tact-lang/tact/pull/481)
 
 ## [1.4.0] - 2024-06-21
 

--- a/cspell.json
+++ b/cspell.json
@@ -42,6 +42,8 @@
     "Korshakov",
     "nocheck",
     "noexcept",
+    "Nonterminal",
+    "nonterminal",
     "Neovim",
     "Offchain",
     "Parens",

--- a/src/test/codegen/all-contracts.tact
+++ b/src/test/codegen/all-contracts.tact
@@ -2,3 +2,4 @@ import "./empty-message.tact";
 import "./large-contract.tact";
 import "./struct-field-storage-annotation.tact";
 import "./struct-field-func-keywords-name-clash";
+import "./message-opcode-parsing.tact";

--- a/src/test/codegen/message-opcode-parsing.tact
+++ b/src/test/codegen/message-opcode-parsing.tact
@@ -1,0 +1,11 @@
+message(0b101010) Binary {}
+message(0o53) Octal {}
+message(44) Decimal {}
+message(0x2D) Hexadecimal {}
+
+contract Example {
+    receive(msg: Binary) { }
+    receive(msg: Octal) { }
+    receive(msg: Decimal) { }
+    receive(msg: Hexadecimal) { }
+}


### PR DESCRIPTION
Closes #473

<!--
IMPORTANT:
If your PR doesn't close a particular issue, please, create the issue first and describe the whole context: what you're adding/changing and why you're doing so. And only then open the Pull Request, which would close that issue!

In case you are adding a new language feature, a standard library function or introducing other user-facing changes, you need to document them via a new PR to tact-docs.
-->

- [x] I have updated CHANGELOG.md
- ~[ ] I have documented my contribution in Tact Docs: https://github.com/tact-lang/tact-docs/pulls/PR_NUMBER~
- [x] I have added tests to demonstrate the contribution is correctly implemented: this usually includes both positive and negative tests, showing the happy path(s) and featuring intentionally broken cases
- [x] I have run all the tests locally and no test failure was reported
- [x] I have run the linter, formatter and spellchecker
- [x] I did not do unrelated and/or undiscussed refactorings
