### PR TITLE
Add dependency and trait diagrams to markdown reporting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `-e` / `--eval` CLI flags to evaluate constant Tact expressions: PR [#462](https://github.com/tact-lang/tact/pull/462)
 - `-q` / `--quiet` CLI flags to suppress compiler log output: PR [#509](https://github.com/tact-lang/tact/pull/509)
-- Markdown report for compiled contracts now include Mermaid diagrams for trait inheritance and contract dependencies: PR [#560](https://github.com/tact-lang/tact/pull/560)
+- Markdown report for compiled contracts now includes Mermaid diagrams for trait inheritance and contract dependencies: PR [#560](https://github.com/tact-lang/tact/pull/560)
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `-e` / `--eval` CLI flags to evaluate constant Tact expressions: PR [#462](https://github.com/tact-lang/tact/pull/462)
 - `-q` / `--quiet` CLI flags to suppress compiler log output: PR [#509](https://github.com/tact-lang/tact/pull/509)
+- Markdown report for compiled contracts now include Mermaid diagrams for trait inheritance and contract dependencies: PR [#560](https://github.com/tact-lang/tact/pull/560)
 
 ### Changed
 

--- a/src/generator/writeReport.ts
+++ b/src/generator/writeReport.ts
@@ -43,6 +43,30 @@ export function writeReport(ctx: CompilerContext, pkg: PackageFileFormat) {
     Object.entries(abi.errors!).forEach(([t, abiError]) => {
         w.write(`${t}: ${abiError.message}`);
     });
+    w.append();
+
+    const t = getType(ctx, pkg.name);
+
+    // Trait Inheritance Diagram
+    w.write(`# Trait Inheritance Diagram`);
+    w.append();
+    w.write("```mermaid");
+    w.write("graph TD");
+    for (const trait of t.traits) {
+        w.write(`${t.name} --> ${trait.name}`);
+    }
+    w.write("```");
+    w.append();
+
+    // Contract Dependency Diagram
+    w.write(`# Contract Dependency Diagram`);
+    w.append();
+    w.write("```mermaid");
+    w.write("graph TD");
+    for (const dep of t.dependsOn) {
+        w.write(`${t.name} --> ${dep.name}`);
+    }
+    w.write("```");
 
     return w.end();
 }

--- a/src/generator/writeReport.ts
+++ b/src/generator/writeReport.ts
@@ -47,6 +47,7 @@ export function writeReport(ctx: CompilerContext, pkg: PackageFileFormat) {
     w.append();
 
     const t = getType(ctx, pkg.name);
+    const writtenEdges: Set<string> = new Set();
 
     // Trait Inheritance Diagram
     w.write(`# Trait Inheritance Diagram`);
@@ -55,13 +56,21 @@ export function writeReport(ctx: CompilerContext, pkg: PackageFileFormat) {
     w.write("graph TD");
     function writeTraits(t: TypeDescription) {
         for (const trait of t.traits) {
-            w.write(`${t.name} --> ${trait.name}`);
+            const edge = `${t.name} --> ${trait.name}`;
+            if (writtenEdges.has(edge)) {
+                continue;
+            }
+            writtenEdges.add(edge);
+            w.write(edge);
             writeTraits(trait);
         }
     }
+    w.write(t.name);
     writeTraits(t);
     w.write("```");
     w.append();
+
+    writtenEdges.clear();
 
     // Contract Dependency Diagram
     w.write(`# Contract Dependency Diagram`);
@@ -70,10 +79,17 @@ export function writeReport(ctx: CompilerContext, pkg: PackageFileFormat) {
     w.write("graph TD");
     function writeDependencies(t: TypeDescription) {
         for (const dep of t.dependsOn) {
-            w.write(`${t.name} --> ${dep.name}`);
+            const edge = `${t.name} --> ${dep.name}`;
+            if (writtenEdges.has(edge)) {
+                continue;
+            }
+            writtenEdges.add(edge);
+            w.write(edge);
             writeDependencies(dep);
         }
     }
+    writtenEdges.clear();
+    w.write(t.name);
     writeDependencies(t);
     w.write("```");
 

--- a/src/generator/writeReport.ts
+++ b/src/generator/writeReport.ts
@@ -3,6 +3,7 @@ import { CompilerContext } from "../context";
 import { PackageFileFormat } from "../packaging/fileFormat";
 import { getType } from "../types/resolveDescriptors";
 import { Writer } from "../utils/Writer";
+import { TypeDescription } from "../types/types";
 
 export function writeReport(ctx: CompilerContext, pkg: PackageFileFormat) {
     const w = new Writer();
@@ -52,9 +53,13 @@ export function writeReport(ctx: CompilerContext, pkg: PackageFileFormat) {
     w.append();
     w.write("```mermaid");
     w.write("graph TD");
-    for (const trait of t.traits) {
-        w.write(`${t.name} --> ${trait.name}`);
+    function writeTraits(t: TypeDescription) {
+        for (const trait of t.traits) {
+            w.write(`${t.name} --> ${trait.name}`);
+            writeTraits(trait);
+        }
     }
+    writeTraits(t);
     w.write("```");
     w.append();
 
@@ -63,9 +68,13 @@ export function writeReport(ctx: CompilerContext, pkg: PackageFileFormat) {
     w.append();
     w.write("```mermaid");
     w.write("graph TD");
-    for (const dep of t.dependsOn) {
-        w.write(`${t.name} --> ${dep.name}`);
+    function writeDependencies(t: TypeDescription) {
+        for (const dep of t.dependsOn) {
+            w.write(`${t.name} --> ${dep.name}`);
+            writeDependencies(dep);
+        }
     }
+    writeDependencies(t);
     w.write("```");
 
     return w.end();


### PR DESCRIPTION
Closes #499 

- [x] I have updated CHANGELOG.md
- [ ] ~~I have documented my contribution in Tact Docs: https://github.com/tact-lang/tact-docs/pull/PR-NUMBER~~
- [ ] ~~I have added tests to demonstrate the contribution is correctly implemented: this usually includes both positive and negative tests, showing the happy path(s) and featuring intentionally broken cases~~
- [x] I have run all the tests locally and no test failure was reported
- [x] I have run the linter, formatter and spellchecker
- [x] I did not do unrelated and/or undiscussed refactorings
