### PR TITLE
fix: detection of non-unique message opcodes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Shadowing of trait constants by contract storage variables: PR [#480](https://github.com/tact-lang/tact/pull/480)
 - Parsing of non-decimal message opcodes: PR [#481](https://github.com/tact-lang/tact/pull/481)
 - Detection of multiple receivers of the same message: PR [#491](https://github.com/tact-lang/tact/pull/491)
+- Detection of non-unique message opcodes: PR [#493](https://github.com/tact-lang/tact/pull/493)
 
 ## [1.4.0] - 2024-06-21
 

--- a/src/generator/writers/writeRouter.ts
+++ b/src/generator/writers/writeRouter.ts
@@ -8,6 +8,15 @@ import { resolveFuncType } from "./resolveFuncType";
 import { resolveFuncTypeUnpack } from "./resolveFuncTypeUnpack";
 import { writeStatement } from "./writeFunction";
 
+export function commentPseudoOpcode(comment: string): string {
+    return beginCell()
+        .storeUint(0, 32)
+        .storeBuffer(Buffer.from(comment, "utf8"))
+        .endCell()
+        .hash()
+        .toString("hex", 0, 64);
+}
+
 export function writeRouter(
     type: TypeDescription,
     kind: "internal" | "external",
@@ -197,14 +206,7 @@ export function writeRouter(
                             selector.kind ===
                             (internal ? "internal-comment" : "external-comment")
                         ) {
-                            const hash = beginCell()
-                                .storeUint(0, 32)
-                                .storeBuffer(
-                                    Buffer.from(selector.comment, "utf8"),
-                                )
-                                .endCell()
-                                .hash()
-                                .toString("hex", 0, 64);
+                            const hash = commentPseudoOpcode(selector.comment);
                             ctx.append();
                             ctx.append(
                                 `;; Receive "${selector.comment}" message`,
@@ -351,12 +353,7 @@ export function writeReceiver(
         selector.kind === "internal-comment" ||
         selector.kind === "external-comment"
     ) {
-        const hash = beginCell()
-            .storeUint(0, 32)
-            .storeBuffer(Buffer.from(selector.comment, "utf8"))
-            .endCell()
-            .hash()
-            .toString("hex", 0, 64);
+        const hash = commentPseudoOpcode(selector.comment);
         ctx.append(
             `(${selfType}, ()) ${ops.receiveText(self.name, selector.kind === "internal-comment" ? "internal" : "external", hash)}(${selfType + " " + id("self")}) impure inline {`,
         );

--- a/src/test/compilation-failed/contract-duplicate-opcodes.spec.ts
+++ b/src/test/compilation-failed/contract-duplicate-opcodes.spec.ts
@@ -2,7 +2,7 @@ import { __DANGER_resetNodeId } from "../../grammar/ast";
 import { consoleLogger } from "../../logger";
 import { itShouldNotCompile } from "./util";
 
-describe("stdlib-bugs", () => {
+describe("contract-duplicate-opcodes", () => {
     beforeAll(() => {
         jest.spyOn(consoleLogger, "error").mockImplementation(() => {});
         jest.spyOn(consoleLogger, "log").mockImplementation(() => {});

--- a/src/test/compilation-failed/contract-duplicate-opcodes.spec.ts
+++ b/src/test/compilation-failed/contract-duplicate-opcodes.spec.ts
@@ -1,0 +1,38 @@
+import { __DANGER_resetNodeId } from "../../grammar/ast";
+import { consoleLogger } from "../../logger";
+import { itShouldNotCompile } from "./util";
+
+describe("stdlib-bugs", () => {
+    beforeAll(() => {
+        jest.spyOn(consoleLogger, "error").mockImplementation(() => {});
+        jest.spyOn(consoleLogger, "log").mockImplementation(() => {});
+    });
+
+    beforeEach(() => {
+        __DANGER_resetNodeId();
+    });
+
+    afterAll(() => {
+        jest.restoreAllMocks();
+    });
+
+    afterEach(() => {
+        jest.clearAllMocks();
+    });
+
+    itShouldNotCompile({
+        testName: "contract-duplicate-bounced-opcode",
+        errorMessage:
+            'Receive functions of a contract or trait cannot process messages with the same opcode: opcodes of message types "Msg2" and "Msg1" are equal',
+    });
+    itShouldNotCompile({
+        testName: "contract-duplicate-external-opcode",
+        errorMessage:
+            'Receive functions of a contract or trait cannot process messages with the same opcode: opcodes of message types "Msg2" and "Msg1" are equal',
+    });
+    itShouldNotCompile({
+        testName: "contract-duplicate-receiver-opcode",
+        errorMessage:
+            'Receive functions of a contract or trait cannot process messages with the same opcode: opcodes of message types "Msg2" and "Msg1" are equal',
+    });
+});

--- a/src/test/compilation-failed/contracts/contract-duplicate-bounced-opcode.tact
+++ b/src/test/compilation-failed/contracts/contract-duplicate-bounced-opcode.tact
@@ -1,0 +1,8 @@
+message(1) Msg1 {}
+message(1) Msg2 {}
+
+contract Test {
+    bounced(msg: Msg1) { }
+    bounced(msg: Msg2) { }
+}
+

--- a/src/test/compilation-failed/contracts/contract-duplicate-external-opcode.tact
+++ b/src/test/compilation-failed/contracts/contract-duplicate-external-opcode.tact
@@ -1,0 +1,8 @@
+message(1) Msg1 {}
+message(1) Msg2 {}
+
+contract Test {
+    external(msg: Msg1) { }
+    external(msg: Msg2) { }
+}
+

--- a/src/test/compilation-failed/contracts/contract-duplicate-receiver-opcode.tact
+++ b/src/test/compilation-failed/contracts/contract-duplicate-receiver-opcode.tact
@@ -1,0 +1,8 @@
+message(1) Msg1 {}
+message(1) Msg2 {}
+
+contract Test {
+    receive(msg: Msg1) { }
+    receive(msg: Msg2) { }
+}
+

--- a/src/test/compilation-failed/tact.config.json
+++ b/src/test/compilation-failed/tact.config.json
@@ -115,6 +115,22 @@
       "name": "stdlib-skipBits",
       "path": "./contracts/stdlib-skipBits.tact",
       "output": "./contracts/output"
+    },
+    {
+      "name": "contract-duplicate-bounced-opcode",
+      "path": "./contracts/contract-duplicate-bounced-opcode.tact",
+      "output": "./contracts/output"
+    },
+    {
+      "name": "contract-duplicate-external-opcode",
+      "path": "./contracts/contract-duplicate-external-opcode.tact",
+      "output": "./contracts/output",
+      "options": { "external": true }
+    },
+    {
+      "name": "contract-duplicate-receiver-opcode",
+      "path": "./contracts/contract-duplicate-receiver-opcode.tact",
+      "output": "./contracts/output"
     }
   ]
 }

--- a/src/types/resolveSignatures.ts
+++ b/src/types/resolveSignatures.ts
@@ -4,6 +4,14 @@ import { CompilerContext } from "../context";
 import { idToHex } from "../utils/idToHex";
 import { newMessageId } from "../utils/newMessageId";
 import { getAllTypes, getType } from "./resolveDescriptors";
+import {
+    BinaryReceiverSelector,
+    CommentReceiverSelector,
+    ReceiverDescription,
+} from "./types";
+import { throwCompilationError } from "../errors";
+import { ASTReceive } from "../grammar/ast";
+import { commentPseudoOpcode } from "../generator/writers/writeRouter";
 
 export function resolveSignatures(ctx: CompilerContext) {
     const types = getAllTypes(ctx);
@@ -171,5 +179,122 @@ export function resolveSignatures(ctx: CompilerContext) {
         }
     }
 
+    checkMessageOpcodesUnique(ctx);
+
     return ctx;
+}
+
+type messageType = string;
+type binOpcode = number;
+
+function checkBinaryMessageReceiver(
+    rcv: BinaryReceiverSelector,
+    rcvAst: ASTReceive,
+    usedOpcodes: Map<binOpcode, messageType>,
+    ctx: CompilerContext,
+) {
+    const msgType = getType(ctx, rcv.type);
+    const opcode = msgType.header!;
+    if (usedOpcodes.has(opcode)) {
+        throwCompilationError(
+            `Receive functions of a contract or trait cannot process messages with the same opcode: opcodes of message types "${rcv.type}" and "${usedOpcodes.get(opcode)}" are equal`,
+            rcvAst.ref,
+        );
+    } else {
+        usedOpcodes.set(opcode, rcv.type);
+    }
+}
+
+type commentOpcode = string;
+
+// "opcode" clashes are highly unlikely in this case, of course
+function checkCommentMessageReceiver(
+    rcv: CommentReceiverSelector,
+    rcvAst: ASTReceive,
+    usedOpcodes: Map<commentOpcode, messageType>,
+) {
+    const opcode = commentPseudoOpcode(rcv.comment);
+    if (usedOpcodes.has(opcode)) {
+        throwCompilationError(
+            `Receive functions of a contract or trait cannot process comments with the same hashes: hashes of comment strings "${rcv.comment}" and "${usedOpcodes.get(opcode)}" are equal`,
+            rcvAst.ref,
+        );
+    } else {
+        usedOpcodes.set(opcode, rcv.comment);
+    }
+}
+
+function checkMessageOpcodesUniqueInContractOrTrait(
+    receivers: ReceiverDescription[],
+    ctx: CompilerContext,
+) {
+    const binBouncedRcvUsedOpcodes = new Map<binOpcode, messageType>();
+    const binExternalRcvUsedOpcodes = new Map<binOpcode, messageType>();
+    const binInternalRcvUsedOpcodes = new Map<binOpcode, messageType>();
+
+    const commentExternalRcvUsedOpcodes = new Map<commentOpcode, messageType>();
+    const commentInternalRcvUsedOpcodes = new Map<commentOpcode, messageType>();
+
+    for (const rcv of receivers) {
+        switch (rcv.selector.kind) {
+            case "internal-binary":
+                checkBinaryMessageReceiver(
+                    rcv.selector,
+                    rcv.ast,
+                    binInternalRcvUsedOpcodes,
+                    ctx,
+                );
+                break;
+            case "bounce-binary":
+                checkBinaryMessageReceiver(
+                    rcv.selector,
+                    rcv.ast,
+                    binBouncedRcvUsedOpcodes,
+                    ctx,
+                );
+                break;
+            case "external-binary":
+                checkBinaryMessageReceiver(
+                    rcv.selector,
+                    rcv.ast,
+                    binExternalRcvUsedOpcodes,
+                    ctx,
+                );
+                break;
+            case "internal-comment":
+                checkCommentMessageReceiver(
+                    rcv.selector,
+                    rcv.ast,
+                    commentInternalRcvUsedOpcodes,
+                );
+                break;
+            case "external-comment":
+                checkCommentMessageReceiver(
+                    rcv.selector,
+                    rcv.ast,
+                    commentExternalRcvUsedOpcodes,
+                );
+                break;
+            default:
+                break;
+        }
+    }
+}
+
+function checkMessageOpcodesUnique(ctx: CompilerContext) {
+    const allTypes = getAllTypes(ctx);
+    for (const aggregateId in allTypes) {
+        const aggregate = allTypes[aggregateId];
+        switch (aggregate.kind) {
+            case "contract":
+            case "trait":
+                checkMessageOpcodesUniqueInContractOrTrait(
+                    aggregate.receivers,
+                    ctx,
+                );
+                break;
+            default:
+                break;
+        }
+    }
 }

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -134,19 +134,43 @@ export type StatementDescription =
           kind: "intrinsic";
       };
 
-export type ReceiverSelector =
+export type BinaryReceiverSelector =
     | {
           kind: "internal-binary";
           type: string;
           name: string;
       }
     | {
-          kind: "internal-empty";
+          kind: "bounce-binary";
+          name: string;
+          type: string;
+          bounced: boolean;
       }
+    | {
+          kind: "external-binary";
+          type: string;
+          name: string;
+      };
+
+export type CommentReceiverSelector =
     | {
           kind: "internal-comment";
           comment: string;
       }
+    | {
+          kind: "external-comment";
+          comment: string;
+      };
+
+export type EmptyReceiverSelector =
+    | {
+          kind: "internal-empty";
+      }
+    | {
+          kind: "external-empty";
+      };
+
+export type FallbackReceiverSelector =
     | {
           kind: "internal-comment-fallback";
           name: string;
@@ -160,24 +184,6 @@ export type ReceiverSelector =
           name: string;
       }
     | {
-          kind: "bounce-binary";
-          name: string;
-          type: string;
-          bounced: boolean;
-      }
-    | {
-          kind: "external-binary";
-          type: string;
-          name: string;
-      }
-    | {
-          kind: "external-empty";
-      }
-    | {
-          kind: "external-comment";
-          comment: string;
-      }
-    | {
           kind: "external-comment-fallback";
           name: string;
       }
@@ -185,6 +191,12 @@ export type ReceiverSelector =
           kind: "external-fallback";
           name: string;
       };
+
+export type ReceiverSelector =
+    | BinaryReceiverSelector
+    | CommentReceiverSelector
+    | EmptyReceiverSelector
+    | FallbackReceiverSelector;
 
 export type ReceiverDescription = {
     selector: ReceiverSelector;


### PR DESCRIPTION
Closes #482

<!--
IMPORTANT:
If your PR doesn't close a particular issue, please, create the issue first and describe the whole context: what you're adding/changing and why you're doing so. And only then open the Pull Request, which would close that issue!

In case you are adding a new language feature, a standard library function or introducing other user-facing changes, you need to document them via a new PR to tact-docs.
-->

- [x] I have updated CHANGELOG.md
- ~[ ] I have documented my contribution in Tact Docs: https://github.com/tact-lang/tact-docs/pulls/PR_NUMBER~
- [x] I have added tests to demonstrate the contribution is correctly implemented: this usually includes both positive and negative tests, showing the happy path(s) and featuring intentionally broken cases
- [x] I have run all the tests locally and no test failure was reported
- [x] I have run the linter, formatter and spellchecker
- [x] I did not do unrelated and/or undiscussed refactorings
