### PR TITLE
fix: disallow non-unique immediately inherited traits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Detection of multiple receivers of the same message: PR [#491](https://github.com/tact-lang/tact/pull/491)
 - Detection of non-unique message opcodes: PR [#493](https://github.com/tact-lang/tact/pull/493)
 - Error messages for non-abstract constants in traits: PR [#483](https://github.com/tact-lang/tact/pull/483)
+- All immediately inherited traits must be unique: PR [#500](https://github.com/tact-lang/tact/pull/500)
 
 ## [1.4.0] - 2024-06-21
 

--- a/src/types/__snapshots__/resolveDescriptors.spec.ts.snap
+++ b/src/types/__snapshots__/resolveDescriptors.spec.ts.snap
@@ -110,6 +110,16 @@ Line 11, col 3:
 "
 `;
 
+exports[`resolveDescriptors should fail descriptors for contract-duplicates-in-trait-list 1`] = `
+"<unknown>:7:1: The list of inherited traits for contract "Test" has duplicates
+Line 7, col 1:
+  6 | 
+> 7 | contract Test with Foo, Foo { }
+      ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  8 | 
+"
+`;
+
 exports[`resolveDescriptors should fail descriptors for contract-missing-type 1`] = `
 "<unknown>:12:23: Type Point not found
 Line 12, col 23:
@@ -322,6 +332,16 @@ Line 12, col 1:
 > 12 | struct Main {
        ^~~~~~~~~~~~~
   13 |     
+"
+`;
+
+exports[`resolveDescriptors should fail descriptors for trait-duplicates-in-trait-list 1`] = `
+"<unknown>:7:1: The list of inherited traits for trait "Test" has duplicates
+Line 7, col 1:
+  6 | 
+> 7 | trait Test with Foo, Foo { }
+      ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  8 | 
 "
 `;
 

--- a/src/types/resolveDescriptors.ts
+++ b/src/types/resolveDescriptors.ts
@@ -1212,6 +1212,18 @@ export function resolveDescriptors(ctx: CompilerContext) {
 
     for (const t of types.values()) {
         if (t.ast.kind === "def_trait" || t.ast.kind === "def_contract") {
+            // Check there are no duplicates in the _immediately_ inherited traits
+            const traitSet = new Set<string>(
+                t.ast.traits.map((trait) => trait.value),
+            );
+            if (traitSet.size !== t.ast.traits.length) {
+                const aggregateType =
+                    t.ast.kind === "def_contract" ? "contract" : "trait";
+                throwCompilationError(
+                    `The list of inherited traits for ${aggregateType} "${t.name}" has duplicates`,
+                    t.ast.ref,
+                );
+            }
             // Flatten traits
             const traits: TypeDescription[] = [];
             const visited = new Set<string>();
@@ -1355,7 +1367,7 @@ export function resolveDescriptors(ctx: CompilerContext) {
                 // Check duplicates
                 if (ex) {
                     throwCompilationError(
-                        `Function "${f.name}" already exist in "${t.name}"`,
+                        `Function "${f.name}" already exists in "${t.name}"`,
                         t.ast.ref,
                     );
                 }
@@ -1398,7 +1410,7 @@ export function resolveDescriptors(ctx: CompilerContext) {
                 // Check duplicates
                 if (ex) {
                     throwCompilationError(
-                        `Constant "${f.name}" already exist in "${t.name}"`,
+                        `Constant "${f.name}" already exists in "${t.name}"`,
                         t.ast.ref,
                     );
                 }

--- a/src/types/test-failed/contract-duplicates-in-trait-list.tact
+++ b/src/types/test-failed/contract-duplicates-in-trait-list.tact
@@ -1,0 +1,8 @@
+trait BaseTrait {}
+
+trait Foo {
+    receive("comment") { }
+}
+
+contract Test with Foo, Foo { }
+

--- a/src/types/test-failed/trait-duplicates-in-trait-list.tact
+++ b/src/types/test-failed/trait-duplicates-in-trait-list.tact
@@ -1,0 +1,8 @@
+trait BaseTrait {}
+
+trait Foo {
+    receive("comment") { }
+}
+
+trait Test with Foo, Foo { }
+


### PR DESCRIPTION
Closes #486

<!--
IMPORTANT:
If your PR doesn't close a particular issue, please, create the issue first and describe the whole context: what you're adding/changing and why you're doing so. And only then open the Pull Request, which would close that issue!

In case you are adding a new language feature, a standard library function or introducing other user-facing changes, you need to document them via a new PR to tact-docs.
-->

- [x] I have updated CHANGELOG.md
- ~[ ] I have documented my contribution in Tact Docs: https://github.com/tact-lang/tact-docs/pull/PR-NUMBER~
- [x] I have added tests to demonstrate the contribution is correctly implemented: this usually includes both positive and negative tests, showing the happy path(s) and featuring intentionally broken cases
- [x] I have run all the tests locally and no test failure was reported
- [x] I have run the linter, formatter and spellchecker
- [x] I did not do unrelated and/or undiscussed refactorings
