### PR TITLE
Remove [DEBUG] prefix from debugging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Removed the `LValue` grammatical category and replaced it with `Expression`: PR [#479](https://github.com/tact-lang/tact/pull/479)
 - Compilation results are placed into the source file directory when compiling without `tact.config.json` file: PR [#495](https://github.com/tact-lang/tact/pull/495)
 - External receivers are enabled for single file compilation: PR [#495](https://github.com/tact-lang/tact/pull/495)
+- `[DEBUG]` prefix was removed from debug prints because a similar prefix was already present: PR [#506](https://github.com/tact-lang/tact/pull/506)
 
 ### Fixed
 

--- a/src/abi/global.ts
+++ b/src/abi/global.ts
@@ -233,7 +233,7 @@ export const GlobalFunctions: Map<string, AbiFunction> = new Map([
                     ? path.relative(cwd(), ref.file!)
                     : "unknown";
                 const lineCol = ref.interval.getLineAndColumn();
-                const debugPrint = `[DEBUG] File ${filePath}:${lineCol.lineNum}:${lineCol.colNum}`;
+                const debugPrint = `File ${filePath}:${lineCol.lineNum}:${lineCol.colNum}`;
 
                 if (arg.kind === "map") {
                     const exp = writeExpression(resolved[0], ctx);
@@ -297,7 +297,7 @@ export const GlobalFunctions: Map<string, AbiFunction> = new Map([
                     ? path.relative(cwd(), ref.file!)
                     : "unknown";
                 const lineCol = ref.interval.getLineAndColumn();
-                const debugPrint = `[DEBUG] File ${filePath}:${lineCol.lineNum}:${lineCol.colNum}`;
+                const debugPrint = `File ${filePath}:${lineCol.lineNum}:${lineCol.colNum}`;
                 return `${ctx.used(`__tact_debug_stack`)}("${debugPrint}")`;
             },
         },

--- a/src/test/e2e-emulated/debug.spec.ts
+++ b/src/test/e2e-emulated/debug.spec.ts
@@ -35,21 +35,21 @@ describe("debug", () => {
             "src/test/e2e-emulated/contracts/debug.tact",
         );
 
-        expect(debugLogs).toStrictEqual(`[DEBUG] File ${filePath}:10:9
+        expect(debugLogs).toStrictEqual(`File ${filePath}:10:9
 stack(2 values) : 10000000000 () 
-[DEBUG] File ${filePath}:11:9
+File ${filePath}:11:9
 Hello world!
-[DEBUG] File ${filePath}:12:9
+File ${filePath}:12:9
 123
-[DEBUG] File ${filePath}:13:9
+File ${filePath}:13:9
 true
-[DEBUG] File ${filePath}:14:9
+File ${filePath}:14:9
 false
-[DEBUG] File ${filePath}:15:9
+File ${filePath}:15:9
 null
-[DEBUG] File ${filePath}:16:9
+File ${filePath}:16:9
 ${contract.address.toString({ bounceable: true })}
-[DEBUG] File ${filePath}:17:9
+File ${filePath}:17:9
 ${Address.parseRaw(
     "0:83dfd552e63729b472fcbcc8c45ebcc6691702558b68ec7527e1ba403a0f31a8",
 )}`);


### PR DESCRIPTION
Closes #505 

- [x] I have updated CHANGELOG.md
- [ ] ~~I have documented my contribution in Tact Docs: https://github.com/tact-lang/tact-docs/pull/PR-NUMBER~~
- [x] I have added tests to demonstrate the contribution is correctly implemented: this usually includes both positive and negative tests, showing the happy path(s) and featuring intentionally broken cases
- [x] I have run all the tests locally and no test failure was reported
- [x] I have run the linter, formatter and spellchecker
- [x] I did not do unrelated and/or undiscussed refactorings
