### PR TITLE
Use the `ILogger` interface in the API functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Removed unsupported iterators API: PR [#633](https://github.com/tact-lang/tact/pull/633)
 - Created a separate API function to enable compiler features: PR [#647](https://github.com/tact-lang/tact/pull/647)
+- Use the `ILogger` interface to enable API users implement their own loggers: PR [#668](https://github.com/tact-lang/tact/pull/668)
 
 ### Fixed
 

--- a/scripts/prepare.ts
+++ b/scripts/prepare.ts
@@ -71,7 +71,7 @@ void (async () => {
                                 content: code,
                             },
                         ],
-                        logger: logger,
+                        logger,
                     });
                     if (!c.ok) {
                         logger.error(c.log);

--- a/src/browser.ts
+++ b/src/browser.ts
@@ -1,12 +1,12 @@
 import { Config, verifyConfig } from "./config/parseConfig";
-import { Logger } from "./logger";
+import { ILogger } from "./logger";
 import { build } from "./pipeline/build";
 import { createVirtualFileSystem } from "./vfs/createVirtualFileSystem";
 
 export async function run(args: {
     config: Config;
     files: Record<string, string>;
-    logger?: Logger;
+    logger?: ILogger;
 }) {
     // Verify config
     const config = verifyConfig(args.config);

--- a/src/func/funcCompile.ts
+++ b/src/func/funcCompile.ts
@@ -1,4 +1,4 @@
-import { Logger } from "../logger";
+import { ILogger } from "../logger";
 
 // Wasm Imports
 // eslint-disable-next-line @typescript-eslint/no-var-requires
@@ -59,7 +59,7 @@ type CompileResult =
 export async function funcCompile(args: {
     entries: string[];
     sources: { path: string; content: string }[];
-    logger: Logger;
+    logger: ILogger;
 }): Promise<FuncCompilationResult> {
     // Parameters
     const files: string[] = args.entries;

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -13,14 +13,18 @@ export enum LogLevel {
 
 type messageType = string | Error;
 
-export interface LogMethods {
+/**
+ * Interface defining the logging methods used by the `Logger` class, enabling
+ * custom logger implementations.
+ */
+export interface ILogger {
     debug: (message: messageType) => void;
     info: (message: messageType) => void;
     warn: (message: messageType) => void;
     error: (message: messageType) => void;
 }
 
-const logLevelToMethodName: { [key in LogLevel]: keyof LogMethods | null } = {
+const logLevelToMethodName: { [key in LogLevel]: keyof ILogger | null } = {
     [LogLevel.NONE]: null,
     [LogLevel.ERROR]: "error",
     [LogLevel.WARN]: "warn",
@@ -28,13 +32,13 @@ const logLevelToMethodName: { [key in LogLevel]: keyof LogMethods | null } = {
     [LogLevel.DEBUG]: "debug",
 };
 
-function getLoggingMethod(level: LogLevel): keyof LogMethods | null {
+function getLoggingMethod(level: LogLevel): keyof ILogger | null {
     return logLevelToMethodName[level];
 }
 
 export class Logger {
     private level: LogLevel;
-    private logMethods: LogMethods;
+    private logMethods: ILogger;
 
     constructor(level: LogLevel = LogLevel.INFO) {
         this.level = level;

--- a/src/pipeline/build.ts
+++ b/src/pipeline/build.ts
@@ -8,7 +8,7 @@ import { funcCompile } from "../func/funcCompile";
 import { writeReport } from "../generator/writeReport";
 import { getRawAST } from "../grammar/store";
 import files from "../imports/stdlib";
-import { Logger } from "../logger";
+import { ILogger, Logger } from "../logger";
 import { PackageFileFormat } from "../packaging/fileFormat";
 import { packageCode } from "../packaging/packageCode";
 import { createABITypeRefFromTypeRef } from "../types/resolveABITypeRef";
@@ -24,7 +24,7 @@ import { TactErrorCollection } from "../errors";
 
 export function enableFeatures(
     ctx: CompilerContext,
-    logger: Logger,
+    logger: ILogger,
     config: ConfigProject,
 ): CompilerContext {
     if (config.options === undefined) {
@@ -51,14 +51,14 @@ export async function build(args: {
     config: ConfigProject;
     project: VirtualFileSystem;
     stdlib: string | VirtualFileSystem;
-    logger?: Logger;
+    logger?: ILogger;
 }): Promise<{ ok: boolean; error: TactErrorCollection[] }> {
     const { config, project } = args;
     const stdlib =
         typeof args.stdlib === "string"
             ? createVirtualFileSystem(args.stdlib, files)
             : args.stdlib;
-    const logger: Logger = args.logger ?? new Logger();
+    const logger: ILogger = args.logger ?? new Logger();
 
     // Configure context
     let ctx: CompilerContext = new CompilerContext({ shared: {} });

--- a/src/verify.ts
+++ b/src/verify.ts
@@ -1,7 +1,7 @@
 import normalize from "path-normalize";
 import { Cell } from "@ton/core";
 import { Config, Options } from "./config/parseConfig";
-import { Logger } from "./logger";
+import { ILogger, Logger } from "./logger";
 import { PackageFileFormat, run } from "./main";
 import { fileFormat } from "./packaging/fileFormat";
 import { getCompilerVersion } from "./pipeline/version";
@@ -24,9 +24,9 @@ export type VerifyResult =
 
 export async function verify(args: {
     pkg: string;
-    logger?: Logger | null | undefined;
+    logger?: ILogger | null | undefined;
 }): Promise<VerifyResult> {
-    const logger = args.logger ?? new Logger();
+    const logger: ILogger = args.logger ?? new Logger();
 
     // Loading package
     let unpacked: PackageFileFormat;


### PR DESCRIPTION
This will enable third-party tools use their own logger implementations.

Closes #648

<!--
IMPORTANT:
If your PR doesn't close a particular issue, please, create the issue first and describe the whole context: what you're adding/changing and why you're doing so. And only then open the Pull Request, which would close that issue!

In case you are adding a new language feature, a standard library function or introducing other user-facing changes, you need to document them via a new PR to tact-docs.
-->

- [x] I have updated CHANGELOG.md
- [ ] ~~I have documented my contribution in Tact Docs: https://github.com/tact-lang/tact-docs/pull/PR-NUMBER~~
- [ ] ~~I have added tests to demonstrate the contribution is correctly implemented: this usually includes both positive and negative tests, showing the happy path(s) and featuring intentionally broken cases~~
- [x] I have run all the tests locally and no test failure was reported
- [x] I have run the linter, formatter and spellchecker
- [x] I did not do unrelated and/or undiscussed refactorings
