### PR TITLE
Fix README markup

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,34 +42,43 @@ For Visual Studio Code syntax support, please download the [Tact extension](http
 
 We have formed a large-scale vision for the philosophy of Tact to make sure that community has something to refer to.
 
-1. Familiar syntax
+1. ### Familiar syntax
+
    Tact features modern post-C syntax familiar to developers who know TypeScript, Swift, Kotlin and Rust.
 
-2. First-class data structures
+2. ### First-class data structures
+
    Tact makes it easy to declare, decode and encode data structures according to their TL-B schemas.
 
-3. Safe contract interfaces and ABI
+3. ### Safe contract interfaces and ABI
+
    Tact offers strong compile-time checks for contract interfaces, typed addresses and lets you describe messages natively in a subset of TL-B.
 
-4. Message dispatch
+4. ### Message dispatch
+
    Tact offers a convenient yet flexible way to declare, receive and send messages between contracts.
 
-5. Plaintext commands
+5. ### Plaintext commands
+
    Tact offers an innovative way for securely sending commands to the contracts by the users using plaintext commands that are parsed on-chain.
 
-6. Composition of contracts
+6. ### Composition of contracts
+
    Tact offers traits to extract commonly used behaviors into reusable and verified components.
 
-7. Statically bounded iterators
+7. ### Statically bounded iterators
+
    Tact offers convenient iterators and arrays are bounded and do not hurt scalability of the contracts.
 
-8. Batteries-included standard library
+8. ### Batteries-included standard library
+
    Tact comes with a rich standard library that offers data handling functions and standardized behaviors.
 
-9. Interactive
+9. ### Interactive
+
    Tact comes with a live playground, explorer and easy to use deployment tools.
 
-10. Verifiable
+10. ### Verifiable
     Tact produces deterministic builds. Compiler helps analyze gas usage and storage costs.
 
 ## License

--- a/README.md
+++ b/README.md
@@ -79,6 +79,7 @@ We have formed a large-scale vision for the philosophy of Tact to make sure that
    Tact comes with a live playground, explorer and easy to use deployment tools.
 
 10. ### Verifiable
+
     Tact produces deterministic builds. Compiler helps analyze gas usage and storage costs.
 
 ## License


### PR DESCRIPTION
Closes #607

<!--
IMPORTANT:
If your PR doesn't close a particular issue, please, create the issue first and describe the whole context: what you're adding/changing and why you're doing so. And only then open the Pull Request, which would close that issue!

In case you are adding a new language feature, a standard library function or introducing other user-facing changes, you need to document them via a new PR to tact-docs.
-->

- ~[ ] I have updated CHANGELOG.md~
- ~[ ] I have documented my contribution in Tact Docs: https://github.com/tact-lang/tact-docs/pull/PR-NUMBER~
- ~[ ] I have added tests to demonstrate the contribution is correctly implemented: this usually includes both positive and negative tests, showing the happy path(s) and featuring intentionally broken cases~
- [ ] I have run all the tests locally and no test failure was reported
- [ ] I have run the linter, formatter and spellchecker
- [ ] I did not do unrelated and/or undiscussed refactorings

Preview of the change: https://github.com/tact-lang/tact/blob/ed007d73869b10cd7f4a6b48095a241d76c4e9d8/README.md#10-commandments-of-tact

The same section on master: https://github.com/tact-lang/tact/blob/main/README.md#10-commandments-of-tact

P.S. I didn't manage to reproduce this newline removing in the PR description. Looks like GitHub treat comment markup differently.
