### PR TITLE
test: `initOf` for parent-child contracts

### DIFF
--- a/src/test/e2e-emulated/contracts/initof.tact
+++ b/src/test/e2e-emulated/contracts/initof.tact
@@ -1,0 +1,71 @@
+contract Self {
+
+    init() { }
+
+    receive() { }
+
+    get fun testInitOfAddress(): Address {
+        return contractAddress(initOf Self());
+    }
+
+    get fun testMyAddress(): Address {
+        return myAddress();
+    }
+}
+
+message ChildAddress {
+    address: Address;
+}
+
+contract Child {
+
+    owner: Address;
+
+    init(owner: Address) {
+        self.owner = owner;
+    }
+
+    receive() {
+        send(SendParameters {
+            to: sender(),
+            value: 0,
+            mode: SendRemainingValue | SendIgnoreErrors,
+            bounce: false, 
+            body: ChildAddress { address: myAddress() }.toCell(),
+        });
+    }
+}
+
+contract Parent {
+
+    childMyAddress: Address;
+
+    init() {
+      self.childMyAddress = myAddress();  // dummy value to be replaced by the child
+    }
+
+    receive() {
+        let ci = initOf Child(myAddress());
+        send(SendParameters {
+            to: contractAddress(ci),
+            value: 0,
+            mode: SendRemainingValue | SendIgnoreErrors,
+            bounce: false, 
+            body: beginCell().endCell(),
+            code: ci.code,
+            data: ci.data,
+        });
+    }
+
+    receive(msg: ChildAddress) {
+        self.childMyAddress = msg.address;
+    }
+
+    get fun testInitOfAddressChild(): Address {
+        return contractAddress(initOf Child(myAddress()));
+    }
+
+    get fun testMyAddressChild(): Address {
+        return self.childMyAddress;
+    }
+}

--- a/src/test/e2e-emulated/initof.spec.ts
+++ b/src/test/e2e-emulated/initof.spec.ts
@@ -1,0 +1,51 @@
+import { toNano } from "@ton/core";
+import { ContractSystem } from "@tact-lang/emulator";
+import { __DANGER_resetNodeId } from "../../grammar/ast";
+import { Self } from "./contracts/output/initof_Self";
+import { Parent } from "./contracts/output/initof_Parent";
+import { consoleLogger } from "../../logger";
+
+describe("initOf", () => {
+    beforeAll(() => {
+        jest.spyOn(consoleLogger, "error").mockImplementation(() => {});
+    });
+
+    beforeEach(() => {
+        __DANGER_resetNodeId();
+    });
+
+    afterAll(() => {
+        (consoleLogger.error as jest.Mock).mockRestore();
+    });
+
+    afterEach(() => {
+        (consoleLogger.error as jest.Mock).mockClear();
+    });
+    it("should implement initOf correctly - 1", async () => {
+        // Init
+        const system = await ContractSystem.create();
+        const treasure = system.treasure("treasure");
+        const contract = system.open(await Self.fromInit());
+        await contract.send(treasure, { value: toNano("10") }, null);
+        await system.run();
+
+        const addr1 = (await contract.getTestInitOfAddress()).toRawString();
+        const addr2 = (await contract.getTestMyAddress()).toRawString();
+        expect(addr1).toEqual(addr2);
+    });
+    it("should implement initOf correctly - 2", async () => {
+        // Init
+        const system = await ContractSystem.create();
+        const treasure = system.treasure("treasure");
+        const contract = system.open(await Parent.fromInit());
+        await contract.send(treasure, { value: toNano("10") }, null);
+        await system.run();
+        const addrChildInitOf = (
+            await contract.getTestInitOfAddressChild()
+        ).toRawString();
+        const addrChildMyAddress = (
+            await contract.getTestMyAddressChild()
+        ).toRawString();
+        expect(addrChildInitOf).toEqual(addrChildMyAddress);
+    });
+});

--- a/tact.config.json
+++ b/tact.config.json
@@ -338,6 +338,14 @@
       "name": "structs",
       "path": "./src/test/e2e-emulated/contracts/structs.tact",
       "output": "./src/test/e2e-emulated/contracts/output"
+    },
+    {
+      "name": "initof",
+      "path": "./src/test/e2e-emulated/contracts/initof.tact",
+      "output": "./src/test/e2e-emulated/contracts/output",
+      "options": {
+        "debug": true
+      }
     }
   ]
 }


### PR DESCRIPTION
Towards #516

<!--
IMPORTANT:
If your PR doesn't close a particular issue, please, create the issue first and describe the whole context: what you're adding/changing and why you're doing so. And only then open the Pull Request, which would close that issue!

In case you are adding a new language feature, a standard library function or introducing other user-facing changes, you need to document them via a new PR to tact-docs.
-->

- ~[ ] I have updated CHANGELOG.md~
- ~[ ] I have documented my contribution in Tact Docs: https://github.com/tact-lang/tact-docs/pull/PR-NUMBER~
- [x] I have added tests to demonstrate the contribution is correctly implemented: this usually includes both positive and negative tests, showing the happy path(s) and featuring intentionally broken cases
- [x] I have run all the tests locally and no test failure was reported
- [x] I have run the linter, formatter and spellchecker
- [x] I did not do unrelated and/or undiscussed refactorings
