### PR TITLE
refactor(api): mark some AST store entities as public

### DIFF
--- a/src/grammar/store.ts
+++ b/src/grammar/store.ts
@@ -8,15 +8,19 @@ import {
 import { CompilerContext, createContextStore } from "../context";
 import { ItemOrigin, parse } from "./grammar";
 
-type TactSource = { code: string; path: string; origin: ItemOrigin };
+/**
+ * @public
+ */
+export type TactSource = { code: string; path: string; origin: ItemOrigin };
 
 /**
  * Represents the storage for all AST-related data within the compiler context.
+ * @public
  * @property functions AST entries representing top-level functions.
  * @property constants AST entries representing top-level constant definitions.
  * @property types AST entries representing structures, contracts, and traits.
  */
-type ASTStore = {
+export type AstStore = {
     sources: TactSource[];
     funcSources: { code: string; path: string }[];
     functions: (AstFunctionDef | AstNativeFunctionDecl)[];
@@ -24,15 +28,16 @@ type ASTStore = {
     types: AstTypeDecl[];
 };
 
-const store = createContextStore<ASTStore>();
+const store = createContextStore<AstStore>();
 
 /**
  * Retrieves the raw AST for the given context.
+ * @public
  * @param ctx The compiler context from which the AST is retrieved.
  * @throws Will throw an error if the AST is not found in the context.
  * @returns The AST types associated with the context.
  */
-export function getRawAST(ctx: CompilerContext) {
+export function getRawAST(ctx: CompilerContext): AstStore {
     const r = store.get(ctx, "types");
     if (!r) {
         throw Error("No AST found in context");
@@ -42,8 +47,9 @@ export function getRawAST(ctx: CompilerContext) {
 
 /**
  * Parses multiple Tact source files into AST modules.
+ * @public
  */
-function parseModules(sources: TactSource[]): AstModule[] {
+export function parseModules(sources: TactSource[]): AstModule[] {
     return sources.map((source) =>
         parse(source.code, source.path, source.origin),
     );
@@ -52,21 +58,22 @@ function parseModules(sources: TactSource[]): AstModule[] {
 /**
  * Extends the compiler context by adding AST entries and source information from
  * given sources and parsed programs.
- * @param parsedPrograms An optional array of previously parsed programs. If not defined, they will be parsed from `sources`.
+ * @public
+ * @param parsedModules An optional array of previously parsed programs. If not defined, they will be parsed from `sources`.
  * @returns The updated compiler context.
  */
 export function openContext(
     ctx: CompilerContext,
     sources: TactSource[],
     funcSources: { code: string; path: string }[],
-    parsedPrograms?: AstModule[],
+    parsedModules?: AstModule[],
 ): CompilerContext {
-    const programs = parsedPrograms ? parsedPrograms : parseModules(sources);
+    const modules = parsedModules ? parsedModules : parseModules(sources);
     const types: AstTypeDecl[] = [];
     const functions: (AstNativeFunctionDecl | AstFunctionDef)[] = [];
     const constants: AstConstantDef[] = [];
-    for (const program of programs) {
-        for (const item of program.items) {
+    for (const module of modules) {
+        for (const item of module.items) {
             switch (item.kind) {
                 case "struct_decl":
                 case "message_decl":


### PR DESCRIPTION
Towards #543

<!--
IMPORTANT:
If your PR doesn't close a particular issue, please, create the issue first and describe the whole context: what you're adding/changing and why you're doing so. And only then open the Pull Request, which would close that issue!

In case you are adding a new language feature, a standard library function or introducing other user-facing changes, you need to document them via a new PR to tact-docs.
-->

- ~[ ] I have updated CHANGELOG.md~
- ~[ ] I have documented my contribution in Tact Docs: https://github.com/tact-lang/tact-docs/pull/PR-NUMBER~
- ~[ ] I have added tests to demonstrate the contribution is correctly implemented: this usually includes both positive and negative tests, showing the happy path(s) and featuring intentionally broken cases~
- [x] I have run all the tests locally and no test failure was reported
- [x] I have run the linter, formatter and spellchecker
- [x] I did not do unrelated and/or undiscussed refactorings
