### PR TITLE
fix(cli): tweaks for single file compilation mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Removed the `LValue` grammatical category and replaced it with `Expression`: PR [#479](https://github.com/tact-lang/tact/pull/479)
+- Compilation results are placed into the source file directory when compiling without `tact.config.json` file: PR [#495](https://github.com/tact-lang/tact/pull/495)
+- External receivers are enabled for single file compilation: PR [#495](https://github.com/tact-lang/tact/pull/495)
 
 ### Fixed
 

--- a/bin/test/success.config.json
+++ b/bin/test/success.config.json
@@ -5,6 +5,7 @@
       "name": "success",
       "path": "./success.tact",
       "output": "./success_output",
+      "options": { "external": true },
       "mode": "full"
     }
   ]

--- a/bin/test/success.config.with.decompilation.json
+++ b/bin/test/success.config.with.decompilation.json
@@ -5,6 +5,7 @@
       "name": "success",
       "path": "./success.tact",
       "output": "./success_output",
+      "options": { "external": true },
       "mode": "fullWithDecompilation"
     }
   ]

--- a/bin/test/success.tact
+++ b/bin/test/success.tact
@@ -3,5 +3,5 @@ contract HelloWorld {
     get fun greeting(): String {
         return "hello world";
     }
-
+    external("foobar") {}
 }

--- a/src/node.ts
+++ b/src/node.ts
@@ -22,8 +22,8 @@ async function configForSingleFile(
             {
                 name: path.basename(fileName, ".tact"),
                 path: fileName,
-                output: process.cwd(),
-                options: { debug: true },
+                output: path.dirname(fileName),
+                options: { debug: true, external: true },
                 mode: "full",
             },
         ],


### PR DESCRIPTION
Make output directory to be the directory of the source file. Enable external receivers.

Closes #484.
Closes #457 

<!--
IMPORTANT:
If your PR doesn't close a particular issue, please, create the issue first and describe the whole context: what you're adding/changing and why you're doing so. And only then open the Pull Request, which would close that issue!

In case you are adding a new language feature, a standard library function or introducing other user-facing changes, you need to document them via a new PR to tact-docs.
-->

- [x] I have updated CHANGELOG.md
- ~[ ] I have documented my contribution in Tact Docs: https://github.com/tact-lang/tact-docs/pull/PR-NUMBER~
- [x] I have added tests to demonstrate the contribution is correctly implemented: this usually includes both positive and negative tests, showing the happy path(s) and featuring intentionally broken cases
- [x] I have run all the tests locally and no test failure was reported
- [x] I have run the linter, formatter and spellchecker
- [x] I did not do unrelated and/or undiscussed refactorings
