### PR TITLE
fix: improve `funcId` recognition and squash misdetection bugs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- FunC function identifiers with characters from hexadecimal set: PR [#635](https://github.com/tact-lang/tact/pull/635)
+- FunC function identifiers with characters from hexadecimal set: PR [#636](https://github.com/tact-lang/tact/pull/636)
 
 ## [1.4.1] - 2024-07-26
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- FunC function identifiers with characters from hexadecimal set: PR [#635](https://github.com/tact-lang/tact/pull/635)
+
 ## [1.4.1] - 2024-07-26
 
 ### Added

--- a/src/grammar/__snapshots__/grammar.spec.ts.snap
+++ b/src/grammar/__snapshots__/grammar.spec.ts.snap
@@ -3861,7 +3861,7 @@ native testFunc(): Bool;,
 
 exports[`grammar should parse items-native-fun-funcid 1`] = `
 {
-  "id": 112,
+  "id": 118,
   "imports": [],
   "items": [
     {
@@ -4637,6 +4637,48 @@ native idTest37();,
         "kind": "func_id",
         "loc": .something,
         "text": ".something",
+      },
+      "params": [],
+      "return": null,
+    },
+    {
+      "attributes": [],
+      "id": 114,
+      "kind": "native_function_decl",
+      "loc": @name(f̷̨͈͚́͌̀i̵̩͔̭̐͐̊n̸̟̝̻̩̎̓͋̕e̸̝̙̒̿͒̾̕)
+native idTest38();,
+      "name": {
+        "id": 112,
+        "kind": "id",
+        "loc": idTest38,
+        "text": "idTest38",
+      },
+      "nativeName": {
+        "id": 113,
+        "kind": "func_id",
+        "loc": f̷̨͈͚́͌̀i̵̩͔̭̐͐̊n̸̟̝̻̩̎̓͋̕e̸̝̙̒̿͒̾̕,
+        "text": "f̷̨͈͚́͌̀i̵̩͔̭̐͐̊n̸̟̝̻̩̎̓͋̕e̸̝̙̒̿͒̾̕",
+      },
+      "params": [],
+      "return": null,
+    },
+    {
+      "attributes": [],
+      "id": 117,
+      "kind": "native_function_decl",
+      "loc": @name(❤️❤️❤️thanks❤️❤️❤️)
+native idTest39();,
+      "name": {
+        "id": 115,
+        "kind": "id",
+        "loc": idTest39,
+        "text": "idTest39",
+      },
+      "nativeName": {
+        "id": 116,
+        "kind": "func_id",
+        "loc": ❤️❤️❤️thanks❤️❤️❤️,
+        "text": "❤️❤️❤️thanks❤️❤️❤️",
       },
       "params": [],
       "return": null,

--- a/src/grammar/__snapshots__/grammar.spec.ts.snap
+++ b/src/grammar/__snapshots__/grammar.spec.ts.snap
@@ -91,8 +91,18 @@ Line 1, col 10:
 "
 `;
 
+exports[`grammar should fail funcid-native-fun-hash 1`] = `
+"<unknown>:1:7: Parse error: expected not ("\\"" or "{-" or "#")
+
+Line 1, col 7:
+> 1 | @name(#notInclude)
+            ^
+  2 | native idTest();
+"
+`;
+
 exports[`grammar should fail funcid-native-fun-multiline-comments 1`] = `
-"<unknown>:1:7: Parse error: expected not ("\\"" or "{-")
+"<unknown>:1:7: Parse error: expected not ("\\"" or "{-" or "#")
 
 Line 1, col 7:
 > 1 | @name({-aaa-})
@@ -127,6 +137,36 @@ exports[`grammar should fail funcid-native-fun-number-hexadecimal 1`] = `
 Line 1, col 10:
 > 1 | @name(0x0)
                ^
+  2 | native idTest();
+"
+`;
+
+exports[`grammar should fail funcid-native-fun-number-hexadecimal-2 1`] = `
+"<unknown>:1:17: Parse error: expected not (a whiteSpace or "(" or ")" or "," or "." or ";" or "~")
+
+Line 1, col 17:
+> 1 | @name(0xDEADBEEF)
+                      ^
+  2 | native idTest();
+"
+`;
+
+exports[`grammar should fail funcid-native-fun-number-neg-decimal 1`] = `
+"<unknown>:1:9: Parse error: expected not (a whiteSpace or "(" or ")" or "," or "." or ";" or "~")
+
+Line 1, col 9:
+> 1 | @name(-1)
+              ^
+  2 | native idTest();
+"
+`;
+
+exports[`grammar should fail funcid-native-fun-number-neg-hexadecimal 1`] = `
+"<unknown>:1:11: Parse error: expected not (a whiteSpace or "(" or ")" or "," or "." or ";" or "~")
+
+Line 1, col 11:
+> 1 | @name(-0x0)
+                ^
   2 | native idTest();
 "
 `;
@@ -172,7 +212,7 @@ Line 1, col 11:
 `;
 
 exports[`grammar should fail funcid-native-fun-string 1`] = `
-"<unknown>:1:7: Parse error: expected not ("\\"" or "{-")
+"<unknown>:1:7: Parse error: expected not ("\\"" or "{-" or "#")
 
 Line 1, col 7:
 > 1 | @name("not_a_string)
@@ -182,7 +222,7 @@ Line 1, col 7:
 `;
 
 exports[`grammar should fail funcid-native-fun-unclosed-parens 1`] = `
-"<unknown>:1:9: Parse error: expected not (a whiteSpace or "(" or ")" or "," or "." or ";" or "~")
+"<unknown>:1:9: Parse error: expected ")"
 
 Line 1, col 9:
 > 1 | @name(aa(bb)
@@ -3821,7 +3861,7 @@ native testFunc(): Bool;,
 
 exports[`grammar should parse items-native-fun-funcid 1`] = `
 {
-  "id": 55,
+  "id": 70,
   "imports": [],
   "items": [
     {
@@ -4198,6 +4238,111 @@ native idTest18();,
         "kind": "func_id",
         "loc": \`any symbols ; ~ () are allowed here...\`,
         "text": "\`any symbols ; ~ () are allowed here...\`",
+      },
+      "params": [],
+      "return": null,
+    },
+    {
+      "attributes": [],
+      "id": 57,
+      "kind": "native_function_decl",
+      "loc": @name(C4)
+native idTest19();,
+      "name": {
+        "id": 55,
+        "kind": "id",
+        "loc": idTest19,
+        "text": "idTest19",
+      },
+      "nativeName": {
+        "id": 56,
+        "kind": "func_id",
+        "loc": C4,
+        "text": "C4",
+      },
+      "params": [],
+      "return": null,
+    },
+    {
+      "attributes": [],
+      "id": 60,
+      "kind": "native_function_decl",
+      "loc": @name(C4g)
+native idTest20();,
+      "name": {
+        "id": 58,
+        "kind": "id",
+        "loc": idTest20,
+        "text": "idTest20",
+      },
+      "nativeName": {
+        "id": 59,
+        "kind": "func_id",
+        "loc": C4g,
+        "text": "C4g",
+      },
+      "params": [],
+      "return": null,
+    },
+    {
+      "attributes": [],
+      "id": 63,
+      "kind": "native_function_decl",
+      "loc": @name(4C)
+native idTest21();,
+      "name": {
+        "id": 61,
+        "kind": "id",
+        "loc": idTest21,
+        "text": "idTest21",
+      },
+      "nativeName": {
+        "id": 62,
+        "kind": "func_id",
+        "loc": 4C,
+        "text": "4C",
+      },
+      "params": [],
+      "return": null,
+    },
+    {
+      "attributes": [],
+      "id": 66,
+      "kind": "native_function_decl",
+      "loc": @name(_0x0)
+native idTest22();,
+      "name": {
+        "id": 64,
+        "kind": "id",
+        "loc": idTest22,
+        "text": "idTest22",
+      },
+      "nativeName": {
+        "id": 65,
+        "kind": "func_id",
+        "loc": _0x0,
+        "text": "_0x0",
+      },
+      "params": [],
+      "return": null,
+    },
+    {
+      "attributes": [],
+      "id": 69,
+      "kind": "native_function_decl",
+      "loc": @name(_0)
+native idTest23();,
+      "name": {
+        "id": 67,
+        "kind": "id",
+        "loc": idTest23,
+        "text": "idTest23",
+      },
+      "nativeName": {
+        "id": 68,
+        "kind": "func_id",
+        "loc": _0,
+        "text": "_0",
       },
       "params": [],
       "return": null,

--- a/src/grammar/__snapshots__/grammar.spec.ts.snap
+++ b/src/grammar/__snapshots__/grammar.spec.ts.snap
@@ -71,12 +71,82 @@ Line 2, col 24:
 "
 `;
 
+exports[`grammar should fail funcid-native-fun-arith-operator 1`] = `
+"<unknown>:1:7: Parse error: expected not a funcInvalidId or "\`"
+
+Line 1, col 7:
+> 1 | @name(/)
+            ^
+  2 | native idTest();
+"
+`;
+
+exports[`grammar should fail funcid-native-fun-assign-operator 1`] = `
+"<unknown>:1:7: Parse error: expected not a funcInvalidId or "\`"
+
+Line 1, col 7:
+> 1 | @name(<<)
+            ^
+  2 | native idTest();
+"
+`;
+
+exports[`grammar should fail funcid-native-fun-bitwise-operator 1`] = `
+"<unknown>:1:8: Parse error: expected not (a whiteSpace or "(" or ")" or "," or "." or ";" or "~") or "\`"
+
+Line 1, col 8:
+> 1 | @name(~)
+             ^
+  2 | native idTest();
+"
+`;
+
 exports[`grammar should fail funcid-native-fun-comma 1`] = `
 "<unknown>:1:19: Parse error: expected ")"
 
 Line 1, col 19:
 > 1 | @name(send_message,then_terminate)
                         ^
+  2 | native idTest();
+"
+`;
+
+exports[`grammar should fail funcid-native-fun-comparison-operator 1`] = `
+"<unknown>:1:7: Parse error: expected not a funcInvalidId or "\`"
+
+Line 1, col 7:
+> 1 | @name(<=>)
+            ^
+  2 | native idTest();
+"
+`;
+
+exports[`grammar should fail funcid-native-fun-control-keyword 1`] = `
+"<unknown>:1:7: Parse error: expected not a funcInvalidId or "\`"
+
+Line 1, col 7:
+> 1 | @name(elseifnot)
+            ^
+  2 | native idTest();
+"
+`;
+
+exports[`grammar should fail funcid-native-fun-delimiter 1`] = `
+"<unknown>:1:7: Parse error: expected not a funcInvalidId or "\`"
+
+Line 1, col 7:
+> 1 | @name([)
+            ^
+  2 | native idTest();
+"
+`;
+
+exports[`grammar should fail funcid-native-fun-directive 1`] = `
+"<unknown>:1:7: Parse error: expected not a funcInvalidId or "\`"
+
+Line 1, col 7:
+> 1 | @name(#include)
+            ^
   2 | native idTest();
 "
 `;
@@ -91,18 +161,18 @@ Line 1, col 10:
 "
 `;
 
-exports[`grammar should fail funcid-native-fun-hash 1`] = `
-"<unknown>:1:7: Parse error: expected not ("\\"" or "{-" or "#")
+exports[`grammar should fail funcid-native-fun-keyword 1`] = `
+"<unknown>:1:7: Parse error: expected not a funcInvalidId or "\`"
 
 Line 1, col 7:
-> 1 | @name(#notInclude)
+> 1 | @name(global)
             ^
   2 | native idTest();
 "
 `;
 
 exports[`grammar should fail funcid-native-fun-multiline-comments 1`] = `
-"<unknown>:1:7: Parse error: expected not ("\\"" or "{-" or "#")
+"<unknown>:1:7: Parse error: expected not ("\\"" or "{-")
 
 Line 1, col 7:
 > 1 | @name({-aaa-})
@@ -112,71 +182,71 @@ Line 1, col 7:
 `;
 
 exports[`grammar should fail funcid-native-fun-number 1`] = `
-"<unknown>:1:10: Parse error: expected "_" or not (a whiteSpace or "(" or ")" or "," or "." or ";" or "~")
+"<unknown>:1:7: Parse error: expected not a funcInvalidId or "\`"
 
-Line 1, col 10:
+Line 1, col 7:
 > 1 | @name(123)
-               ^
+            ^
   2 | native idTest();
 "
 `;
 
 exports[`grammar should fail funcid-native-fun-number-decimal 1`] = `
-"<unknown>:1:8: Parse error: expected "_" or not (a whiteSpace or "(" or ")" or "," or "." or ";" or "~")
+"<unknown>:1:7: Parse error: expected not a funcInvalidId or "\`"
 
-Line 1, col 8:
+Line 1, col 7:
 > 1 | @name(0)
-             ^
+            ^
   2 | native idTest();
 "
 `;
 
 exports[`grammar should fail funcid-native-fun-number-hexadecimal 1`] = `
-"<unknown>:1:10: Parse error: expected "_" or not (a whiteSpace or "(" or ")" or "," or "." or ";" or "~")
+"<unknown>:1:7: Parse error: expected not a funcInvalidId or "\`"
 
-Line 1, col 10:
+Line 1, col 7:
 > 1 | @name(0x0)
-               ^
+            ^
   2 | native idTest();
 "
 `;
 
 exports[`grammar should fail funcid-native-fun-number-hexadecimal-2 1`] = `
-"<unknown>:1:17: Parse error: expected "_" or not (a whiteSpace or "(" or ")" or "," or "." or ";" or "~")
+"<unknown>:1:7: Parse error: expected not a funcInvalidId or "\`"
 
-Line 1, col 17:
+Line 1, col 7:
 > 1 | @name(0xDEADBEEF)
-                      ^
+            ^
   2 | native idTest();
 "
 `;
 
 exports[`grammar should fail funcid-native-fun-number-neg-decimal 1`] = `
-"<unknown>:1:9: Parse error: expected "_" or not (a whiteSpace or "(" or ")" or "," or "." or ";" or "~")
+"<unknown>:1:7: Parse error: expected not a funcInvalidId or "\`"
 
-Line 1, col 9:
+Line 1, col 7:
 > 1 | @name(-1)
-              ^
+            ^
   2 | native idTest();
 "
 `;
 
 exports[`grammar should fail funcid-native-fun-number-neg-hexadecimal 1`] = `
-"<unknown>:1:11: Parse error: expected "_" or not (a whiteSpace or "(" or ")" or "," or "." or ";" or "~")
+"<unknown>:1:7: Parse error: expected not a funcInvalidId or "\`"
 
-Line 1, col 11:
+Line 1, col 7:
 > 1 | @name(-0x0)
-                ^
+            ^
   2 | native idTest();
 "
 `;
 
 exports[`grammar should fail funcid-native-fun-only-underscore 1`] = `
-"<unknown>:1:8: Parse error: expected not (a whiteSpace or "(" or ")" or "," or "." or ";" or "~")
+"<unknown>:1:7: Parse error: expected not a funcInvalidId or "\`"
 
-Line 1, col 8:
+Line 1, col 7:
 > 1 | @name(_)
-             ^
+            ^
   2 | native idTest();
 "
 `;
@@ -212,10 +282,20 @@ Line 1, col 11:
 `;
 
 exports[`grammar should fail funcid-native-fun-string 1`] = `
-"<unknown>:1:7: Parse error: expected not ("\\"" or "{-" or "#")
+"<unknown>:1:7: Parse error: expected not ("\\"" or "{-")
 
 Line 1, col 7:
 > 1 | @name("not_a_string)
+            ^
+  2 | native idTest();
+"
+`;
+
+exports[`grammar should fail funcid-native-fun-type-keyword 1`] = `
+"<unknown>:1:7: Parse error: expected not a funcInvalidId or "\`"
+
+Line 1, col 7:
+> 1 | @name(->)
             ^
   2 | native idTest();
 "

--- a/src/grammar/__snapshots__/grammar.spec.ts.snap
+++ b/src/grammar/__snapshots__/grammar.spec.ts.snap
@@ -85,7 +85,7 @@ exports[`grammar should fail funcid-native-fun-assign-operator 1`] = `
 "<unknown>:1:7: Parse error: expected not a funcInvalidId or "\`"
 
 Line 1, col 7:
-> 1 | @name(<<)
+> 1 | @name(^>>=)
             ^
   2 | native idTest();
 "

--- a/src/grammar/__snapshots__/grammar.spec.ts.snap
+++ b/src/grammar/__snapshots__/grammar.spec.ts.snap
@@ -3861,7 +3861,7 @@ native testFunc(): Bool;,
 
 exports[`grammar should parse items-native-fun-funcid 1`] = `
 {
-  "id": 70,
+  "id": 76,
   "imports": [],
   "items": [
     {
@@ -4343,6 +4343,48 @@ native idTest23();,
         "kind": "func_id",
         "loc": _0,
         "text": "_0",
+      },
+      "params": [],
+      "return": null,
+    },
+    {
+      "attributes": [],
+      "id": 72,
+      "kind": "native_function_decl",
+      "loc": @name(hash#256)
+native idTest24();,
+      "name": {
+        "id": 70,
+        "kind": "id",
+        "loc": idTest24,
+        "text": "idTest24",
+      },
+      "nativeName": {
+        "id": 71,
+        "kind": "func_id",
+        "loc": hash#256,
+        "text": "hash#256",
+      },
+      "params": [],
+      "return": null,
+    },
+    {
+      "attributes": [],
+      "id": 75,
+      "kind": "native_function_decl",
+      "loc": @name(💀💀💀0xDEADBEEF💀💀💀)
+native idTest25();,
+      "name": {
+        "id": 73,
+        "kind": "id",
+        "loc": idTest25,
+        "text": "idTest25",
+      },
+      "nativeName": {
+        "id": 74,
+        "kind": "func_id",
+        "loc": 💀💀💀0xDEADBEEF💀💀💀,
+        "text": "💀💀💀0xDEADBEEF💀💀💀",
       },
       "params": [],
       "return": null,

--- a/src/grammar/__snapshots__/grammar.spec.ts.snap
+++ b/src/grammar/__snapshots__/grammar.spec.ts.snap
@@ -112,7 +112,7 @@ Line 1, col 7:
 `;
 
 exports[`grammar should fail funcid-native-fun-number 1`] = `
-"<unknown>:1:10: Parse error: expected not (a whiteSpace or "(" or ")" or "," or "." or ";" or "~")
+"<unknown>:1:10: Parse error: expected "_" or not (a whiteSpace or "(" or ")" or "," or "." or ";" or "~")
 
 Line 1, col 10:
 > 1 | @name(123)
@@ -122,7 +122,7 @@ Line 1, col 10:
 `;
 
 exports[`grammar should fail funcid-native-fun-number-decimal 1`] = `
-"<unknown>:1:8: Parse error: expected not (a whiteSpace or "(" or ")" or "," or "." or ";" or "~")
+"<unknown>:1:8: Parse error: expected "_" or not (a whiteSpace or "(" or ")" or "," or "." or ";" or "~")
 
 Line 1, col 8:
 > 1 | @name(0)
@@ -132,7 +132,7 @@ Line 1, col 8:
 `;
 
 exports[`grammar should fail funcid-native-fun-number-hexadecimal 1`] = `
-"<unknown>:1:10: Parse error: expected not (a whiteSpace or "(" or ")" or "," or "." or ";" or "~")
+"<unknown>:1:10: Parse error: expected "_" or not (a whiteSpace or "(" or ")" or "," or "." or ";" or "~")
 
 Line 1, col 10:
 > 1 | @name(0x0)
@@ -142,7 +142,7 @@ Line 1, col 10:
 `;
 
 exports[`grammar should fail funcid-native-fun-number-hexadecimal-2 1`] = `
-"<unknown>:1:17: Parse error: expected not (a whiteSpace or "(" or ")" or "," or "." or ";" or "~")
+"<unknown>:1:17: Parse error: expected "_" or not (a whiteSpace or "(" or ")" or "," or "." or ";" or "~")
 
 Line 1, col 17:
 > 1 | @name(0xDEADBEEF)
@@ -152,7 +152,7 @@ Line 1, col 17:
 `;
 
 exports[`grammar should fail funcid-native-fun-number-neg-decimal 1`] = `
-"<unknown>:1:9: Parse error: expected not (a whiteSpace or "(" or ")" or "," or "." or ";" or "~")
+"<unknown>:1:9: Parse error: expected "_" or not (a whiteSpace or "(" or ")" or "," or "." or ";" or "~")
 
 Line 1, col 9:
 > 1 | @name(-1)
@@ -162,7 +162,7 @@ Line 1, col 9:
 `;
 
 exports[`grammar should fail funcid-native-fun-number-neg-hexadecimal 1`] = `
-"<unknown>:1:11: Parse error: expected not (a whiteSpace or "(" or ")" or "," or "." or ";" or "~")
+"<unknown>:1:11: Parse error: expected "_" or not (a whiteSpace or "(" or ")" or "," or "." or ";" or "~")
 
 Line 1, col 11:
 > 1 | @name(-0x0)
@@ -3861,7 +3861,7 @@ native testFunc(): Bool;,
 
 exports[`grammar should parse items-native-fun-funcid 1`] = `
 {
-  "id": 76,
+  "id": 112,
   "imports": [],
   "items": [
     {
@@ -4351,7 +4351,7 @@ native idTest23();,
       "attributes": [],
       "id": 72,
       "kind": "native_function_decl",
-      "loc": @name(hash#256)
+      "loc": @name(0x_)
 native idTest24();,
       "name": {
         "id": 70,
@@ -4362,8 +4362,8 @@ native idTest24();,
       "nativeName": {
         "id": 71,
         "kind": "func_id",
-        "loc": hash#256,
-        "text": "hash#256",
+        "loc": 0x_,
+        "text": "0x_",
       },
       "params": [],
       "return": null,
@@ -4372,7 +4372,7 @@ native idTest24();,
       "attributes": [],
       "id": 75,
       "kind": "native_function_decl",
-      "loc": @name(💀💀💀0xDEADBEEF💀💀💀)
+      "loc": @name(0x0_)
 native idTest25();,
       "name": {
         "id": 73,
@@ -4383,8 +4383,260 @@ native idTest25();,
       "nativeName": {
         "id": 74,
         "kind": "func_id",
+        "loc": 0x0_,
+        "text": "0x0_",
+      },
+      "params": [],
+      "return": null,
+    },
+    {
+      "attributes": [],
+      "id": 78,
+      "kind": "native_function_decl",
+      "loc": @name(0_)
+native idTest26();,
+      "name": {
+        "id": 76,
+        "kind": "id",
+        "loc": idTest26,
+        "text": "idTest26",
+      },
+      "nativeName": {
+        "id": 77,
+        "kind": "func_id",
+        "loc": 0_,
+        "text": "0_",
+      },
+      "params": [],
+      "return": null,
+    },
+    {
+      "attributes": [],
+      "id": 81,
+      "kind": "native_function_decl",
+      "loc": @name(hash#256)
+native idTest27();,
+      "name": {
+        "id": 79,
+        "kind": "id",
+        "loc": idTest27,
+        "text": "idTest27",
+      },
+      "nativeName": {
+        "id": 80,
+        "kind": "func_id",
+        "loc": hash#256,
+        "text": "hash#256",
+      },
+      "params": [],
+      "return": null,
+    },
+    {
+      "attributes": [],
+      "id": 84,
+      "kind": "native_function_decl",
+      "loc": @name(💀💀💀0xDEADBEEF💀💀💀)
+native idTest28();,
+      "name": {
+        "id": 82,
+        "kind": "id",
+        "loc": idTest28,
+        "text": "idTest28",
+      },
+      "nativeName": {
+        "id": 83,
+        "kind": "func_id",
         "loc": 💀💀💀0xDEADBEEF💀💀💀,
         "text": "💀💀💀0xDEADBEEF💀💀💀",
+      },
+      "params": [],
+      "return": null,
+    },
+    {
+      "attributes": [],
+      "id": 87,
+      "kind": "native_function_decl",
+      "loc": @name(__tact_verify_address)
+native idTest29();,
+      "name": {
+        "id": 85,
+        "kind": "id",
+        "loc": idTest29,
+        "text": "idTest29",
+      },
+      "nativeName": {
+        "id": 86,
+        "kind": "func_id",
+        "loc": __tact_verify_address,
+        "text": "__tact_verify_address",
+      },
+      "params": [],
+      "return": null,
+    },
+    {
+      "attributes": [],
+      "id": 90,
+      "kind": "native_function_decl",
+      "loc": @name(__tact_pow2)
+native idTest30();,
+      "name": {
+        "id": 88,
+        "kind": "id",
+        "loc": idTest30,
+        "text": "idTest30",
+      },
+      "nativeName": {
+        "id": 89,
+        "kind": "func_id",
+        "loc": __tact_pow2,
+        "text": "__tact_pow2",
+      },
+      "params": [],
+      "return": null,
+    },
+    {
+      "attributes": [],
+      "id": 93,
+      "kind": "native_function_decl",
+      "loc": @name(randomize_lt)
+native idTest31();,
+      "name": {
+        "id": 91,
+        "kind": "id",
+        "loc": idTest31,
+        "text": "idTest31",
+      },
+      "nativeName": {
+        "id": 92,
+        "kind": "func_id",
+        "loc": randomize_lt,
+        "text": "randomize_lt",
+      },
+      "params": [],
+      "return": null,
+    },
+    {
+      "attributes": [],
+      "id": 96,
+      "kind": "native_function_decl",
+      "loc": @name(fixed248::asin)
+native idTest32();,
+      "name": {
+        "id": 94,
+        "kind": "id",
+        "loc": idTest32,
+        "text": "idTest32",
+      },
+      "nativeName": {
+        "id": 95,
+        "kind": "func_id",
+        "loc": fixed248::asin,
+        "text": "fixed248::asin",
+      },
+      "params": [],
+      "return": null,
+    },
+    {
+      "attributes": [],
+      "id": 99,
+      "kind": "native_function_decl",
+      "loc": @name(fixed248::nrand_fast)
+native idTest33();,
+      "name": {
+        "id": 97,
+        "kind": "id",
+        "loc": idTest33,
+        "text": "idTest33",
+      },
+      "nativeName": {
+        "id": 98,
+        "kind": "func_id",
+        "loc": fixed248::nrand_fast,
+        "text": "fixed248::nrand_fast",
+      },
+      "params": [],
+      "return": null,
+    },
+    {
+      "attributes": [],
+      "id": 102,
+      "kind": "native_function_decl",
+      "loc": @name(atan_f261_inlined)
+native idTest34();,
+      "name": {
+        "id": 100,
+        "kind": "id",
+        "loc": idTest34,
+        "text": "idTest34",
+      },
+      "nativeName": {
+        "id": 101,
+        "kind": "func_id",
+        "loc": atan_f261_inlined,
+        "text": "atan_f261_inlined",
+      },
+      "params": [],
+      "return": null,
+    },
+    {
+      "attributes": [],
+      "id": 105,
+      "kind": "native_function_decl",
+      "loc": @name(~impure_touch)
+native idTest35();,
+      "name": {
+        "id": 103,
+        "kind": "id",
+        "loc": idTest35,
+        "text": "idTest35",
+      },
+      "nativeName": {
+        "id": 104,
+        "kind": "func_id",
+        "loc": ~impure_touch,
+        "text": "~impure_touch",
+      },
+      "params": [],
+      "return": null,
+    },
+    {
+      "attributes": [],
+      "id": 108,
+      "kind": "native_function_decl",
+      "loc": @name(~udict::delete_get_min)
+native idTest36();,
+      "name": {
+        "id": 106,
+        "kind": "id",
+        "loc": idTest36,
+        "text": "idTest36",
+      },
+      "nativeName": {
+        "id": 107,
+        "kind": "func_id",
+        "loc": ~udict::delete_get_min,
+        "text": "~udict::delete_get_min",
+      },
+      "params": [],
+      "return": null,
+    },
+    {
+      "attributes": [],
+      "id": 111,
+      "kind": "native_function_decl",
+      "loc": @name(.something)
+native idTest37();,
+      "name": {
+        "id": 109,
+        "kind": "id",
+        "loc": idTest37,
+        "text": "idTest37",
+      },
+      "nativeName": {
+        "id": 110,
+        "kind": "func_id",
+        "loc": .something,
+        "text": ".something",
       },
       "params": [],
       "return": null,

--- a/src/grammar/__snapshots__/grammar.spec.ts.snap
+++ b/src/grammar/__snapshots__/grammar.spec.ts.snap
@@ -3941,7 +3941,7 @@ native testFunc(): Bool;,
 
 exports[`grammar should parse items-native-fun-funcid 1`] = `
 {
-  "id": 118,
+  "id": 124,
   "imports": [],
   "items": [
     {
@@ -4759,6 +4759,48 @@ native idTest39();,
         "kind": "func_id",
         "loc": ❤️❤️❤️thanks❤️❤️❤️,
         "text": "❤️❤️❤️thanks❤️❤️❤️",
+      },
+      "params": [],
+      "return": null,
+    },
+    {
+      "attributes": [],
+      "id": 120,
+      "kind": "native_function_decl",
+      "loc": @name(intslice)
+native idTest40();,
+      "name": {
+        "id": 118,
+        "kind": "id",
+        "loc": idTest40,
+        "text": "idTest40",
+      },
+      "nativeName": {
+        "id": 119,
+        "kind": "func_id",
+        "loc": intslice,
+        "text": "intslice",
+      },
+      "params": [],
+      "return": null,
+    },
+    {
+      "attributes": [],
+      "id": 123,
+      "kind": "native_function_decl",
+      "loc": @name(int2)
+native idTest40();,
+      "name": {
+        "id": 121,
+        "kind": "id",
+        "loc": idTest40,
+        "text": "idTest40",
+      },
+      "nativeName": {
+        "id": 122,
+        "kind": "func_id",
+        "loc": int2,
+        "text": "int2",
       },
       "params": [],
       "return": null,

--- a/src/grammar/__snapshots__/grammar.spec.ts.snap
+++ b/src/grammar/__snapshots__/grammar.spec.ts.snap
@@ -92,7 +92,7 @@ Line 1, col 7:
 `;
 
 exports[`grammar should fail funcid-native-fun-bitwise-operator 1`] = `
-"<unknown>:1:8: Parse error: expected not (a whiteSpace or "(" or ")" or "," or "." or ";" or "~") or "\`"
+"<unknown>:1:8: Parse error: expected not (a whiteSpace or "(" or ")" or "[" or "]" or "," or "." or ";" or "~") or "\`"
 
 Line 1, col 8:
 > 1 | @name(~)
@@ -276,6 +276,16 @@ exports[`grammar should fail funcid-native-fun-space 1`] = `
 
 Line 1, col 11:
 > 1 | @name(foo foo)
+                ^
+  2 | native idTest();
+"
+`;
+
+exports[`grammar should fail funcid-native-fun-square-brackets 1`] = `
+"<unknown>:1:11: Parse error: expected ")"
+
+Line 1, col 11:
+> 1 | @name(take[some]entry)
                 ^
   2 | native idTest();
 "

--- a/src/grammar/grammar.ohm
+++ b/src/grammar/grammar.ohm
@@ -284,7 +284,7 @@ Tact {
                   | ("-"? digit+) ")" --notDecimalNumber
                   | ("-"? "0x" hexDigit+) ")" --notHexadecimalNumber
 
-    funcPlainId = ~funcInvalidId (~(whiteSpace | "(" | ")" | "," | "." | ";" | "~") any)+
+    funcPlainId = ~funcInvalidId (~(whiteSpace | "(" | ")" | "[" | "]" | "," | "." | ";" | "~") any)+
 
     funcQuotedId = "`" (~("`" | "\n") any)+ "`"
 

--- a/src/grammar/grammar.ohm
+++ b/src/grammar/grammar.ohm
@@ -263,12 +263,12 @@ Tact {
     id = ~reservedWord #idStart #(idPart*)
 
     // FunC identifiers, where `funcId` stands for FunC function identifier
-    // The plain identifier cannot be a single underscore nor just a number
-    funcPlainId = "_"? "-"? "0x"? hexDigit* ~hexDigit (~(whiteSpace | "(" | ")" | "," | "." | ";" | "~") any)+
+    // A plain identifier cannot be a number or a single underscore
+    funcPlainId = ("-"? "0x" hexDigit+ ~hexDigit)? ("-"? digit+ ~digit)? "_"? (~(whiteSpace | "(" | ")" | "," | "." | ";" | "~") any)+
 
     funcQuotedId = "`" (~("`" | "\n") any)+ "`"
 
-    funcId = ~("\"" | "{-") ("." | "~")? (funcQuotedId | funcPlainId)
+    funcId = ~("\"" | "{-" | "#") ("." | "~")? (funcQuotedId | funcPlainId)
 
     // Boolean literals
     boolLiteral = ("true" | "false") ~idPart

--- a/src/grammar/grammar.ohm
+++ b/src/grammar/grammar.ohm
@@ -264,11 +264,21 @@ Tact {
 
     // FunC identifiers, where `funcId` stands for FunC function identifier
     // A plain identifier cannot be a number or a single underscore
-    funcPlainId = ("-"? "0x" hexDigit+ ~hexDigit)? ("-"? digit+ ~digit)? "_"? (~(whiteSpace | "(" | ")" | "," | "." | ";" | "~") any)+
+    funcPlainId = ("-"? "0x" hexDigit+ ~hexDigit)? ("-"? digit+ ~digit)? "_"? (~(whiteSpace | "(" | ")" | "," | "." | ";" | "~") any)+ --generic
+                | "-"? "0x" hexDigit* "_" --justHexUnderscore
+                | "-"? digit+ "_" --justDecUnderscore
 
     funcQuotedId = "`" (~("`" | "\n") any)+ "`"
 
     funcId = ~("\"" | "{-" | "#") ("." | "~")? (funcQuotedId | funcPlainId)
+
+    /*
+      NOTE(novusnota):
+
+      FunC can parse much more than Fift can handle. For example, _0x0 and _0 are valid identifiers in FunC, and using either of them compiles and is then interpreted fine by Fift. But if you use both, FunC still compiles, but Fift crashes.
+
+      Same goes for plain identifiers using hashes # or emojis — you can have one FunC function with any of those combinations of characters, but you (generally) cannot have two or more of such functions.
+    */
 
     // Boolean literals
     boolLiteral = ("true" | "false") ~idPart

--- a/src/grammar/grammar.ohm
+++ b/src/grammar/grammar.ohm
@@ -273,8 +273,6 @@ Tact {
     funcId = ~("\"" | "{-" | "#") ("." | "~")? (funcQuotedId | funcPlainId)
 
     /*
-      NOTE(novusnota):
-
       FunC can parse much more than Fift can handle. For example, _0x0 and _0 are valid identifiers in FunC, and using either of them compiles and is then interpreted fine by Fift. But if you use both, FunC still compiles, but Fift crashes.
 
       Same goes for plain identifiers using hashes # or emojis — you can have one FunC function with any of those combinations of characters, but you (generally) cannot have two or more of such functions.

--- a/src/grammar/grammar.ohm
+++ b/src/grammar/grammar.ohm
@@ -269,7 +269,7 @@ Tact {
     // Order of inner alternations matters
     funcInvalidId = "_" ")" --notUnderscore
                   | ("+" | "-" | "*" | "/%" | "/" | "%" | "~/" | "^/" | "~%" | "^%") ")" --notArithOperator
-                  | ("<=>" | "<=" | "<" | ">" | "=>" | "!=" | "==") ")" --notComparisonOperator
+                  | ("<=>" | "<=" | "<" | ">=" | ">" | "!=" | "==") ")" --notComparisonOperator
                   | ("~>>" | "~" | "^>>" | "^" | "&" | "|" | "<<" | ">>" ) ")" --notBitwiseOperator
                   | ("=" | "+=" | "-=" | "*=" | "/=" | "%="
                          | "~>>=" | "~/=" | "~%=" | "^>>=" | "^/=" | "^%=" | "^="

--- a/src/grammar/grammar.ohm
+++ b/src/grammar/grammar.ohm
@@ -263,14 +263,32 @@ Tact {
     id = ~reservedWord #idStart #(idPart*)
 
     // FunC identifiers, where `funcId` stands for FunC function identifier
-    // A plain identifier cannot be a number or a single underscore
-    funcPlainId = ("-"? "0x" hexDigit+ ~hexDigit)? ("-"? digit+ ~digit)? "_"? (~(whiteSpace | "(" | ")" | "," | "." | ";" | "~") any)+ --generic
-                | "-"? "0x" hexDigit* "_" --justHexUnderscore
-                | "-"? digit+ "_" --justDecUnderscore
+    // A plain identifier cannot be a number, a single underscore, an operator, a keyword or a compiler directive
+    // See: https://github.com/ton-blockchain/ton/blob/master/crypto/func/keywords.cpp
+
+    // Order of inner alternations matters
+    funcInvalidId = "_" ")" --notUnderscore
+                  | ("+" | "-" | "*" | "/%" | "/" | "%" | "~/" | "^/" | "~%" | "^%") ")" --notArithOperator
+                  | ("<=>" | "<=" | "<" | ">" | "=>" | "!=" | "==") ")" --notComparisonOperator
+                  | ("~>>" | "~" | "^>>" | "^" | "&" | "|" | "<<" | ">>" ) ")" --notBitwiseOperator
+                  | ("=" | "+=" | "-=" | "*=" | "/=" | "%="
+                         | "~>>=" | "~/=" | "~%=" | "^>>=" | "^/=" | "^%=" | "^="
+                         | "<<=" | ">>=" | "&=" | "|=") ")" --notAssignOperator
+                  | ("[" | "]" | "{" | "}" | "?" | ":") ")" --notDelimiter
+                  | ("return" | "var" | "repeat" | "do" | "while" | "until" | "try" | "catch"
+                              | "ifnot" | "if" | "then" | "elseifnot" | "elseif" | "else") ")" --notControlKeyword
+                  | ("int" | "cell" | "builder" | "slice" | "cont" | "tuple" | "type" | "->" | "forall") ")" --notTypeKeyword
+                  | ("extern" | "global" | "asm" | "impure" | "inline_ref" | "inline" | "auto_apply" | "method_id"
+                              | "operator" | "infixl" | "infixr" | "infix" | "const") ")" --notKeyword
+                  | ("#include" | "#pragma") ")" --notDirective
+                  | ("-"? digit+) ")" --notDecimalNumber
+                  | ("-"? "0x" hexDigit+) ")" --notHexadecimalNumber
+
+    funcPlainId = ~funcInvalidId (~(whiteSpace | "(" | ")" | "," | "." | ";" | "~") any)+
 
     funcQuotedId = "`" (~("`" | "\n") any)+ "`"
 
-    funcId = ~("\"" | "{-" | "#") ("." | "~")? (funcQuotedId | funcPlainId)
+    funcId = ~("\"" | "{-") ("." | "~")? (funcQuotedId | funcPlainId)
 
     /*
       FunC can parse much more than Fift can handle. For example, _0x0 and _0 are valid identifiers in FunC, and using either of them compiles and is then interpreted fine by Fift. But if you use both, FunC still compiles, but Fift crashes.

--- a/src/grammar/test-failed/funcid-native-fun-arith-operator.tact
+++ b/src/grammar/test-failed/funcid-native-fun-arith-operator.tact
@@ -1,0 +1,2 @@
+@name(/)
+native idTest();

--- a/src/grammar/test-failed/funcid-native-fun-assign-operator.tact
+++ b/src/grammar/test-failed/funcid-native-fun-assign-operator.tact
@@ -1,0 +1,2 @@
+@name(^>>=)
+native idTest();

--- a/src/grammar/test-failed/funcid-native-fun-bitwise-operator.tact
+++ b/src/grammar/test-failed/funcid-native-fun-bitwise-operator.tact
@@ -1,0 +1,2 @@
+@name(~)
+native idTest();

--- a/src/grammar/test-failed/funcid-native-fun-comparison-operator.tact
+++ b/src/grammar/test-failed/funcid-native-fun-comparison-operator.tact
@@ -1,0 +1,2 @@
+@name(<=>)
+native idTest();

--- a/src/grammar/test-failed/funcid-native-fun-control-keyword.tact
+++ b/src/grammar/test-failed/funcid-native-fun-control-keyword.tact
@@ -1,0 +1,2 @@
+@name(elseifnot)
+native idTest();

--- a/src/grammar/test-failed/funcid-native-fun-delimiter.tact
+++ b/src/grammar/test-failed/funcid-native-fun-delimiter.tact
@@ -1,0 +1,2 @@
+@name([)
+native idTest();

--- a/src/grammar/test-failed/funcid-native-fun-directive.tact
+++ b/src/grammar/test-failed/funcid-native-fun-directive.tact
@@ -1,0 +1,2 @@
+@name(#include)
+native idTest();

--- a/src/grammar/test-failed/funcid-native-fun-hash.tact
+++ b/src/grammar/test-failed/funcid-native-fun-hash.tact
@@ -1,2 +1,0 @@
-@name(#notInclude)
-native idTest();

--- a/src/grammar/test-failed/funcid-native-fun-hash.tact
+++ b/src/grammar/test-failed/funcid-native-fun-hash.tact
@@ -1,0 +1,2 @@
+@name(#notInclude)
+native idTest();

--- a/src/grammar/test-failed/funcid-native-fun-keyword.tact
+++ b/src/grammar/test-failed/funcid-native-fun-keyword.tact
@@ -1,0 +1,2 @@
+@name(global)
+native idTest();

--- a/src/grammar/test-failed/funcid-native-fun-number-hexadecimal-2.tact
+++ b/src/grammar/test-failed/funcid-native-fun-number-hexadecimal-2.tact
@@ -1,0 +1,2 @@
+@name(0xDEADBEEF)
+native idTest();

--- a/src/grammar/test-failed/funcid-native-fun-number-neg-decimal.tact
+++ b/src/grammar/test-failed/funcid-native-fun-number-neg-decimal.tact
@@ -1,0 +1,2 @@
+@name(-1)
+native idTest();

--- a/src/grammar/test-failed/funcid-native-fun-number-neg-hexadecimal.tact
+++ b/src/grammar/test-failed/funcid-native-fun-number-neg-hexadecimal.tact
@@ -1,0 +1,2 @@
+@name(-0x0)
+native idTest();

--- a/src/grammar/test-failed/funcid-native-fun-square-brackets.tact
+++ b/src/grammar/test-failed/funcid-native-fun-square-brackets.tact
@@ -1,0 +1,2 @@
+@name(take[some]entry)
+native idTest();

--- a/src/grammar/test-failed/funcid-native-fun-type-keyword.tact
+++ b/src/grammar/test-failed/funcid-native-fun-type-keyword.tact
@@ -1,0 +1,2 @@
+@name(->)
+native idTest();

--- a/src/grammar/test/items-native-fun-funcid.tact
+++ b/src/grammar/test/items-native-fun-funcid.tact
@@ -64,6 +64,8 @@ native idTest21();
 // Fun fact:
 // Individually, _0x0 and _0 are totally valid identifiers in FunC, and the resulting Fift works fine too.
 // But if they're together, FunC still compiles, but Fift interpreter cannot deal with that and crashes.
+// Same goes for identifiers using hashes # or emojis.
+// I.e., you can have a function with any of those combinations of characters, but only one.
 
 @name(_0x0)
 native idTest22();
@@ -78,3 +80,9 @@ native idTest23();
 //
 // I decided not to fix these peculiar cases, as the RegEx gets absolutely wild. Also, these are super-weird identifiers,
 // which have a big chance of breaking once the Fift interpreter comes into play, as described in the "Fun fact" paragraph above.
+
+@name(hash#256)
+native idTest24();
+
+@name(💀💀💀0xDEADBEEF💀💀💀)
+native idTest25();

--- a/src/grammar/test/items-native-fun-funcid.tact
+++ b/src/grammar/test/items-native-fun-funcid.tact
@@ -114,3 +114,9 @@ native idTest36();
 
 @name(.something)
 native idTest37();
+
+@name(f̷̨͈͚́͌̀i̵̩͔̭̐͐̊n̸̟̝̻̩̎̓͋̕e̸̝̙̒̿͒̾̕)
+native idTest38();
+
+@name(❤️❤️❤️thanks❤️❤️❤️)
+native idTest39();

--- a/src/grammar/test/items-native-fun-funcid.tact
+++ b/src/grammar/test/items-native-fun-funcid.tact
@@ -51,3 +51,30 @@ native idTest17();
 
 @name(`any symbols ; ~ () are allowed here...`)
 native idTest18();
+
+@name(C4)
+native idTest19();
+
+@name(C4g)
+native idTest20();
+
+@name(4C)
+native idTest21();
+
+// Fun fact:
+// Individually, _0x0 and _0 are totally valid identifiers in FunC, and the resulting Fift works fine too.
+// But if they're together, FunC still compiles, but Fift interpreter cannot deal with that and crashes.
+
+@name(_0x0)
+native idTest22();
+
+@name(_0)
+native idTest23();
+
+// NOTE(novusnota):
+// There is a only small set of cases related to the above that our parser won't parse, but C++ FunC's will:
+// The hexadecimal or decimal number, followed immediately by a single underscore.
+// It can look like: 0x0_, for example. Or like: 9000_.
+//
+// I decided not to fix these peculiar cases, as the RegEx gets absolutely wild. Also, these are super-weird identifiers,
+// which have a big chance of breaking once the Fift interpreter comes into play, as described in the "Fun fact" paragraph above.

--- a/src/grammar/test/items-native-fun-funcid.tact
+++ b/src/grammar/test/items-native-fun-funcid.tact
@@ -120,3 +120,9 @@ native idTest38();
 
 @name(❤️❤️❤️thanks❤️❤️❤️)
 native idTest39();
+
+@name(intslice)
+native idTest40();
+
+@name(int2)
+native idTest40();

--- a/src/grammar/test/items-native-fun-funcid.tact
+++ b/src/grammar/test/items-native-fun-funcid.tact
@@ -73,16 +73,44 @@ native idTest22();
 @name(_0)
 native idTest23();
 
-// NOTE(novusnota):
-// There is a only small set of cases related to the above that our parser won't parse, but C++ FunC's will:
-// The hexadecimal or decimal number, followed immediately by a single underscore.
-// It can look like: 0x0_, for example. Or like: 9000_.
-//
-// I decided not to fix these peculiar cases, as the RegEx gets absolutely wild. Also, these are super-weird identifiers,
-// which have a big chance of breaking once the Fift interpreter comes into play, as described in the "Fun fact" paragraph above.
-
-@name(hash#256)
+@name(0x_)
 native idTest24();
 
-@name(💀💀💀0xDEADBEEF💀💀💀)
+@name(0x0_)
 native idTest25();
+
+@name(0_)
+native idTest26();
+
+@name(hash#256)
+native idTest27();
+
+@name(💀💀💀0xDEADBEEF💀💀💀)
+native idTest28();
+
+@name(__tact_verify_address)
+native idTest29();
+
+@name(__tact_pow2)
+native idTest30();
+
+@name(randomize_lt)
+native idTest31();
+
+@name(fixed248::asin)
+native idTest32();
+
+@name(fixed248::nrand_fast)
+native idTest33();
+
+@name(atan_f261_inlined)
+native idTest34();
+
+@name(~impure_touch)
+native idTest35();
+
+@name(~udict::delete_get_min)
+native idTest36();
+
+@name(.something)
+native idTest37();


### PR DESCRIPTION
That took a looooooooot of RegEx iterations.

Closes #635

<!--
IMPORTANT:
If your PR doesn't close a particular issue, please, create the issue first and describe the whole context: what you're adding/changing and why you're doing so. And only then open the Pull Request, which would close that issue!

In case you are adding a new language feature, a standard library function or introducing other user-facing changes, you need to document them via a new PR to tact-docs.
-->

- [x] I have updated CHANGELOG.md
~~- [ ] I have documented my contribution in Tact Docs: https://github.com/tact-lang/tact-docs/pull/PR-NUMBER~~
- [x] I have added tests to demonstrate the contribution is correctly implemented: this usually includes both positive and negative tests, showing the happy path(s) and featuring intentionally broken cases
- [x] I have run all the tests locally and no test failure was reported
- [x] I have run the linter, formatter and spellchecker
- [x] I did not do unrelated and/or undiscussed refactorings
