### PR TITLE
fixed small typos in 'src' scripts

### DIFF
--- a/src/config/parseConfig.ts
+++ b/src/config/parseConfig.ts
@@ -3,7 +3,7 @@ import { z } from "zod";
 const optionsSchema = z
     .object({
         /**
-         * If set to true, enables debug output of a contract and allows usage of `dump()` function,
+         * If set to true, enables debug output of a contract and allows the usage of the `dump()` function,
          * which is useful for debugging purposes.
          *
          * Read more: https://docs.tact-lang.org/book/debug

--- a/src/constEval.ts
+++ b/src/constEval.ts
@@ -44,8 +44,8 @@ const maxTvmInt: bigint = 2n ** 256n - 1n;
 const optimizer: ExpressionTransformer = new StandardOptimizer();
 
 // Throws a non-fatal const-eval error, in the sense that const-eval as a compiler
-// optimization cannot be applied, e.g. to `let`-statements.
-// Note that for const initializers this is a show-stopper.
+// optimization cannot be applied, e.g., to `let` statements.
+// Note that for const initializers, this is a show-stopper.
 function throwNonFatalErrorConstEval(msg: string, source: SrcInfo): never {
     throwConstEvalError(
         `Cannot evaluate expression to a constant: ${msg}`,

--- a/src/verify.ts
+++ b/src/verify.ts
@@ -41,7 +41,7 @@ export async function verify(args: {
         return { ok: false, error: "invalid-package-format" };
     }
 
-    // Check compiler and version
+    // Check compiler and the version
     if (unpacked.compiler.name !== "tact") {
         return { ok: false, error: "invalid-compiler" };
     }


### PR DESCRIPTION
Closes #number

<!--
IMPORTANT:
If your PR doesn't close a particular issue, please, create the issue first and describe the whole context: what you're adding/changing and why you're doing so. And only then open the Pull Request, which would close that issue!

In case you are adding a new language feature, a standard library function or introducing other user-facing changes, you need to document them via a new PR to tact-docs.
-->

- [ ] I have updated CHANGELOG.md
- [ ] I have documented my contribution in Tact Docs: https://github.com/tact-lang/tact-docs/pull/PR-NUMBER
- [ ] I have added tests to demonstrate the contribution is correctly implemented: this usually includes both positive and negative tests, showing the happy path(s) and featuring intentionally broken cases
- [ ] I have run all the tests locally and no test failure was reported
- [ ] I have run the linter, formatter and spellchecker
- [ ] I did not do unrelated and/or undiscussed refactorings
