### PR TITLE
Fix Typo in CHANGELOG.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,7 +67,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Trailing semicolons in struct and message declarations are optional now: PR [#395](https://github.com/tact-lang/tact/pull/395)
 - Tests are refactored and renamed to convey the sense of what is being tested and to reduce the amount of merge conflicts during development: PR [#402](https://github.com/tact-lang/tact/pull/402)
-- `let`-statements can now be used without an explicit type declaration and determine the type automatically if it was not specified: PR [#198](https://github.com/tact-lang/tact/pull/198) and PR [#438](https://github.com/tact-lang/tact/pull/438)
+- `Let`-statements can now be used without an explicit type declaration and determine the type automatically if it was not specified: PR [#198](https://github.com/tact-lang/tact/pull/198) and PR [#438](https://github.com/tact-lang/tact/pull/438)
 - The outdated TextMate-style grammar files for text editors have been removed (the most recent grammar files can be found in the [tact-sublime](https://github.com/tact-lang/tact-sublime) repo): PR [#404](https://github.com/tact-lang/tact/pull/404)
 - The JSON schema for `tact.config.json` has been moved to the `schemas` project folder: PR [#404](https://github.com/tact-lang/tact/pull/404)
 - Allow underscores as unused variable identifiers: PR [#338](https://github.com/tact-lang/tact/pull/338)


### PR DESCRIPTION
In Roadmap.md there was a line "let". The mistake is that the first letter in the sentence should be capitalized. 

I suggest fixing this problem by writing "Let" instead of "let".

Original:
"let-statements can now be used without an explicit type declaration and determine the type automatically if it was not specified: PR #198 and PR #438" Improved:
"Let-statements can now be used without an explicit type declaration and determine the type automatically if it was not specified: PR #198 and PR #438"

Closes #591


- [x] I have updated CHANGELOG.md

- [x] I have documented my contribution in Tact Docs: https://github.com/tact-lang/tact-docs/pull/PR-NUMBER
- [x] I have added tests to demonstrate the contribution is correctly implemented: this usually includes both positive and negative tests, showing the happy path(s) and featuring intentionally broken cases
- [x] I have run all the tests locally and no test failure was reported
- [x] I have run the linter, formatter and spellchecker
- [x] I did not do unrelated and/or undiscussed refactorings

