### PR TITLE
chore: bump @tact-lang/opcode version to 0.0.16

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Correct regex for unicode code points and escaping of control codes in generated comments: PR [#535](https://github.com/tact-lang/tact/pull/535)
 - Add `impure` specifier to some stdlib functions that are expected to throw errors: PR [#565](https://github.com/tact-lang/tact/pull/565)
 - Defining non-existing native FunC functions now throws an understandable compilation error: PR [#585](https://github.com/tact-lang/tact/pull/585)
+- Bump used `@tact-lang/opcode` version to `0.0.16` which fixes the issue with `DIV` instructions: PR [#589](https://github.com/tact-lang/tact/pull/589)
 
 ## [1.4.0] - 2024-06-21
 

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "tact": "bin/tact.js"
   },
   "dependencies": {
-    "@tact-lang/opcode": "^0.0.14",
+    "@tact-lang/opcode": "^0.0.16",
     "@ton/core": "0.56.3",
     "@ton/crypto": "^3.2.0",
     "blockstore-core": "1.0.5",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1287,6 +1287,11 @@
   resolved "https://registry.npmjs.org/@tact-lang/opcode/-/opcode-0.0.14.tgz"
   integrity sha512-8FKHK2jwvViRBReO2t40DCkHAP9KPTRWZof4kdsAUJFlyeWIC8SsRQSl9QkZxF+48WvjDduKNqN5Ltb80paufA==
 
+"@tact-lang/opcode@^0.0.16":
+  version "0.0.16"
+  resolved "https://registry.yarnpkg.com/@tact-lang/opcode/-/opcode-0.0.16.tgz#cc9e4117ce706d8bb6e054a520bab719f70adf96"
+  integrity sha512-YJTUjoDOy+e+FHHppJiF+uWJ2IMjVknB9VQ5n78pknCE129DazCb/nFXnw0wVRDVcn8Tn59ky+pmjiQjQOjEbw==
+
 "@tact-lang/ton-abi@^0.0.3":
   version "0.0.3"
   resolved "https://registry.npmjs.org/@tact-lang/ton-abi/-/ton-abi-0.0.3.tgz"


### PR DESCRIPTION
Closes #588 

- [x] I have updated CHANGELOG.md
- [ ] ~~I have documented my contribution in Tact Docs: https://github.com/tact-lang/tact-docs/pull/PR-NUMBER~~
- [ ] ~~I have added tests to demonstrate the contribution is correctly implemented: this usually includes both positive and negative tests, showing the happy path(s) and featuring intentionally broken cases~~
- [x] I have run all the tests locally and no test failure was reported
- [x] I have run the linter, formatter and spellchecker
- [x] I did not do unrelated and/or undiscussed refactorings
