### PR TITLE
fix: allow overriding of abstract and virtual getters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Detection of non-unique message opcodes: PR [#493](https://github.com/tact-lang/tact/pull/493)
 - Error messages for non-abstract constants in traits: PR [#483](https://github.com/tact-lang/tact/pull/483)
 - All immediately inherited traits must be unique: PR [#500](https://github.com/tact-lang/tact/pull/500)
+- Do not throw error when overriding abstract and virtual getters: PR [#503](https://github.com/tact-lang/tact/pull/503)
 
 ## [1.4.0] - 2024-06-21
 

--- a/src/types/__snapshots__/resolveDescriptors.spec.ts.snap
+++ b/src/types/__snapshots__/resolveDescriptors.spec.ts.snap
@@ -30,6 +30,36 @@ Line 15, col 3:
 "
 `;
 
+exports[`resolveDescriptors should fail descriptors for contract-const-override-virtual-no-keyword 1`] = `
+"<unknown>:9:3: Constant "Foo" is defined as virtual in trait "T": you are probably missing "override" keyword
+Line 9, col 3:
+   8 | contract TestContract with T {
+>  9 |   const Foo: Int = 42;
+         ^~~~~~~~~~~~~~~~~~~~
+  10 | }
+"
+`;
+
+exports[`resolveDescriptors should fail descriptors for contract-does-not-override-abstract-const 1`] = `
+"<unknown>:8:1: Trait "T" requires constant "Foo"
+Line 8, col 1:
+  7 | 
+> 8 | contract TestContract with T {
+      ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  9 |   // does not override an abstract const
+"
+`;
+
+exports[`resolveDescriptors should fail descriptors for contract-does-not-override-abstract-getter 1`] = `
+"<unknown>:8:1: Trait "T" requires function "getter"
+Line 8, col 1:
+  7 | 
+> 8 | contract TestContract with T {
+      ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  9 |   // does not override an abstract getter
+"
+`;
+
 exports[`resolveDescriptors should fail descriptors for contract-duplicate-bounced-fallback 1`] = `
 "<unknown>:24:3: Fallback bounce receive function already exists
 Line 24, col 3:
@@ -117,6 +147,16 @@ Line 7, col 1:
 > 7 | contract Test with Foo, Foo { }
       ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
   8 | 
+"
+`;
+
+exports[`resolveDescriptors should fail descriptors for contract-getter-override-virtual-no-keyword 1`] = `
+"<unknown>:9:3: Function "getter" is defined as virtual in trait "T": you are probably missing "override" keyword
+Line 9, col 3:
+   8 | contract TestContract with T {
+>  9 |   get fun getter(): Int { return 43 }
+         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  10 | }
 "
 `;
 
@@ -1240,6 +1280,868 @@ exports[`resolveDescriptors should resolve descriptors for contract-bounced-too-
 
 exports[`resolveDescriptors should resolve descriptors for contract-bounced-too-small-not-detected 2`] = `{}`;
 
+exports[`resolveDescriptors should resolve descriptors for contract-const-override-abstract 1`] = `
+{
+  "BaseTrait": {
+    "ast": {
+      "attributes": [],
+      "declarations": [],
+      "id": 2,
+      "kind": "def_trait",
+      "name": "BaseTrait",
+      "origin": "user",
+      "ref": trait BaseTrait { },
+      "traits": [],
+    },
+    "constants": [],
+    "dependsOn": [],
+    "fields": [],
+    "functions": Map {},
+    "header": null,
+    "init": null,
+    "interfaces": [],
+    "kind": "trait",
+    "name": "BaseTrait",
+    "origin": "user",
+    "partialFieldCount": 0,
+    "receivers": [],
+    "signature": null,
+    "tlb": null,
+    "traits": [],
+    "uid": 1020,
+  },
+  "Int": {
+    "ast": {
+      "id": 1,
+      "kind": "primitive",
+      "name": "Int",
+      "origin": "user",
+      "ref": primitive Int;,
+    },
+    "constants": [],
+    "dependsOn": [],
+    "fields": [],
+    "functions": Map {},
+    "header": null,
+    "init": null,
+    "interfaces": [],
+    "kind": "primitive",
+    "name": "Int",
+    "origin": "user",
+    "partialFieldCount": 0,
+    "receivers": [],
+    "signature": null,
+    "tlb": null,
+    "traits": [],
+    "uid": 38154,
+  },
+  "T": {
+    "ast": {
+      "attributes": [],
+      "declarations": [
+        {
+          "attributes": [
+            {
+              "ref": abstract,
+              "type": "abstract",
+            },
+          ],
+          "id": 4,
+          "kind": "def_constant",
+          "name": "Foo",
+          "ref": abstract const Foo: Int;,
+          "type": {
+            "id": 3,
+            "kind": "type_ref_simple",
+            "name": "Int",
+            "optional": false,
+            "ref": Int,
+          },
+          "value": null,
+        },
+      ],
+      "id": 5,
+      "kind": "def_trait",
+      "name": "T",
+      "origin": "user",
+      "ref": trait T {
+  abstract const Foo: Int;
+},
+      "traits": [],
+    },
+    "constants": [
+      {
+        "ast": {
+          "attributes": [
+            {
+              "ref": abstract,
+              "type": "abstract",
+            },
+          ],
+          "id": 4,
+          "kind": "def_constant",
+          "name": "Foo",
+          "ref": abstract const Foo: Int;,
+          "type": {
+            "id": 3,
+            "kind": "type_ref_simple",
+            "name": "Int",
+            "optional": false,
+            "ref": Int,
+          },
+          "value": null,
+        },
+        "name": "Foo",
+        "ref": abstract const Foo: Int;,
+        "type": {
+          "kind": "ref",
+          "name": "Int",
+          "optional": false,
+        },
+        "value": undefined,
+      },
+    ],
+    "dependsOn": [],
+    "fields": [],
+    "functions": Map {},
+    "header": null,
+    "init": null,
+    "interfaces": [],
+    "kind": "trait",
+    "name": "T",
+    "origin": "user",
+    "partialFieldCount": 0,
+    "receivers": [],
+    "signature": null,
+    "tlb": null,
+    "traits": [
+      {
+        "ast": {
+          "attributes": [],
+          "declarations": [],
+          "id": 2,
+          "kind": "def_trait",
+          "name": "BaseTrait",
+          "origin": "user",
+          "ref": trait BaseTrait { },
+          "traits": [],
+        },
+        "constants": [],
+        "dependsOn": [],
+        "fields": [],
+        "functions": Map {},
+        "header": null,
+        "init": null,
+        "interfaces": [],
+        "kind": "trait",
+        "name": "BaseTrait",
+        "origin": "user",
+        "partialFieldCount": 0,
+        "receivers": [],
+        "signature": null,
+        "tlb": null,
+        "traits": [],
+        "uid": 1020,
+      },
+    ],
+    "uid": 6769,
+  },
+  "TestContract": {
+    "ast": {
+      "attributes": [],
+      "declarations": [
+        {
+          "attributes": [
+            {
+              "ref": override,
+              "type": "overrides",
+            },
+          ],
+          "id": 8,
+          "kind": "def_constant",
+          "name": "Foo",
+          "ref": override const Foo: Int = 42;,
+          "type": {
+            "id": 6,
+            "kind": "type_ref_simple",
+            "name": "Int",
+            "optional": false,
+            "ref": Int,
+          },
+          "value": {
+            "id": 7,
+            "kind": "number",
+            "ref": 42,
+            "value": 42n,
+          },
+        },
+      ],
+      "id": 10,
+      "kind": "def_contract",
+      "name": "TestContract",
+      "origin": "user",
+      "ref": contract TestContract with T {
+  override const Foo: Int = 42;
+},
+      "traits": [
+        {
+          "id": 9,
+          "kind": "id",
+          "ref": T,
+          "value": "T",
+        },
+      ],
+    },
+    "constants": [
+      {
+        "ast": {
+          "attributes": [
+            {
+              "ref": override,
+              "type": "overrides",
+            },
+          ],
+          "id": 8,
+          "kind": "def_constant",
+          "name": "Foo",
+          "ref": override const Foo: Int = 42;,
+          "type": {
+            "id": 6,
+            "kind": "type_ref_simple",
+            "name": "Int",
+            "optional": false,
+            "ref": Int,
+          },
+          "value": {
+            "id": 7,
+            "kind": "number",
+            "ref": 42,
+            "value": 42n,
+          },
+        },
+        "name": "Foo",
+        "ref": override const Foo: Int = 42;,
+        "type": {
+          "kind": "ref",
+          "name": "Int",
+          "optional": false,
+        },
+        "value": 42n,
+      },
+    ],
+    "dependsOn": [],
+    "fields": [],
+    "functions": Map {},
+    "header": null,
+    "init": {
+      "args": [],
+      "ast": {
+        "args": [],
+        "id": 12,
+        "kind": "def_init_function",
+        "ref": contract TestContract with T {
+  override const Foo: Int = 42;
+},
+        "statements": [],
+      },
+    },
+    "interfaces": [],
+    "kind": "contract",
+    "name": "TestContract",
+    "origin": "user",
+    "partialFieldCount": 0,
+    "receivers": [],
+    "signature": null,
+    "tlb": null,
+    "traits": [
+      {
+        "ast": {
+          "attributes": [],
+          "declarations": [],
+          "id": 2,
+          "kind": "def_trait",
+          "name": "BaseTrait",
+          "origin": "user",
+          "ref": trait BaseTrait { },
+          "traits": [],
+        },
+        "constants": [],
+        "dependsOn": [],
+        "fields": [],
+        "functions": Map {},
+        "header": null,
+        "init": null,
+        "interfaces": [],
+        "kind": "trait",
+        "name": "BaseTrait",
+        "origin": "user",
+        "partialFieldCount": 0,
+        "receivers": [],
+        "signature": null,
+        "tlb": null,
+        "traits": [],
+        "uid": 1020,
+      },
+      {
+        "ast": {
+          "attributes": [],
+          "declarations": [
+            {
+              "attributes": [
+                {
+                  "ref": abstract,
+                  "type": "abstract",
+                },
+              ],
+              "id": 4,
+              "kind": "def_constant",
+              "name": "Foo",
+              "ref": abstract const Foo: Int;,
+              "type": {
+                "id": 3,
+                "kind": "type_ref_simple",
+                "name": "Int",
+                "optional": false,
+                "ref": Int,
+              },
+              "value": null,
+            },
+          ],
+          "id": 5,
+          "kind": "def_trait",
+          "name": "T",
+          "origin": "user",
+          "ref": trait T {
+  abstract const Foo: Int;
+},
+          "traits": [],
+        },
+        "constants": [
+          {
+            "ast": {
+              "attributes": [
+                {
+                  "ref": abstract,
+                  "type": "abstract",
+                },
+              ],
+              "id": 4,
+              "kind": "def_constant",
+              "name": "Foo",
+              "ref": abstract const Foo: Int;,
+              "type": {
+                "id": 3,
+                "kind": "type_ref_simple",
+                "name": "Int",
+                "optional": false,
+                "ref": Int,
+              },
+              "value": null,
+            },
+            "name": "Foo",
+            "ref": abstract const Foo: Int;,
+            "type": {
+              "kind": "ref",
+              "name": "Int",
+              "optional": false,
+            },
+            "value": undefined,
+          },
+        ],
+        "dependsOn": [],
+        "fields": [],
+        "functions": Map {},
+        "header": null,
+        "init": null,
+        "interfaces": [],
+        "kind": "trait",
+        "name": "T",
+        "origin": "user",
+        "partialFieldCount": 0,
+        "receivers": [],
+        "signature": null,
+        "tlb": null,
+        "traits": [
+          {
+            "ast": {
+              "attributes": [],
+              "declarations": [],
+              "id": 2,
+              "kind": "def_trait",
+              "name": "BaseTrait",
+              "origin": "user",
+              "ref": trait BaseTrait { },
+              "traits": [],
+            },
+            "constants": [],
+            "dependsOn": [],
+            "fields": [],
+            "functions": Map {},
+            "header": null,
+            "init": null,
+            "interfaces": [],
+            "kind": "trait",
+            "name": "BaseTrait",
+            "origin": "user",
+            "partialFieldCount": 0,
+            "receivers": [],
+            "signature": null,
+            "tlb": null,
+            "traits": [],
+            "uid": 1020,
+          },
+        ],
+        "uid": 6769,
+      },
+    ],
+    "uid": 63070,
+  },
+}
+`;
+
+exports[`resolveDescriptors should resolve descriptors for contract-const-override-abstract 2`] = `{}`;
+
+exports[`resolveDescriptors should resolve descriptors for contract-const-override-virtual 1`] = `
+{
+  "BaseTrait": {
+    "ast": {
+      "attributes": [],
+      "declarations": [],
+      "id": 2,
+      "kind": "def_trait",
+      "name": "BaseTrait",
+      "origin": "user",
+      "ref": trait BaseTrait { },
+      "traits": [],
+    },
+    "constants": [],
+    "dependsOn": [],
+    "fields": [],
+    "functions": Map {},
+    "header": null,
+    "init": null,
+    "interfaces": [],
+    "kind": "trait",
+    "name": "BaseTrait",
+    "origin": "user",
+    "partialFieldCount": 0,
+    "receivers": [],
+    "signature": null,
+    "tlb": null,
+    "traits": [],
+    "uid": 1020,
+  },
+  "Int": {
+    "ast": {
+      "id": 1,
+      "kind": "primitive",
+      "name": "Int",
+      "origin": "user",
+      "ref": primitive Int;,
+    },
+    "constants": [],
+    "dependsOn": [],
+    "fields": [],
+    "functions": Map {},
+    "header": null,
+    "init": null,
+    "interfaces": [],
+    "kind": "primitive",
+    "name": "Int",
+    "origin": "user",
+    "partialFieldCount": 0,
+    "receivers": [],
+    "signature": null,
+    "tlb": null,
+    "traits": [],
+    "uid": 38154,
+  },
+  "T": {
+    "ast": {
+      "attributes": [],
+      "declarations": [
+        {
+          "attributes": [
+            {
+              "ref": virtual,
+              "type": "virtual",
+            },
+          ],
+          "id": 5,
+          "kind": "def_constant",
+          "name": "Foo",
+          "ref": virtual const Foo: Int = 41;,
+          "type": {
+            "id": 3,
+            "kind": "type_ref_simple",
+            "name": "Int",
+            "optional": false,
+            "ref": Int,
+          },
+          "value": {
+            "id": 4,
+            "kind": "number",
+            "ref": 41,
+            "value": 41n,
+          },
+        },
+      ],
+      "id": 6,
+      "kind": "def_trait",
+      "name": "T",
+      "origin": "user",
+      "ref": trait T {
+   virtual const Foo: Int = 41;
+},
+      "traits": [],
+    },
+    "constants": [
+      {
+        "ast": {
+          "attributes": [
+            {
+              "ref": virtual,
+              "type": "virtual",
+            },
+          ],
+          "id": 5,
+          "kind": "def_constant",
+          "name": "Foo",
+          "ref": virtual const Foo: Int = 41;,
+          "type": {
+            "id": 3,
+            "kind": "type_ref_simple",
+            "name": "Int",
+            "optional": false,
+            "ref": Int,
+          },
+          "value": {
+            "id": 4,
+            "kind": "number",
+            "ref": 41,
+            "value": 41n,
+          },
+        },
+        "name": "Foo",
+        "ref": virtual const Foo: Int = 41;,
+        "type": {
+          "kind": "ref",
+          "name": "Int",
+          "optional": false,
+        },
+        "value": 41n,
+      },
+    ],
+    "dependsOn": [],
+    "fields": [],
+    "functions": Map {},
+    "header": null,
+    "init": null,
+    "interfaces": [],
+    "kind": "trait",
+    "name": "T",
+    "origin": "user",
+    "partialFieldCount": 0,
+    "receivers": [],
+    "signature": null,
+    "tlb": null,
+    "traits": [
+      {
+        "ast": {
+          "attributes": [],
+          "declarations": [],
+          "id": 2,
+          "kind": "def_trait",
+          "name": "BaseTrait",
+          "origin": "user",
+          "ref": trait BaseTrait { },
+          "traits": [],
+        },
+        "constants": [],
+        "dependsOn": [],
+        "fields": [],
+        "functions": Map {},
+        "header": null,
+        "init": null,
+        "interfaces": [],
+        "kind": "trait",
+        "name": "BaseTrait",
+        "origin": "user",
+        "partialFieldCount": 0,
+        "receivers": [],
+        "signature": null,
+        "tlb": null,
+        "traits": [],
+        "uid": 1020,
+      },
+    ],
+    "uid": 6769,
+  },
+  "TestContract": {
+    "ast": {
+      "attributes": [],
+      "declarations": [
+        {
+          "attributes": [
+            {
+              "ref": override,
+              "type": "overrides",
+            },
+          ],
+          "id": 9,
+          "kind": "def_constant",
+          "name": "Foo",
+          "ref": override const Foo: Int = 42;,
+          "type": {
+            "id": 7,
+            "kind": "type_ref_simple",
+            "name": "Int",
+            "optional": false,
+            "ref": Int,
+          },
+          "value": {
+            "id": 8,
+            "kind": "number",
+            "ref": 42,
+            "value": 42n,
+          },
+        },
+      ],
+      "id": 11,
+      "kind": "def_contract",
+      "name": "TestContract",
+      "origin": "user",
+      "ref": contract TestContract with T {
+  override const Foo: Int = 42;
+},
+      "traits": [
+        {
+          "id": 10,
+          "kind": "id",
+          "ref": T,
+          "value": "T",
+        },
+      ],
+    },
+    "constants": [
+      {
+        "ast": {
+          "attributes": [
+            {
+              "ref": override,
+              "type": "overrides",
+            },
+          ],
+          "id": 9,
+          "kind": "def_constant",
+          "name": "Foo",
+          "ref": override const Foo: Int = 42;,
+          "type": {
+            "id": 7,
+            "kind": "type_ref_simple",
+            "name": "Int",
+            "optional": false,
+            "ref": Int,
+          },
+          "value": {
+            "id": 8,
+            "kind": "number",
+            "ref": 42,
+            "value": 42n,
+          },
+        },
+        "name": "Foo",
+        "ref": override const Foo: Int = 42;,
+        "type": {
+          "kind": "ref",
+          "name": "Int",
+          "optional": false,
+        },
+        "value": 42n,
+      },
+    ],
+    "dependsOn": [],
+    "fields": [],
+    "functions": Map {},
+    "header": null,
+    "init": {
+      "args": [],
+      "ast": {
+        "args": [],
+        "id": 13,
+        "kind": "def_init_function",
+        "ref": contract TestContract with T {
+  override const Foo: Int = 42;
+},
+        "statements": [],
+      },
+    },
+    "interfaces": [],
+    "kind": "contract",
+    "name": "TestContract",
+    "origin": "user",
+    "partialFieldCount": 0,
+    "receivers": [],
+    "signature": null,
+    "tlb": null,
+    "traits": [
+      {
+        "ast": {
+          "attributes": [],
+          "declarations": [],
+          "id": 2,
+          "kind": "def_trait",
+          "name": "BaseTrait",
+          "origin": "user",
+          "ref": trait BaseTrait { },
+          "traits": [],
+        },
+        "constants": [],
+        "dependsOn": [],
+        "fields": [],
+        "functions": Map {},
+        "header": null,
+        "init": null,
+        "interfaces": [],
+        "kind": "trait",
+        "name": "BaseTrait",
+        "origin": "user",
+        "partialFieldCount": 0,
+        "receivers": [],
+        "signature": null,
+        "tlb": null,
+        "traits": [],
+        "uid": 1020,
+      },
+      {
+        "ast": {
+          "attributes": [],
+          "declarations": [
+            {
+              "attributes": [
+                {
+                  "ref": virtual,
+                  "type": "virtual",
+                },
+              ],
+              "id": 5,
+              "kind": "def_constant",
+              "name": "Foo",
+              "ref": virtual const Foo: Int = 41;,
+              "type": {
+                "id": 3,
+                "kind": "type_ref_simple",
+                "name": "Int",
+                "optional": false,
+                "ref": Int,
+              },
+              "value": {
+                "id": 4,
+                "kind": "number",
+                "ref": 41,
+                "value": 41n,
+              },
+            },
+          ],
+          "id": 6,
+          "kind": "def_trait",
+          "name": "T",
+          "origin": "user",
+          "ref": trait T {
+   virtual const Foo: Int = 41;
+},
+          "traits": [],
+        },
+        "constants": [
+          {
+            "ast": {
+              "attributes": [
+                {
+                  "ref": virtual,
+                  "type": "virtual",
+                },
+              ],
+              "id": 5,
+              "kind": "def_constant",
+              "name": "Foo",
+              "ref": virtual const Foo: Int = 41;,
+              "type": {
+                "id": 3,
+                "kind": "type_ref_simple",
+                "name": "Int",
+                "optional": false,
+                "ref": Int,
+              },
+              "value": {
+                "id": 4,
+                "kind": "number",
+                "ref": 41,
+                "value": 41n,
+              },
+            },
+            "name": "Foo",
+            "ref": virtual const Foo: Int = 41;,
+            "type": {
+              "kind": "ref",
+              "name": "Int",
+              "optional": false,
+            },
+            "value": 41n,
+          },
+        ],
+        "dependsOn": [],
+        "fields": [],
+        "functions": Map {},
+        "header": null,
+        "init": null,
+        "interfaces": [],
+        "kind": "trait",
+        "name": "T",
+        "origin": "user",
+        "partialFieldCount": 0,
+        "receivers": [],
+        "signature": null,
+        "tlb": null,
+        "traits": [
+          {
+            "ast": {
+              "attributes": [],
+              "declarations": [],
+              "id": 2,
+              "kind": "def_trait",
+              "name": "BaseTrait",
+              "origin": "user",
+              "ref": trait BaseTrait { },
+              "traits": [],
+            },
+            "constants": [],
+            "dependsOn": [],
+            "fields": [],
+            "functions": Map {},
+            "header": null,
+            "init": null,
+            "interfaces": [],
+            "kind": "trait",
+            "name": "BaseTrait",
+            "origin": "user",
+            "partialFieldCount": 0,
+            "receivers": [],
+            "signature": null,
+            "tlb": null,
+            "traits": [],
+            "uid": 1020,
+          },
+        ],
+        "uid": 6769,
+      },
+    ],
+    "uid": 63070,
+  },
+}
+`;
+
+exports[`resolveDescriptors should resolve descriptors for contract-const-override-virtual 2`] = `{}`;
+
 exports[`resolveDescriptors should resolve descriptors for contract-external-fallback-receiver 1`] = `
 {
   "A": {
@@ -1600,6 +2502,1038 @@ exports[`resolveDescriptors should resolve descriptors for contract-external-fal
 `;
 
 exports[`resolveDescriptors should resolve descriptors for contract-external-fallback-receiver 2`] = `{}`;
+
+exports[`resolveDescriptors should resolve descriptors for contract-getter-override-abstract 1`] = `
+{
+  "BaseTrait": {
+    "ast": {
+      "attributes": [],
+      "declarations": [],
+      "id": 2,
+      "kind": "def_trait",
+      "name": "BaseTrait",
+      "origin": "user",
+      "ref": trait BaseTrait { },
+      "traits": [],
+    },
+    "constants": [],
+    "dependsOn": [],
+    "fields": [],
+    "functions": Map {},
+    "header": null,
+    "init": null,
+    "interfaces": [],
+    "kind": "trait",
+    "name": "BaseTrait",
+    "origin": "user",
+    "partialFieldCount": 0,
+    "receivers": [],
+    "signature": null,
+    "tlb": null,
+    "traits": [],
+    "uid": 1020,
+  },
+  "Int": {
+    "ast": {
+      "id": 1,
+      "kind": "primitive",
+      "name": "Int",
+      "origin": "user",
+      "ref": primitive Int;,
+    },
+    "constants": [],
+    "dependsOn": [],
+    "fields": [],
+    "functions": Map {},
+    "header": null,
+    "init": null,
+    "interfaces": [],
+    "kind": "primitive",
+    "name": "Int",
+    "origin": "user",
+    "partialFieldCount": 0,
+    "receivers": [],
+    "signature": null,
+    "tlb": null,
+    "traits": [],
+    "uid": 38154,
+  },
+  "T": {
+    "ast": {
+      "attributes": [],
+      "declarations": [
+        {
+          "args": [],
+          "attributes": [
+            {
+              "ref": abstract,
+              "type": "abstract",
+            },
+            {
+              "ref": get,
+              "type": "get",
+            },
+          ],
+          "id": 4,
+          "kind": "def_function",
+          "name": "getter",
+          "origin": "user",
+          "ref": abstract get fun getter(): Int;,
+          "return": {
+            "id": 3,
+            "kind": "type_ref_simple",
+            "name": "Int",
+            "optional": false,
+            "ref": Int,
+          },
+          "statements": null,
+        },
+      ],
+      "id": 5,
+      "kind": "def_trait",
+      "name": "T",
+      "origin": "user",
+      "ref": trait T {
+  abstract get fun getter(): Int;
+},
+      "traits": [],
+    },
+    "constants": [],
+    "dependsOn": [],
+    "fields": [],
+    "functions": Map {
+      "getter" => {
+        "args": [],
+        "ast": {
+          "args": [],
+          "attributes": [
+            {
+              "ref": abstract,
+              "type": "abstract",
+            },
+            {
+              "ref": get,
+              "type": "get",
+            },
+          ],
+          "id": 4,
+          "kind": "def_function",
+          "name": "getter",
+          "origin": "user",
+          "ref": abstract get fun getter(): Int;,
+          "return": {
+            "id": 3,
+            "kind": "type_ref_simple",
+            "name": "Int",
+            "optional": false,
+            "ref": Int,
+          },
+          "statements": null,
+        },
+        "isAbstract": true,
+        "isGetter": true,
+        "isInline": false,
+        "isMutating": true,
+        "isOverrides": false,
+        "isVirtual": false,
+        "name": "getter",
+        "origin": "user",
+        "returns": {
+          "kind": "ref",
+          "name": "Int",
+          "optional": false,
+        },
+        "self": "T",
+      },
+    },
+    "header": null,
+    "init": null,
+    "interfaces": [],
+    "kind": "trait",
+    "name": "T",
+    "origin": "user",
+    "partialFieldCount": 0,
+    "receivers": [],
+    "signature": null,
+    "tlb": null,
+    "traits": [
+      {
+        "ast": {
+          "attributes": [],
+          "declarations": [],
+          "id": 2,
+          "kind": "def_trait",
+          "name": "BaseTrait",
+          "origin": "user",
+          "ref": trait BaseTrait { },
+          "traits": [],
+        },
+        "constants": [],
+        "dependsOn": [],
+        "fields": [],
+        "functions": Map {},
+        "header": null,
+        "init": null,
+        "interfaces": [],
+        "kind": "trait",
+        "name": "BaseTrait",
+        "origin": "user",
+        "partialFieldCount": 0,
+        "receivers": [],
+        "signature": null,
+        "tlb": null,
+        "traits": [],
+        "uid": 1020,
+      },
+    ],
+    "uid": 6769,
+  },
+  "TestContract": {
+    "ast": {
+      "attributes": [],
+      "declarations": [
+        {
+          "args": [],
+          "attributes": [
+            {
+              "ref": override,
+              "type": "overrides",
+            },
+            {
+              "ref": get,
+              "type": "get",
+            },
+          ],
+          "id": 9,
+          "kind": "def_function",
+          "name": "getter",
+          "origin": "user",
+          "ref": override get fun getter(): Int { return 0 },
+          "return": {
+            "id": 6,
+            "kind": "type_ref_simple",
+            "name": "Int",
+            "optional": false,
+            "ref": Int,
+          },
+          "statements": [
+            {
+              "expression": {
+                "id": 7,
+                "kind": "number",
+                "ref": 0,
+                "value": 0n,
+              },
+              "id": 8,
+              "kind": "statement_return",
+              "ref": return 0,
+            },
+          ],
+        },
+      ],
+      "id": 11,
+      "kind": "def_contract",
+      "name": "TestContract",
+      "origin": "user",
+      "ref": contract TestContract with T {
+  override get fun getter(): Int { return 0 }
+},
+      "traits": [
+        {
+          "id": 10,
+          "kind": "id",
+          "ref": T,
+          "value": "T",
+        },
+      ],
+    },
+    "constants": [],
+    "dependsOn": [],
+    "fields": [],
+    "functions": Map {
+      "getter" => {
+        "args": [],
+        "ast": {
+          "args": [],
+          "attributes": [
+            {
+              "ref": override,
+              "type": "overrides",
+            },
+            {
+              "ref": get,
+              "type": "get",
+            },
+          ],
+          "id": 9,
+          "kind": "def_function",
+          "name": "getter",
+          "origin": "user",
+          "ref": override get fun getter(): Int { return 0 },
+          "return": {
+            "id": 6,
+            "kind": "type_ref_simple",
+            "name": "Int",
+            "optional": false,
+            "ref": Int,
+          },
+          "statements": [
+            {
+              "expression": {
+                "id": 7,
+                "kind": "number",
+                "ref": 0,
+                "value": 0n,
+              },
+              "id": 8,
+              "kind": "statement_return",
+              "ref": return 0,
+            },
+          ],
+        },
+        "isAbstract": false,
+        "isGetter": true,
+        "isInline": false,
+        "isMutating": true,
+        "isOverrides": true,
+        "isVirtual": false,
+        "name": "getter",
+        "origin": "user",
+        "returns": {
+          "kind": "ref",
+          "name": "Int",
+          "optional": false,
+        },
+        "self": "TestContract",
+      },
+    },
+    "header": null,
+    "init": {
+      "args": [],
+      "ast": {
+        "args": [],
+        "id": 13,
+        "kind": "def_init_function",
+        "ref": contract TestContract with T {
+  override get fun getter(): Int { return 0 }
+},
+        "statements": [],
+      },
+    },
+    "interfaces": [],
+    "kind": "contract",
+    "name": "TestContract",
+    "origin": "user",
+    "partialFieldCount": 0,
+    "receivers": [],
+    "signature": null,
+    "tlb": null,
+    "traits": [
+      {
+        "ast": {
+          "attributes": [],
+          "declarations": [],
+          "id": 2,
+          "kind": "def_trait",
+          "name": "BaseTrait",
+          "origin": "user",
+          "ref": trait BaseTrait { },
+          "traits": [],
+        },
+        "constants": [],
+        "dependsOn": [],
+        "fields": [],
+        "functions": Map {},
+        "header": null,
+        "init": null,
+        "interfaces": [],
+        "kind": "trait",
+        "name": "BaseTrait",
+        "origin": "user",
+        "partialFieldCount": 0,
+        "receivers": [],
+        "signature": null,
+        "tlb": null,
+        "traits": [],
+        "uid": 1020,
+      },
+      {
+        "ast": {
+          "attributes": [],
+          "declarations": [
+            {
+              "args": [],
+              "attributes": [
+                {
+                  "ref": abstract,
+                  "type": "abstract",
+                },
+                {
+                  "ref": get,
+                  "type": "get",
+                },
+              ],
+              "id": 4,
+              "kind": "def_function",
+              "name": "getter",
+              "origin": "user",
+              "ref": abstract get fun getter(): Int;,
+              "return": {
+                "id": 3,
+                "kind": "type_ref_simple",
+                "name": "Int",
+                "optional": false,
+                "ref": Int,
+              },
+              "statements": null,
+            },
+          ],
+          "id": 5,
+          "kind": "def_trait",
+          "name": "T",
+          "origin": "user",
+          "ref": trait T {
+  abstract get fun getter(): Int;
+},
+          "traits": [],
+        },
+        "constants": [],
+        "dependsOn": [],
+        "fields": [],
+        "functions": Map {
+          "getter" => {
+            "args": [],
+            "ast": {
+              "args": [],
+              "attributes": [
+                {
+                  "ref": abstract,
+                  "type": "abstract",
+                },
+                {
+                  "ref": get,
+                  "type": "get",
+                },
+              ],
+              "id": 4,
+              "kind": "def_function",
+              "name": "getter",
+              "origin": "user",
+              "ref": abstract get fun getter(): Int;,
+              "return": {
+                "id": 3,
+                "kind": "type_ref_simple",
+                "name": "Int",
+                "optional": false,
+                "ref": Int,
+              },
+              "statements": null,
+            },
+            "isAbstract": true,
+            "isGetter": true,
+            "isInline": false,
+            "isMutating": true,
+            "isOverrides": false,
+            "isVirtual": false,
+            "name": "getter",
+            "origin": "user",
+            "returns": {
+              "kind": "ref",
+              "name": "Int",
+              "optional": false,
+            },
+            "self": "T",
+          },
+        },
+        "header": null,
+        "init": null,
+        "interfaces": [],
+        "kind": "trait",
+        "name": "T",
+        "origin": "user",
+        "partialFieldCount": 0,
+        "receivers": [],
+        "signature": null,
+        "tlb": null,
+        "traits": [
+          {
+            "ast": {
+              "attributes": [],
+              "declarations": [],
+              "id": 2,
+              "kind": "def_trait",
+              "name": "BaseTrait",
+              "origin": "user",
+              "ref": trait BaseTrait { },
+              "traits": [],
+            },
+            "constants": [],
+            "dependsOn": [],
+            "fields": [],
+            "functions": Map {},
+            "header": null,
+            "init": null,
+            "interfaces": [],
+            "kind": "trait",
+            "name": "BaseTrait",
+            "origin": "user",
+            "partialFieldCount": 0,
+            "receivers": [],
+            "signature": null,
+            "tlb": null,
+            "traits": [],
+            "uid": 1020,
+          },
+        ],
+        "uid": 6769,
+      },
+    ],
+    "uid": 63070,
+  },
+}
+`;
+
+exports[`resolveDescriptors should resolve descriptors for contract-getter-override-abstract 2`] = `{}`;
+
+exports[`resolveDescriptors should resolve descriptors for contract-getter-override-virtual 1`] = `
+{
+  "BaseTrait": {
+    "ast": {
+      "attributes": [],
+      "declarations": [],
+      "id": 2,
+      "kind": "def_trait",
+      "name": "BaseTrait",
+      "origin": "user",
+      "ref": trait BaseTrait { },
+      "traits": [],
+    },
+    "constants": [],
+    "dependsOn": [],
+    "fields": [],
+    "functions": Map {},
+    "header": null,
+    "init": null,
+    "interfaces": [],
+    "kind": "trait",
+    "name": "BaseTrait",
+    "origin": "user",
+    "partialFieldCount": 0,
+    "receivers": [],
+    "signature": null,
+    "tlb": null,
+    "traits": [],
+    "uid": 1020,
+  },
+  "Int": {
+    "ast": {
+      "id": 1,
+      "kind": "primitive",
+      "name": "Int",
+      "origin": "user",
+      "ref": primitive Int;,
+    },
+    "constants": [],
+    "dependsOn": [],
+    "fields": [],
+    "functions": Map {},
+    "header": null,
+    "init": null,
+    "interfaces": [],
+    "kind": "primitive",
+    "name": "Int",
+    "origin": "user",
+    "partialFieldCount": 0,
+    "receivers": [],
+    "signature": null,
+    "tlb": null,
+    "traits": [],
+    "uid": 38154,
+  },
+  "T": {
+    "ast": {
+      "attributes": [],
+      "declarations": [
+        {
+          "args": [],
+          "attributes": [
+            {
+              "ref": virtual,
+              "type": "virtual",
+            },
+            {
+              "ref": get,
+              "type": "get",
+            },
+          ],
+          "id": 6,
+          "kind": "def_function",
+          "name": "getter",
+          "origin": "user",
+          "ref": virtual get fun getter(): Int { return 42 },
+          "return": {
+            "id": 3,
+            "kind": "type_ref_simple",
+            "name": "Int",
+            "optional": false,
+            "ref": Int,
+          },
+          "statements": [
+            {
+              "expression": {
+                "id": 4,
+                "kind": "number",
+                "ref": 42,
+                "value": 42n,
+              },
+              "id": 5,
+              "kind": "statement_return",
+              "ref": return 42,
+            },
+          ],
+        },
+      ],
+      "id": 7,
+      "kind": "def_trait",
+      "name": "T",
+      "origin": "user",
+      "ref": trait T {
+   virtual get fun getter(): Int { return 42 }
+},
+      "traits": [],
+    },
+    "constants": [],
+    "dependsOn": [],
+    "fields": [],
+    "functions": Map {
+      "getter" => {
+        "args": [],
+        "ast": {
+          "args": [],
+          "attributes": [
+            {
+              "ref": virtual,
+              "type": "virtual",
+            },
+            {
+              "ref": get,
+              "type": "get",
+            },
+          ],
+          "id": 6,
+          "kind": "def_function",
+          "name": "getter",
+          "origin": "user",
+          "ref": virtual get fun getter(): Int { return 42 },
+          "return": {
+            "id": 3,
+            "kind": "type_ref_simple",
+            "name": "Int",
+            "optional": false,
+            "ref": Int,
+          },
+          "statements": [
+            {
+              "expression": {
+                "id": 4,
+                "kind": "number",
+                "ref": 42,
+                "value": 42n,
+              },
+              "id": 5,
+              "kind": "statement_return",
+              "ref": return 42,
+            },
+          ],
+        },
+        "isAbstract": false,
+        "isGetter": true,
+        "isInline": false,
+        "isMutating": true,
+        "isOverrides": false,
+        "isVirtual": true,
+        "name": "getter",
+        "origin": "user",
+        "returns": {
+          "kind": "ref",
+          "name": "Int",
+          "optional": false,
+        },
+        "self": "T",
+      },
+    },
+    "header": null,
+    "init": null,
+    "interfaces": [],
+    "kind": "trait",
+    "name": "T",
+    "origin": "user",
+    "partialFieldCount": 0,
+    "receivers": [],
+    "signature": null,
+    "tlb": null,
+    "traits": [
+      {
+        "ast": {
+          "attributes": [],
+          "declarations": [],
+          "id": 2,
+          "kind": "def_trait",
+          "name": "BaseTrait",
+          "origin": "user",
+          "ref": trait BaseTrait { },
+          "traits": [],
+        },
+        "constants": [],
+        "dependsOn": [],
+        "fields": [],
+        "functions": Map {},
+        "header": null,
+        "init": null,
+        "interfaces": [],
+        "kind": "trait",
+        "name": "BaseTrait",
+        "origin": "user",
+        "partialFieldCount": 0,
+        "receivers": [],
+        "signature": null,
+        "tlb": null,
+        "traits": [],
+        "uid": 1020,
+      },
+    ],
+    "uid": 6769,
+  },
+  "TestContract": {
+    "ast": {
+      "attributes": [],
+      "declarations": [
+        {
+          "args": [],
+          "attributes": [
+            {
+              "ref": override,
+              "type": "overrides",
+            },
+            {
+              "ref": get,
+              "type": "get",
+            },
+          ],
+          "id": 11,
+          "kind": "def_function",
+          "name": "getter",
+          "origin": "user",
+          "ref": override get fun getter(): Int { return 43 },
+          "return": {
+            "id": 8,
+            "kind": "type_ref_simple",
+            "name": "Int",
+            "optional": false,
+            "ref": Int,
+          },
+          "statements": [
+            {
+              "expression": {
+                "id": 9,
+                "kind": "number",
+                "ref": 43,
+                "value": 43n,
+              },
+              "id": 10,
+              "kind": "statement_return",
+              "ref": return 43,
+            },
+          ],
+        },
+      ],
+      "id": 13,
+      "kind": "def_contract",
+      "name": "TestContract",
+      "origin": "user",
+      "ref": contract TestContract with T {
+  override get fun getter(): Int { return 43 }
+},
+      "traits": [
+        {
+          "id": 12,
+          "kind": "id",
+          "ref": T,
+          "value": "T",
+        },
+      ],
+    },
+    "constants": [],
+    "dependsOn": [],
+    "fields": [],
+    "functions": Map {
+      "getter" => {
+        "args": [],
+        "ast": {
+          "args": [],
+          "attributes": [
+            {
+              "ref": override,
+              "type": "overrides",
+            },
+            {
+              "ref": get,
+              "type": "get",
+            },
+          ],
+          "id": 11,
+          "kind": "def_function",
+          "name": "getter",
+          "origin": "user",
+          "ref": override get fun getter(): Int { return 43 },
+          "return": {
+            "id": 8,
+            "kind": "type_ref_simple",
+            "name": "Int",
+            "optional": false,
+            "ref": Int,
+          },
+          "statements": [
+            {
+              "expression": {
+                "id": 9,
+                "kind": "number",
+                "ref": 43,
+                "value": 43n,
+              },
+              "id": 10,
+              "kind": "statement_return",
+              "ref": return 43,
+            },
+          ],
+        },
+        "isAbstract": false,
+        "isGetter": true,
+        "isInline": false,
+        "isMutating": true,
+        "isOverrides": true,
+        "isVirtual": false,
+        "name": "getter",
+        "origin": "user",
+        "returns": {
+          "kind": "ref",
+          "name": "Int",
+          "optional": false,
+        },
+        "self": "TestContract",
+      },
+    },
+    "header": null,
+    "init": {
+      "args": [],
+      "ast": {
+        "args": [],
+        "id": 15,
+        "kind": "def_init_function",
+        "ref": contract TestContract with T {
+  override get fun getter(): Int { return 43 }
+},
+        "statements": [],
+      },
+    },
+    "interfaces": [],
+    "kind": "contract",
+    "name": "TestContract",
+    "origin": "user",
+    "partialFieldCount": 0,
+    "receivers": [],
+    "signature": null,
+    "tlb": null,
+    "traits": [
+      {
+        "ast": {
+          "attributes": [],
+          "declarations": [],
+          "id": 2,
+          "kind": "def_trait",
+          "name": "BaseTrait",
+          "origin": "user",
+          "ref": trait BaseTrait { },
+          "traits": [],
+        },
+        "constants": [],
+        "dependsOn": [],
+        "fields": [],
+        "functions": Map {},
+        "header": null,
+        "init": null,
+        "interfaces": [],
+        "kind": "trait",
+        "name": "BaseTrait",
+        "origin": "user",
+        "partialFieldCount": 0,
+        "receivers": [],
+        "signature": null,
+        "tlb": null,
+        "traits": [],
+        "uid": 1020,
+      },
+      {
+        "ast": {
+          "attributes": [],
+          "declarations": [
+            {
+              "args": [],
+              "attributes": [
+                {
+                  "ref": virtual,
+                  "type": "virtual",
+                },
+                {
+                  "ref": get,
+                  "type": "get",
+                },
+              ],
+              "id": 6,
+              "kind": "def_function",
+              "name": "getter",
+              "origin": "user",
+              "ref": virtual get fun getter(): Int { return 42 },
+              "return": {
+                "id": 3,
+                "kind": "type_ref_simple",
+                "name": "Int",
+                "optional": false,
+                "ref": Int,
+              },
+              "statements": [
+                {
+                  "expression": {
+                    "id": 4,
+                    "kind": "number",
+                    "ref": 42,
+                    "value": 42n,
+                  },
+                  "id": 5,
+                  "kind": "statement_return",
+                  "ref": return 42,
+                },
+              ],
+            },
+          ],
+          "id": 7,
+          "kind": "def_trait",
+          "name": "T",
+          "origin": "user",
+          "ref": trait T {
+   virtual get fun getter(): Int { return 42 }
+},
+          "traits": [],
+        },
+        "constants": [],
+        "dependsOn": [],
+        "fields": [],
+        "functions": Map {
+          "getter" => {
+            "args": [],
+            "ast": {
+              "args": [],
+              "attributes": [
+                {
+                  "ref": virtual,
+                  "type": "virtual",
+                },
+                {
+                  "ref": get,
+                  "type": "get",
+                },
+              ],
+              "id": 6,
+              "kind": "def_function",
+              "name": "getter",
+              "origin": "user",
+              "ref": virtual get fun getter(): Int { return 42 },
+              "return": {
+                "id": 3,
+                "kind": "type_ref_simple",
+                "name": "Int",
+                "optional": false,
+                "ref": Int,
+              },
+              "statements": [
+                {
+                  "expression": {
+                    "id": 4,
+                    "kind": "number",
+                    "ref": 42,
+                    "value": 42n,
+                  },
+                  "id": 5,
+                  "kind": "statement_return",
+                  "ref": return 42,
+                },
+              ],
+            },
+            "isAbstract": false,
+            "isGetter": true,
+            "isInline": false,
+            "isMutating": true,
+            "isOverrides": false,
+            "isVirtual": true,
+            "name": "getter",
+            "origin": "user",
+            "returns": {
+              "kind": "ref",
+              "name": "Int",
+              "optional": false,
+            },
+            "self": "T",
+          },
+        },
+        "header": null,
+        "init": null,
+        "interfaces": [],
+        "kind": "trait",
+        "name": "T",
+        "origin": "user",
+        "partialFieldCount": 0,
+        "receivers": [],
+        "signature": null,
+        "tlb": null,
+        "traits": [
+          {
+            "ast": {
+              "attributes": [],
+              "declarations": [],
+              "id": 2,
+              "kind": "def_trait",
+              "name": "BaseTrait",
+              "origin": "user",
+              "ref": trait BaseTrait { },
+              "traits": [],
+            },
+            "constants": [],
+            "dependsOn": [],
+            "fields": [],
+            "functions": Map {},
+            "header": null,
+            "init": null,
+            "interfaces": [],
+            "kind": "trait",
+            "name": "BaseTrait",
+            "origin": "user",
+            "partialFieldCount": 0,
+            "receivers": [],
+            "signature": null,
+            "tlb": null,
+            "traits": [],
+            "uid": 1020,
+          },
+        ],
+        "uid": 6769,
+      },
+    ],
+    "uid": 63070,
+  },
+}
+`;
+
+exports[`resolveDescriptors should resolve descriptors for contract-getter-override-virtual 2`] = `{}`;
 
 exports[`resolveDescriptors should resolve descriptors for init-vars-analysis-uninit-storage-vars 1`] = `
 {

--- a/src/types/resolveDescriptors.ts
+++ b/src/types/resolveDescriptors.ts
@@ -1313,51 +1313,67 @@ export function resolveDescriptors(ctx: CompilerContext) {
     // Copy Trait functions and constants
     //
 
-    function copyTraits(t: TypeDescription) {
-        for (const tr of t.traits) {
+    function copyTraits(contractOrTrait: TypeDescription) {
+        for (const inheritedTrait of contractOrTrait.traits) {
             // Copy functions
-            for (const f of tr.functions.values()) {
-                const ex = t.functions.get(f.name);
-                if (!ex && f.isAbstract) {
+            for (const traitFunction of inheritedTrait.functions.values()) {
+                const funInContractOrTrait = contractOrTrait.functions.get(
+                    traitFunction.name,
+                );
+                if (!funInContractOrTrait && traitFunction.isAbstract) {
                     throwCompilationError(
-                        `Trait "${tr.name}" requires function "${f.name}"`,
-                        t.ast.ref,
+                        `Trait "${inheritedTrait.name}" requires function "${traitFunction.name}"`,
+                        contractOrTrait.ast.ref,
                     );
                 }
 
                 // Check overrides
-                if (ex && ex.isOverrides) {
-                    if (f.isGetter) {
+                if (funInContractOrTrait && funInContractOrTrait.isOverrides) {
+                    if (
+                        traitFunction.isGetter &&
+                        !funInContractOrTrait.isGetter
+                    ) {
                         throwCompilationError(
-                            `Overridden function "${f.name}" can not be a getter`,
-                            ex.ast.ref,
+                            `Overridden function "${traitFunction.name}" must be a getter`,
+                            funInContractOrTrait.ast.ref,
                         );
                     }
-                    if (f.isMutating !== ex.isMutating) {
+                    if (
+                        traitFunction.isMutating !==
+                        funInContractOrTrait.isMutating
+                    ) {
                         throwCompilationError(
-                            `Overridden function "${f.name}" should have same mutability`,
-                            ex.ast.ref,
+                            `Overridden function "${traitFunction.name}" should have same mutability`,
+                            funInContractOrTrait.ast.ref,
                         );
                     }
-                    if (!typeRefEquals(f.returns, ex.returns)) {
+                    if (
+                        !typeRefEquals(
+                            traitFunction.returns,
+                            funInContractOrTrait.returns,
+                        )
+                    ) {
                         throwCompilationError(
-                            `Overridden function "${f.name}" should have same return type`,
-                            ex.ast.ref,
+                            `Overridden function "${traitFunction.name}" should have same return type`,
+                            funInContractOrTrait.ast.ref,
                         );
                     }
-                    if (f.args.length !== ex.args.length) {
+                    if (
+                        traitFunction.args.length !==
+                        funInContractOrTrait.args.length
+                    ) {
                         throwCompilationError(
-                            `Overridden function "${f.name}" should have same number of arguments`,
-                            ex.ast.ref,
+                            `Overridden function "${traitFunction.name}" should have same number of arguments`,
+                            funInContractOrTrait.ast.ref,
                         );
                     }
-                    for (let i = 0; i < f.args.length; i++) {
-                        const a = ex.args[i];
-                        const b = f.args[i];
+                    for (let i = 0; i < traitFunction.args.length; i++) {
+                        const a = funInContractOrTrait.args[i];
+                        const b = traitFunction.args[i];
                         if (!typeRefEquals(a.type, b.type)) {
                             throwCompilationError(
-                                `Overridden function "${f.name}" should have same argument types`,
-                                ex.ast.ref,
+                                `Overridden function "${traitFunction.name}" should have same argument types`,
+                                funInContractOrTrait.ast.ref,
                             );
                         }
                     }
@@ -1365,73 +1381,102 @@ export function resolveDescriptors(ctx: CompilerContext) {
                 }
 
                 // Check duplicates
-                if (ex) {
+                if (funInContractOrTrait) {
+                    if (traitFunction.isVirtual) {
+                        throwCompilationError(
+                            `Function "${traitFunction.name}" is defined as virtual in trait "${inheritedTrait.name}": you are probably missing "override" keyword`,
+                            funInContractOrTrait.ast.ref,
+                        );
+                    }
                     throwCompilationError(
-                        `Function "${f.name}" already exists in "${t.name}"`,
-                        t.ast.ref,
+                        `Function "${traitFunction.name}" is already defined in trait "${inheritedTrait.name}"`,
+                        funInContractOrTrait.ast.ref,
                     );
                 }
 
                 // Register function
-                t.functions.set(f.name, {
-                    ...f,
-                    self: t.name,
-                    ast: cloneNode(f.ast),
+                contractOrTrait.functions.set(traitFunction.name, {
+                    ...traitFunction,
+                    self: contractOrTrait.name,
+                    ast: cloneNode(traitFunction.ast),
                 });
             }
 
             // Copy constants
-            for (const f of tr.constants) {
-                const ex = t.constants.find((v) => v.name === f.name);
+            for (const traitConstant of inheritedTrait.constants) {
+                const constInContractOrTrait = contractOrTrait.constants.find(
+                    (v) => v.name === traitConstant.name,
+                );
                 if (
-                    !ex &&
-                    f.ast.attributes.find((v) => v.type === "abstract")
+                    !constInContractOrTrait &&
+                    traitConstant.ast.attributes.find(
+                        (v) => v.type === "abstract",
+                    )
                 ) {
                     throwCompilationError(
-                        `Trait "${tr.name}" requires constant "${f.name}"`,
-                        t.ast.ref,
+                        `Trait "${inheritedTrait.name}" requires constant "${traitConstant.name}"`,
+                        contractOrTrait.ast.ref,
                     );
                 }
 
                 // Check overrides
                 if (
-                    ex &&
-                    ex.ast.attributes.find((v) => v.type === "overrides")
+                    constInContractOrTrait &&
+                    constInContractOrTrait.ast.attributes.find(
+                        (v) => v.type === "overrides",
+                    )
                 ) {
-                    if (!typeRefEquals(f.type, ex.type)) {
+                    if (
+                        !typeRefEquals(
+                            traitConstant.type,
+                            constInContractOrTrait.type,
+                        )
+                    ) {
                         throwCompilationError(
-                            `Overridden constant "${f.name}" should have same type`,
-                            ex.ast.ref,
+                            `Overridden constant "${traitConstant.name}" should have same type`,
+                            constInContractOrTrait.ast.ref,
                         );
                     }
                     continue;
                 }
 
                 // Check duplicates
-                if (ex) {
+                if (constInContractOrTrait) {
+                    if (
+                        traitConstant.ast.attributes.find(
+                            (v) => v.type === "virtual",
+                        )
+                    ) {
+                        throwCompilationError(
+                            `Constant "${traitConstant.name}" is defined as virtual in trait "${inheritedTrait.name}": you are probably missing "override" keyword`,
+                            constInContractOrTrait.ast.ref,
+                        );
+                    }
                     throwCompilationError(
-                        `Constant "${f.name}" already exists in "${t.name}"`,
-                        t.ast.ref,
+                        `Constant "${traitConstant.name}" is already defined in trait "${inheritedTrait.name}"`,
+                        constInContractOrTrait.ast.ref,
                     );
                 }
-                const contractField = t.fields.find((v) => v.name === f.name);
+                const contractField = contractOrTrait.fields.find(
+                    (v) => v.name === traitConstant.name,
+                );
                 if (contractField) {
                     // a trait constant has the same name as a contract field
                     throwCompilationError(
-                        `Contract ${t.name} inherits constant "${f.name}" from its traits and hence cannot have a storage variable with the same name`,
+                        `Contract ${contractOrTrait.name} inherits constant "${traitConstant.name}" from its traits and hence cannot have a storage variable with the same name`,
                         contractField.ref,
                     );
                 }
 
                 // Register constant
-                t.constants.push({
-                    ...f,
-                    ast: cloneNode(f.ast),
+                contractOrTrait.constants.push({
+                    ...traitConstant,
+                    ast: cloneNode(traitConstant.ast),
                 });
             }
 
             // Copy receivers
-            for (const f of tr.receivers) {
+            for (const f of inheritedTrait.receivers) {
                 // eslint-disable-next-line no-inner-declarations
                 function sameReceiver(
                     a: ReceiverSelector,
@@ -1482,25 +1527,25 @@ export function resolveDescriptors(ctx: CompilerContext) {
                     return false;
                 }
                 if (
-                    t.receivers.find((v) =>
+                    contractOrTrait.receivers.find((v) =>
                         sameReceiver(v.selector, f.selector),
                     )
                 ) {
                     throwCompilationError(
                         `Receive function for "${f.selector}" already exists`,
-                        t.ast.ref,
+                        contractOrTrait.ast.ref,
                     );
                 }
-                t.receivers.push({
+                contractOrTrait.receivers.push({
                     selector: f.selector,
                     ast: cloneNode(f.ast),
                 });
             }
 
             // Copy interfaces
-            for (const i of tr.interfaces) {
-                if (!t.interfaces.find((v) => v === i)) {
-                    t.interfaces.push(i);
+            for (const i of inheritedTrait.interfaces) {
+                if (!contractOrTrait.interfaces.find((v) => v === i)) {
+                    contractOrTrait.interfaces.push(i);
                 }
             }
         }

--- a/src/types/test-failed/contract-const-override-virtual-no-keyword.tact
+++ b/src/types/test-failed/contract-const-override-virtual-no-keyword.tact
@@ -1,0 +1,10 @@
+primitive Int;
+trait BaseTrait { }
+
+trait T {
+  virtual const Foo: Int = 42;
+}
+
+contract TestContract with T {
+  const Foo: Int = 42;
+}

--- a/src/types/test-failed/contract-does-not-override-abstract-const.tact
+++ b/src/types/test-failed/contract-does-not-override-abstract-const.tact
@@ -1,0 +1,10 @@
+primitive Int;
+trait BaseTrait { }
+
+trait T {
+  abstract const Foo: Int;
+}
+
+contract TestContract with T {
+  // does not override an abstract const
+}

--- a/src/types/test-failed/contract-does-not-override-abstract-getter.tact
+++ b/src/types/test-failed/contract-does-not-override-abstract-getter.tact
@@ -1,0 +1,10 @@
+primitive Int;
+trait BaseTrait { }
+
+trait T {
+  abstract get fun getter(): Int;
+}
+
+contract TestContract with T {
+  // does not override an abstract getter
+}

--- a/src/types/test-failed/contract-getter-override-virtual-no-keyword.tact
+++ b/src/types/test-failed/contract-getter-override-virtual-no-keyword.tact
@@ -1,0 +1,10 @@
+primitive Int;
+trait BaseTrait { }
+
+trait T {
+   virtual get fun getter(): Int { return 42 }
+}
+
+contract TestContract with T {
+  get fun getter(): Int { return 43 }
+}

--- a/src/types/test/contract-const-override-abstract.tact
+++ b/src/types/test/contract-const-override-abstract.tact
@@ -1,0 +1,10 @@
+primitive Int;
+trait BaseTrait { }
+
+trait T {
+  abstract const Foo: Int;
+}
+
+contract TestContract with T {
+  override const Foo: Int = 42;
+}

--- a/src/types/test/contract-const-override-virtual.tact
+++ b/src/types/test/contract-const-override-virtual.tact
@@ -1,0 +1,10 @@
+primitive Int;
+trait BaseTrait { }
+
+trait T {
+   virtual const Foo: Int = 41;
+}
+
+contract TestContract with T {
+  override const Foo: Int = 42;
+}

--- a/src/types/test/contract-getter-override-abstract.tact
+++ b/src/types/test/contract-getter-override-abstract.tact
@@ -1,0 +1,10 @@
+primitive Int;
+trait BaseTrait { }
+
+trait T {
+  abstract get fun getter(): Int;
+}
+
+contract TestContract with T {
+  override get fun getter(): Int { return 0 }
+}

--- a/src/types/test/contract-getter-override-virtual.tact
+++ b/src/types/test/contract-getter-override-virtual.tact
@@ -1,0 +1,10 @@
+primitive Int;
+trait BaseTrait { }
+
+trait T {
+   virtual get fun getter(): Int { return 42 }
+}
+
+contract TestContract with T {
+  override get fun getter(): Int { return 43 }
+}


### PR DESCRIPTION
Also, fix some error messages for functions and constants inherited from traits

Closes #490

<!--
IMPORTANT:
If your PR doesn't close a particular issue, please, create the issue first and describe the whole context: what you're adding/changing and why you're doing so. And only then open the Pull Request, which would close that issue!

In case you are adding a new language feature, a standard library function or introducing other user-facing changes, you need to document them via a new PR to tact-docs.
-->

- [x] I have updated CHANGELOG.md
- ~[ ] I have documented my contribution in Tact Docs: https://github.com/tact-lang/tact-docs/pull/PR-NUMBER~
- [x] I have added tests to demonstrate the contribution is correctly implemented: this usually includes both positive and negative tests, showing the happy path(s) and featuring intentionally broken cases
- [x] I have run all the tests locally and no test failure was reported
- [x] I have run the linter, formatter and spellchecker
- [x] I did not do unrelated and/or undiscussed refactorings
