### PR TITLE
fix: error message for missing types for bounced receivers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Typechecking for constant and struct field initializers: PR [#621](https://github.com/tact-lang/tact/pull/621)
 - Constant evaluation for structures with default and optional fields: PR [#621](https://github.com/tact-lang/tact/pull/621)
 - Report error for self-referencing and mutually-recursive types: PR [#624](https://github.com/tact-lang/tact/pull/624)
+- Error reporting for bounced receivers with missing parameter types: PR [#626](https://github.com/tact-lang/tact/pull/626)
 
 ## [1.4.0] - 2024-06-21
 

--- a/src/types/__snapshots__/resolveDescriptors.spec.ts.snap
+++ b/src/types/__snapshots__/resolveDescriptors.spec.ts.snap
@@ -30,6 +30,26 @@ Line 17, col 3:
 "
 `;
 
+exports[`resolveDescriptors should fail descriptors for contract-bounced-receiver-missing-type-1 1`] = `
+"<unknown>:2:14: Unknown bounced receiver parameter type: "A"
+Line 2, col 14:
+  1 | contract Test {
+> 2 |   bounced(a: A) {}
+                   ^
+  3 | }
+"
+`;
+
+exports[`resolveDescriptors should fail descriptors for contract-bounced-receiver-missing-type-2 1`] = `
+"<unknown>:2:14: Unknown bounced receiver parameter type: "A"
+Line 2, col 14:
+  1 | contract Test {
+> 2 |   bounced(a: bounced<A>) {}
+                   ^~~~~~~~~~
+  3 | }
+"
+`;
+
 exports[`resolveDescriptors should fail descriptors for contract-bounced-storage-var 1`] = `
 "<unknown>:15:3: bounced<A> is a runtime only type and can't be used as field
 Line 15, col 3:

--- a/src/types/resolveDescriptors.ts
+++ b/src/types/resolveDescriptors.ts
@@ -1163,7 +1163,13 @@ export function resolveDescriptors(ctx: CompilerContext) {
                                         ast: d,
                                     });
                                 } else {
-                                    const type = types.get(idText(param.type))!;
+                                    const type = types.get(idText(param.type));
+                                    if (type === undefined) {
+                                        throwCompilationError(
+                                            `Unknown bounced receiver parameter type: ${idTextErr(param.type)}`,
+                                            param.type.loc,
+                                        );
+                                    }
                                     if (type.ast.kind !== "message_decl") {
                                         throwCompilationError(
                                             "Bounce receive function can only accept bounced message, message or Slice",
@@ -1212,7 +1218,13 @@ export function resolveDescriptors(ctx: CompilerContext) {
                             ) {
                                 const t = types.get(
                                     idText(param.type.messageType),
-                                )!;
+                                );
+                                if (t === undefined) {
+                                    throwCompilationError(
+                                        `Unknown bounced receiver parameter type: ${idTextErr(param.type.messageType)}`,
+                                        param.type.loc,
+                                    );
+                                }
                                 if (t.kind !== "struct") {
                                     throwCompilationError(
                                         "Bounce receive function can only accept bounced<T> struct types",

--- a/src/types/test-failed/contract-bounced-receiver-missing-type-1.tact
+++ b/src/types/test-failed/contract-bounced-receiver-missing-type-1.tact
@@ -1,0 +1,3 @@
+contract Test {
+  bounced(a: A) {}
+}

--- a/src/types/test-failed/contract-bounced-receiver-missing-type-2.tact
+++ b/src/types/test-failed/contract-bounced-receiver-missing-type-2.tact
@@ -1,0 +1,3 @@
+contract Test {
+  bounced(a: bounced<A>) {}
+}


### PR DESCRIPTION
Closes #623

<!--
IMPORTANT:
If your PR doesn't close a particular issue, please, create the issue first and describe the whole context: what you're adding/changing and why you're doing so. And only then open the Pull Request, which would close that issue!

In case you are adding a new language feature, a standard library function or introducing other user-facing changes, you need to document them via a new PR to tact-docs.
-->

- [x] I have updated CHANGELOG.md
- ~[ ] I have documented my contribution in Tact Docs: https://github.com/tact-lang/tact-docs/pull/PR-NUMBER~
- [x] I have added tests to demonstrate the contribution is correctly implemented: this usually includes both positive and negative tests, showing the happy path(s) and featuring intentionally broken cases
- [x] I have run all the tests locally and no test failure was reported
- [x] I have run the linter, formatter and spellchecker
- [x] I did not do unrelated and/or undiscussed refactorings
