### PR TITLE
Use POSIX paths for file paths in debug prints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Compilation results are placed into the source file directory when compiling without `tact.config.json` file: PR [#495](https://github.com/tact-lang/tact/pull/495)
 - External receivers are enabled for single file compilation: PR [#495](https://github.com/tact-lang/tact/pull/495)
 - `[DEBUG]` prefix was removed from debug prints because a similar prefix was already present: PR [#506](https://github.com/tact-lang/tact/pull/506)
+- File paths in debug prints always use POSIX file paths (even on Windows): PR [#523](https://github.com/tact-lang/tact/pull/523)
 
 ### Fixed
 

--- a/src/abi/global.ts
+++ b/src/abi/global.ts
@@ -9,6 +9,7 @@ import { AbiFunction } from "./AbiFunction";
 import { sha256_sync } from "@ton/crypto";
 import path from "path";
 import { cwd } from "process";
+import { posixNormalize } from "../utils/filePath";
 
 export const GlobalFunctions: Map<string, AbiFunction> = new Map([
     [
@@ -230,7 +231,7 @@ export const GlobalFunctions: Map<string, AbiFunction> = new Map([
                 const arg = args[0];
 
                 const filePath = ref.file
-                    ? path.relative(cwd(), ref.file!)
+                    ? posixNormalize(path.relative(cwd(), ref.file!))
                     : "unknown";
                 const lineCol = ref.interval.getLineAndColumn();
                 const debugPrint = `File ${filePath}:${lineCol.lineNum}:${lineCol.colNum}`;
@@ -294,7 +295,7 @@ export const GlobalFunctions: Map<string, AbiFunction> = new Map([
                     return `${ctx.used("__tact_nop")}()`;
                 }
                 const filePath = ref.file
-                    ? path.relative(cwd(), ref.file!)
+                    ? posixNormalize(path.relative(cwd(), ref.file!))
                     : "unknown";
                 const lineCol = ref.interval.getLineAndColumn();
                 const debugPrint = `File ${filePath}:${lineCol.lineNum}:${lineCol.colNum}`;

--- a/src/test/e2e-emulated/debug.spec.ts
+++ b/src/test/e2e-emulated/debug.spec.ts
@@ -2,7 +2,7 @@ import { Address, toNano } from "@ton/core";
 import { ContractSystem } from "@tact-lang/emulator";
 import { __DANGER_resetNodeId } from "../../grammar/ast";
 import { Debug } from "./contracts/output/debug_Debug";
-import path from "path";
+import { posixNormalize } from '../../utils/filePath'
 
 describe("debug", () => {
     beforeEach(() => {
@@ -31,7 +31,7 @@ describe("debug", () => {
             res.indexOf("=== VM LOGS ===") - 2,
         );
 
-        const filePath = path.normalize(
+        const filePath = posixNormalize(
             "src/test/e2e-emulated/contracts/debug.tact",
         );
 

--- a/src/test/e2e-emulated/debug.spec.ts
+++ b/src/test/e2e-emulated/debug.spec.ts
@@ -2,7 +2,7 @@ import { Address, toNano } from "@ton/core";
 import { ContractSystem } from "@tact-lang/emulator";
 import { __DANGER_resetNodeId } from "../../grammar/ast";
 import { Debug } from "./contracts/output/debug_Debug";
-import { posixNormalize } from '../../utils/filePath'
+import { posixNormalize } from "../../utils/filePath";
 
 describe("debug", () => {
     beforeEach(() => {


### PR DESCRIPTION
Closes #522 

- [x] I have updated CHANGELOG.md
- [ ] ~~I have documented my contribution in Tact Docs: https://github.com/tact-lang/tact-docs/pull/PR-NUMBER~~
- [x] I have added tests to demonstrate the contribution is correctly implemented: this usually includes both positive and negative tests, showing the happy path(s) and featuring intentionally broken cases
- [x] I have run all the tests locally and no test failure was reported
- [x] I have run the linter, formatter and spellchecker
- [x] I did not do unrelated and/or undiscussed refactorings
