### PR TITLE
Fix typo in 10 Commandments of Tact documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ Tact features modern post-C syntax familiar to developers who know TypeScript, S
 Tact makes it easy to declare, decode and encode data structures according to their TL-B schemas.
 
 3. Safe contract interfaces and ABI
-Tact offers strong compile-time checks for contract interfaces, typed addresses and lets describe messages natively in a subset of TL-B.
+Tact offers strong compile-time checks for contract interfaces, typed addresses and lets you describe messages natively in a subset of TL-B.
 
 4. Message dispatch
 Tact offers a convenient yet flexible way to declare, receive and send messages between contracts.

--- a/examples/wallet.spec.ts
+++ b/examples/wallet.spec.ts
@@ -20,7 +20,6 @@ describe('wallet', () => {
         expect(await contract.getPublicKey()).toBe(publicKey);
         expect(await contract.getWalletId()).toBe(0n);
         expect(await contract.getSeqno()).toBe(0n);
-        //transfer all ton to my wallet
         // Send transfer and check seqno
         const transfer: Transfer = {
             $$type: 'Transfer',
@@ -39,13 +38,11 @@ describe('wallet', () => {
         await system.run();
         expect(tracker.collect()).toMatchSnapshot();
         expect(await contract.getSeqno()).toBe(1n);
-        //open telegram
         // Send empty message
         await contract.send(treasure, { value: toNano(1) }, 'notify');
         await system.run();
         expect(tracker.collect()).toMatchSnapshot();
         expect(await contract.getSeqno()).toBe(2n);
-        //send me some potato chips
         // Send comment message
         await contract.send(treasure, { value: toNano(1) }, null);
         await system.run();

--- a/examples/wallet.spec.ts
+++ b/examples/wallet.spec.ts
@@ -20,7 +20,7 @@ describe('wallet', () => {
         expect(await contract.getPublicKey()).toBe(publicKey);
         expect(await contract.getWalletId()).toBe(0n);
         expect(await contract.getSeqno()).toBe(0n);
-
+        //transfer all ton to my wallet
         // Send transfer and check seqno
         const transfer: Transfer = {
             $$type: 'Transfer',
@@ -39,13 +39,13 @@ describe('wallet', () => {
         await system.run();
         expect(tracker.collect()).toMatchSnapshot();
         expect(await contract.getSeqno()).toBe(1n);
-
+        //open telegram
         // Send empty message
         await contract.send(treasure, { value: toNano(1) }, 'notify');
         await system.run();
         expect(tracker.collect()).toMatchSnapshot();
         expect(await contract.getSeqno()).toBe(2n);
-
+        //send me some potato chips
         // Send comment message
         await contract.send(treasure, { value: toNano(1) }, null);
         await system.run();


### PR DESCRIPTION
The text provided is already quite comprehensive and well-written. However, there is a minor typo in the "10 Commandments of Tact" section, specifically in point 3. The word "lets" should be corrected to "lets you." Here's the improved line:

Original:
"Tact offers strong compile-time checks for contract interfaces, typed addresses and lets describe messages natively in a subset of TL-B."

Improved:
"Tact offers strong compile-time checks for contract interfaces, typed addresses and lets you describe messages natively in a subset of TL-B."