### PR TITLE
fix: safety condition fixed in associative rule

### DIFF
--- a/src/optimizer/associative.ts
+++ b/src/optimizer/associative.ts
@@ -531,8 +531,10 @@ export class AssociativeRule3 extends Rule {
         Map<AstBinaryOperation, Transform>
     >;
 
-    // Some standard conditions that repeat a lot in the rule.
+    // Some standard safety conditions that repeat a lot.
 
+    // Safety condition:
+    // c1 != 0 ==> sign(c1) === sign(val_) && abs(c1) <= abs(val_)
     private standardAdditiveCondition: (c1: bigint, val_: bigint) => boolean = (
         c1,
         val_,
@@ -543,20 +545,41 @@ export class AssociativeRule3 extends Rule {
         return sign(c1) === sign(val_) && abs(c1) <= abs(val_);
     };
 
+    // Safety condition:
+    // c1 != 0 ==> sign(c1) === sign(val_) && abs(c1) <= abs(val_)
+    // c1 == 0 ==> val_ >= 0
+    private standardAdditiveWithZeroCondition: (
+        c1: bigint,
+        val_: bigint,
+    ) => boolean = (c1, val_) => {
+        if (c1 === 0n) {
+            return val_ >= 0n;
+        }
+        return sign(c1) === sign(val_) && abs(c1) <= abs(val_);
+    };
+
+    // Safety condition:
+    // c1 != 0 && sign(c1) == sign(val_) ==> abs(c1) <= abs(val_)
+    // c1 != 0 && sign(c1) != sign(val_) ==> abs(c1) < abs(val_)
+    // c1 != 0 ==> val_ != 0
     private standardMultiplicativeCondition: (
         c1: bigint,
         val_: bigint,
     ) => boolean = (c1, val_) => {
-        if (c1 < 0n) {
-            if (sign(c1) === sign(val_)) {
-                return abs(c1) <= abs(val_);
-            } else {
-                return abs(c1) < abs(val_);
-            }
-        } else if (c1 === 0n) {
+        if (c1 === 0n) {
             return true;
-        } else {
+        }
+        // At this point, c1 != 0
+        // hence, val_ must be non-zero as
+        // required by the safety condition
+        if (val_ === 0n) {
+            return false;
+        }
+        // At this point, both c1 and val_ are non-zero
+        if (sign(c1) === sign(val_)) {
             return abs(c1) <= abs(val_);
+        } else {
+            return abs(c1) < abs(val_);
         }
     };
 
@@ -720,7 +743,10 @@ export class AssociativeRule3 extends Rule {
                         safetyCondition: (c1, val_) => {
                             const n1 = ensureInt(c1);
                             const res = ensureInt(val_);
-                            return this.standardAdditiveCondition(n1, res);
+                            return this.standardAdditiveWithZeroCondition(
+                                n1,
+                                res,
+                            );
                         },
                     },
                 ],
@@ -903,7 +929,10 @@ export class AssociativeRule3 extends Rule {
                         safetyCondition: (c1, val_) => {
                             const n1 = ensureInt(c1);
                             const res = ensureInt(val_);
-                            return this.standardAdditiveCondition(n1, res);
+                            return this.standardAdditiveWithZeroCondition(
+                                n1,
+                                res,
+                            );
                         },
                     },
                 ],
@@ -920,7 +949,10 @@ export class AssociativeRule3 extends Rule {
                         safetyCondition: (c1, val_) => {
                             const n1 = ensureInt(c1);
                             const res = ensureInt(val_);
-                            return this.standardAdditiveCondition(n1, res);
+                            return this.standardAdditiveWithZeroCondition(
+                                n1,
+                                res,
+                            );
                         },
                     },
                 ],

--- a/src/optimizer/test/partial-eval.spec.ts
+++ b/src/optimizer/test/partial-eval.spec.ts
@@ -151,11 +151,8 @@ const mixedExpressions = [
     { original: "(X * -1 * -2) + (X * -1 * -2)", simplified: "X * 4" },
 ];
 
-const previousFailingAssoc3Expressions = [
-    // Previously, the following cases where wrongly simplified
-    // by the partial evaluator. Now, they do not simplify,
-    // as it should be.
-
+// These expressions are edge cases to test the associative rule only.
+const associativeRuleExpressions = [
     // The following three cases should NOT simplify to
     // -1 - X because X could be MIN, so that 0 - X overflows
     // but -1 - X = MAX does not.
@@ -316,7 +313,7 @@ describe("partial-evaluator", () => {
         new AssociativeRule3(),
     ]);
 
-    previousFailingAssoc3Expressions.forEach((test) => {
+    associativeRuleExpressions.forEach((test) => {
         testExpressionWithOptimizer(test.original, test.simplified, optimizer);
     });
 });

--- a/src/optimizer/test/partial-eval.spec.ts
+++ b/src/optimizer/test/partial-eval.spec.ts
@@ -153,37 +153,20 @@ const mixedExpressions = [
 
 const previousFailingAssoc3Expressions = [
     // Previously, the following cases where wrongly simplified
-    // by the partial evaluator.
+    // by the partial evaluator. Now, they do not simplify,
+    // as it should be.
 
-    // PROBLEM: X could be MIN, so that 0 - X overflows but
-    // -1 - X = MAX does not
-    //{ original: "(0 - X) + -1", simplified: "-1 - X" },
-
-    // PROBLEM: Same as before
-    //{ original: "-1 + (0 - X)", simplified: "-1 - X" },
-
-    // PROBLEM: Same as before
-    //{ original: "(0 - X) - 1", simplified: "-1 - X" },
-
-    // PROBLEM: X could be -(MIN/2) = 2^255, so that
-    // X * 2 = -(MIN/2) * 2 = MAX + 1 = 2^256 overflows,
-    // but X * -2 = 2^255 * -2 = -2^256 = MIN does not.
-    //{ original: "(X * 2) * -1", simplified: "X * -2" },
-
-    // PROBLEM: Same as before
-    //{ original: "(2 * X) * -1", simplified: "-2 * X" },
-
-    // PROBLEM: Same as before
-    //{ original: "-1 * (X * 2)", simplified: "X * -2" },
-
-    // PROBLEM: Same as before
-    //{ original: "-1 * (2 * X)", simplified: "-2 * X" },
-
-    // The above cases are now fixed, and no longer simplify:
-
+    // The following three cases should NOT simplify to
+    // -1 - X because X could be MIN, so that 0 - X overflows
+    // but -1 - X = MAX does not.
     { original: "(0 - X) + -1", simplified: "(0 - X) + -1" },
     { original: "-1 + (0 - X)", simplified: "-1 + (0 - X)" },
     { original: "(0 - X) - 1", simplified: "(0 - X) - 1" },
+
+    // The following 4 cases Should NOT simplify to X * -2
+    // because X could be -(MIN/2) = 2^255, so that
+    // X * 2 = -(MIN/2) * 2 = MAX + 1 = 2^256 overflows,
+    // but X * -2 = 2^255 * -2 = -2^256 = MIN does not.
     { original: "(X * 2) * -1", simplified: "(X * 2) * -1" },
     { original: "(2 * X) * -1", simplified: "(2 * X) * -1" },
     { original: "-1 * (X * 2)", simplified: "-1 * (X * 2)" },

--- a/src/optimizer/test/partial-eval.spec.ts
+++ b/src/optimizer/test/partial-eval.spec.ts
@@ -151,42 +151,43 @@ const mixedExpressions = [
     { original: "(X * -1 * -2) + (X * -1 * -2)", simplified: "X * 4" },
 ];
 
-const failingAssoc3Expressions = [
-    // The following examples should NOT simplify, but they DO.
-    // This is due to edge cases not considered in the safety conditions of the associative rules
-
-    // The following three cases forgot to check the case when c1 in
-    // (c1 - X) is 0. The safety condition works when c1 is not 0.
+const previousFailingAssoc3Expressions = [
+    // Previously, the following cases where wrongly simplified
+    // by the partial evaluator.
 
     // PROBLEM: X could be MIN, so that 0 - X overflows but
     // -1 - X = MAX does not
-    { original: "(0 - X) + -1", simplified: "-1 - X" },
+    //{ original: "(0 - X) + -1", simplified: "-1 - X" },
 
     // PROBLEM: Same as before
-    { original: "-1 + (0 - X)", simplified: "-1 - X" },
+    //{ original: "-1 + (0 - X)", simplified: "-1 - X" },
 
     // PROBLEM: Same as before
-    { original: "(0 - X) - 1", simplified: "-1 - X" },
-
-    // The following case four cases forgot to check that
-    // c2 * c1 < 0 when c1 > 0 in (X * c1) * c2.
-    // The safety condition requires the strict inequality
-    // |c1| < |c1 * c2| for the case c1 > 0 and c1 * c2 < 0,
-    // while currently has |c1| <= |c1 * c2|
+    //{ original: "(0 - X) - 1", simplified: "-1 - X" },
 
     // PROBLEM: X could be -(MIN/2) = 2^255, so that
     // X * 2 = -(MIN/2) * 2 = MAX + 1 = 2^256 overflows,
     // but X * -2 = 2^255 * -2 = -2^256 = MIN does not.
-    { original: "(X * 2) * -1", simplified: "X * -2" },
+    //{ original: "(X * 2) * -1", simplified: "X * -2" },
 
     // PROBLEM: Same as before
-    { original: "(2 * X) * -1", simplified: "-2 * X" },
+    //{ original: "(2 * X) * -1", simplified: "-2 * X" },
 
     // PROBLEM: Same as before
-    { original: "-1 * (X * 2)", simplified: "X * -2" },
+    //{ original: "-1 * (X * 2)", simplified: "X * -2" },
 
     // PROBLEM: Same as before
-    { original: "-1 * (2 * X)", simplified: "-2 * X" },
+    //{ original: "-1 * (2 * X)", simplified: "-2 * X" },
+
+    // The above cases are now fixed, and no longer simplify:
+
+    { original: "(0 - X) + -1", simplified: "(0 - X) + -1" },
+    { original: "-1 + (0 - X)", simplified: "-1 + (0 - X)" },
+    { original: "(0 - X) - 1", simplified: "(0 - X) - 1" },
+    { original: "(X * 2) * -1", simplified: "(X * 2) * -1" },
+    { original: "(2 * X) * -1", simplified: "(2 * X) * -1" },
+    { original: "-1 * (X * 2)", simplified: "-1 * (X * 2)" },
+    { original: "-1 * (2 * X)", simplified: "-1 * (2 * X)" },
 ];
 
 function testExpression(original: string, simplified: string) {
@@ -332,7 +333,7 @@ describe("partial-evaluator", () => {
         new AssociativeRule3(),
     ]);
 
-    failingAssoc3Expressions.forEach((test) => {
+    previousFailingAssoc3Expressions.forEach((test) => {
         testExpressionWithOptimizer(test.original, test.simplified, optimizer);
     });
 });


### PR DESCRIPTION
Closes #599.

- [ ] ~~I have updated CHANGELOG.md~~
- [ ] ~~I have documented my contribution in Tact Docs: https://github.com/tact-lang/tact-docs/pull/PR-NUMBER~~
- [X] I have added tests to demonstrate the contribution is correctly implemented: this usually includes both positive and negative tests, showing the happy path(s) and featuring intentionally broken cases
- [X] I have run all the tests locally and no test failure was reported
- [X] I have run the linter, formatter and spellchecker
- [X] I did not do unrelated and/or undiscussed refactorings
