### PR TITLE
Fix FunC code generated for `recv_external`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add `impure` specifier to some stdlib functions that are expected to throw errors: PR [#565](https://github.com/tact-lang/tact/pull/565)
 - Defining non-existing native FunC functions now throws an understandable compilation error: PR [#585](https://github.com/tact-lang/tact/pull/585)
 - Bump used `@tact-lang/opcode` version to `0.0.16` which fixes the issue with `DIV` instructions: PR [#589](https://github.com/tact-lang/tact/pull/589)
+- Incorrect FunC code generated for `recv_external`: PR [#604](https://github.com/tact-lang/tact/pull/604)
 
 ## [1.4.0] - 2024-06-21
 

--- a/src/generator/writers/writeContract.ts
+++ b/src/generator/writers/writeContract.ts
@@ -355,7 +355,7 @@ export function writeMainContract(
                 // Throw if not handled
                 ctx.append(`;; Throw if not handled`);
                 ctx.append(
-                    `throw_unless(handled, ${contractErrors.invalidMessage.id});`,
+                    `throw_unless(${contractErrors.invalidMessage.id}, handled);`,
                 );
                 ctx.append();
 


### PR DESCRIPTION
Closes #610.

The external receiver generates the following code:

```
;; Handle operation
int handled = ...;
;; Throw if not handled
throw_unless(handled, 130);
```

Which uses the incorrect order of argument in `throw_unless`.

- [x] I have updated CHANGELOG.md
- [ ] ~~I have documented my contribution in Tact Docs: https://github.com/tact-lang/tact-docs/pull/PR-NUMBER~~
- [ ] ~~I have added tests to demonstrate the contribution is correctly implemented: this usually includes both positive and negative tests, showing the happy path(s) and featuring intentionally broken cases~~
- [x] I have run all the tests locally and no test failure was reported
- [x] I have run the linter, formatter and spellchecker
- [x] I did not do unrelated and/or undiscussed refactorings
