### PR TITLE
Throw internal/compiler errors instead `Error` when possible

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Removed unsupported iterators API: PR [#633](https://github.com/tact-lang/tact/pull/633)
 - Created a separate API function to enable compiler features: PR [#647](https://github.com/tact-lang/tact/pull/647)
 - Use the `ILogger` interface to enable API users implement their own loggers: PR [#668](https://github.com/tact-lang/tact/pull/668)
+- Use specific Internal or Compiler errors when throwing exceptions: PR [#669](https://github.com/tact-lang/tact/pull/669)
 
 ### Fixed
 

--- a/src/bindings/typescript/serializers.ts
+++ b/src/bindings/typescript/serializers.ts
@@ -1,5 +1,6 @@
 import { ABITypeRef } from "@ton/core";
 import { Writer } from "../../utils/Writer";
+import { throwInternalCompilerError } from "../../errors";
 
 const primitiveTypes = [
     "int",
@@ -519,7 +520,7 @@ const guard: Serializer<unknown> = {
     abiMatcher(src) {
         if (src.kind === "simple") {
             if (primitiveTypes.includes(src.type)) {
-                throw Error(
+                throwInternalCompilerError(
                     `Unable to resolve serializer for ${src.type} with ${src.format ? src.format : null} format`,
                 );
             }
@@ -527,19 +528,19 @@ const guard: Serializer<unknown> = {
         return null;
     },
     tsType(_v) {
-        throw Error("Unreachable");
+        throwInternalCompilerError("Unreachable");
     },
     tsLoad(_v, _slice, _field, _w) {
-        throw Error("Unreachable");
+        throwInternalCompilerError("Unreachable");
     },
     tsLoadTuple(_v, _reader, _field, _w) {
-        throw Error("Unreachable");
+        throwInternalCompilerError("Unreachable");
     },
     tsStore(_v, _builder, _field, _w) {
-        throw Error("Unreachable");
+        throwInternalCompilerError("Unreachable");
     },
     tsStoreTuple(_v, _to, _field, _w) {
-        throw Error("Unreachable");
+        throwInternalCompilerError("Unreachable");
     },
 };
 

--- a/src/bindings/typescript/writeStruct.ts
+++ b/src/bindings/typescript/writeStruct.ts
@@ -1,9 +1,14 @@
 import { ABIType, ABITypeRef } from "@ton/core";
 import { serializers } from "./serializers";
 import { AllocationCell, AllocationOperation } from "../../storage/operation";
+import { throwInternalCompilerError } from "../../errors";
 import { Writer } from "../../utils/Writer";
 
 export const maxTupleSize = 15;
+
+function throwUnsupportedType(type: ABITypeRef): never {
+    throwInternalCompilerError(`Unsupported type: ${JSON.stringify(type)}`);
+}
 
 export function writeStruct(
     name: string,
@@ -22,8 +27,7 @@ export function writeStruct(
                     continue outer;
                 }
             }
-
-            throw Error("Unsupported type: " + JSON.stringify(f.type));
+            throwUnsupportedType(f.type);
         }
     });
     w.append(`}`);
@@ -78,7 +82,7 @@ function writeParserField(
             return;
         }
     }
-    throw Error("Unsupported type");
+    throwUnsupportedType(type);
 }
 
 export function writeSerializer(
@@ -141,7 +145,7 @@ function writeSerializerField(gen: number, s: AllocationOperation, w: Writer) {
             return;
         }
     }
-    throw Error("Unsupported field type: " + JSON.stringify(type));
+    throwUnsupportedType(type);
 }
 
 export function writeTupleParser(s: ABIType, w: Writer) {
@@ -189,7 +193,7 @@ function writeTupleFieldParser(
             return;
         }
     }
-    throw Error("Unsupported field type: " + JSON.stringify(type));
+    throwUnsupportedType(type);
 }
 
 export function writeTupleSerializer(s: ABIType, w: Writer) {
@@ -217,7 +221,7 @@ function writeVariableToStack(name: string, type: ABITypeRef, w: Writer) {
             return;
         }
     }
-    throw Error("Unsupported field type: " + JSON.stringify(type));
+    throwUnsupportedType(type);
 }
 
 export function writeDictParser(s: ABIType, w: Writer) {

--- a/src/bindings/writeTypescript.ts
+++ b/src/bindings/writeTypescript.ts
@@ -13,6 +13,7 @@ import {
     writeTupleSerializer,
 } from "./typescript/writeStruct";
 import { AllocationCell } from "../storage/operation";
+import { throwInternalCompilerError } from "../errors";
 import { topologicalSort } from "../utils/utils";
 import {
     allocate,
@@ -31,7 +32,9 @@ function writeArguments(args: ABIArgument[]) {
                 continue outer;
             }
         }
-        throw Error("Unsupported type: " + JSON.stringify(f.type));
+        throwInternalCompilerError(
+            `Unsupported type: ${JSON.stringify(f.type)}`,
+        );
     }
 
     return res;

--- a/src/check.ts
+++ b/src/check.ts
@@ -7,7 +7,7 @@ import { precompile } from "./pipeline/precompile";
 export type CheckResultItem = {
     type: "error" | "warning";
     message: string;
-    location: {
+    location?: {
         file: string;
         line: number;
         column: number;
@@ -44,20 +44,25 @@ export function check(args: {
             items.push({
                 type: "error",
                 message: e.message,
-                location: e.loc.file
-                    ? {
-                          file: e.loc.file,
-                          line: e.loc.interval.getLineAndColumn().lineNum,
-                          column: e.loc.interval.getLineAndColumn().colNum,
-                          length:
-                              e.loc.interval.endIdx - e.loc.interval.startIdx,
-                      }
-                    : {
-                          file: args.entrypoint,
-                          line: 0,
-                          column: 0,
-                          length: 0,
-                      },
+                location:
+                    e.loc === undefined
+                        ? undefined
+                        : e.loc.file
+                          ? {
+                                file: e.loc.file,
+                                line: e.loc.interval.getLineAndColumn().lineNum,
+                                column: e.loc.interval.getLineAndColumn()
+                                    .colNum,
+                                length:
+                                    e.loc.interval.endIdx -
+                                    e.loc.interval.startIdx,
+                            }
+                          : {
+                                file: args.entrypoint,
+                                line: 0,
+                                column: 0,
+                                length: 0,
+                            },
             });
         } else {
             // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -5,8 +5,8 @@ import { AstFuncId, AstId, AstTypeId, SrcInfo } from "./grammar/ast";
 import { ItemOrigin } from "./grammar/grammar";
 
 export class TactError extends Error {
-    readonly loc: SrcInfo;
-    constructor(message: string, loc: SrcInfo) {
+    readonly loc?: SrcInfo;
+    constructor(message: string, loc?: SrcInfo) {
         super(message);
         this.loc = loc;
     }
@@ -26,13 +26,13 @@ export class TactSyntaxError extends TactError {
 
 /// This will be split at least into two categories: typechecking and codegen errors
 export class TactCompilationError extends TactError {
-    constructor(message: string, loc: SrcInfo) {
+    constructor(message: string, loc?: SrcInfo) {
         super(message, loc);
     }
 }
 
 export class TactInternalCompilerError extends TactError {
-    constructor(message: string, loc: SrcInfo) {
+    constructor(message: string, loc?: SrcInfo) {
         super(message, loc);
     }
 }
@@ -80,21 +80,28 @@ export function throwSyntaxError(message: string, source: SrcInfo): never {
     );
 }
 
-export function throwCompilationError(message: string, source: SrcInfo): never {
-    throw new TactCompilationError(
-        `${locationStr(source)}${message}\n${source.interval.getLineAndColumnMessage()}`,
-        source,
-    );
+export function throwCompilationError(
+    message: string,
+    source?: SrcInfo,
+): never {
+    const loc =
+        source === undefined
+            ? ""
+            : `${locationStr(source)}${message}\n${source.interval.getLineAndColumnMessage()}`;
+    throw new TactCompilationError(loc, source);
 }
 
 export function throwInternalCompilerError(
     message: string,
-    source: SrcInfo,
+    source?: SrcInfo,
 ): never {
-    throw new TactInternalCompilerError(
-        `${locationStr(source)}\n[INTERNAL COMPILER ERROR]: ${message}\nPlease report at https://github.com/tact-lang/tact/issues\n${source.interval.getLineAndColumnMessage()}`,
-        source,
-    );
+    const msg = `[INTERNAL COMPILER ERROR]: ${message}\nPlease report at https://github.com/tact-lang/tact/issues`;
+    throw source === undefined
+        ? new TactInternalCompilerError(msg)
+        : new TactInternalCompilerError(
+              `${locationStr(source)}\n${msg}\n${source.interval.getLineAndColumnMessage()}`,
+              source,
+          );
 }
 
 export function throwConstEvalError(

--- a/src/grammar/clone.ts
+++ b/src/grammar/clone.ts
@@ -1,4 +1,5 @@
 import { AstNode, cloneAstNode } from "./ast";
+import { throwInternalCompilerError } from "../errors";
 
 export function cloneNode<T extends AstNode>(src: T): T {
     if (src.kind === "boolean") {
@@ -174,5 +175,5 @@ export function cloneNode<T extends AstNode>(src: T): T {
         });
     }
 
-    throw Error("Not implemented for " + src.kind);
+    throwInternalCompilerError(`Not implemented for ${src.kind}`);
 }

--- a/src/grammar/grammar.ts
+++ b/src/grammar/grammar.ts
@@ -7,6 +7,7 @@ import {
     Grammar,
 } from "ohm-js";
 import tactGrammar from "./grammar.ohm-bundle";
+import { throwInternalCompilerError } from "../errors";
 import {
     AstAugmentedAssignOperation,
     AstConstantAttribute,
@@ -675,8 +676,8 @@ semantics.addOperation<AstNode>("astOfStatement", {
                     op = "^";
                     break;
                 default:
-                    throw Error(
-                        "Internal compiler error: unreachable augmented assignment operator. Please report at https://github.com/tact-lang/tact/issues",
+                    throwInternalCompilerError(
+                        "Unreachable augmented assignment operator.",
                     );
             }
             return createAstNode({

--- a/src/grammar/store.ts
+++ b/src/grammar/store.ts
@@ -5,6 +5,7 @@ import {
     AstNativeFunctionDecl,
     AstTypeDecl,
 } from "./ast";
+import { throwInternalCompilerError } from "../errors";
 import { CompilerContext, createContextStore } from "../context";
 import { ItemOrigin, parse } from "./grammar";
 
@@ -40,7 +41,7 @@ const store = createContextStore<AstStore>();
 export function getRawAST(ctx: CompilerContext): AstStore {
     const r = store.get(ctx, "types");
     if (!r) {
-        throw Error("No AST found in context");
+        throwInternalCompilerError("No AST found in context");
     }
     return r;
 }

--- a/src/imports/resolveImports.ts
+++ b/src/imports/resolveImports.ts
@@ -1,5 +1,6 @@
 import { ItemOrigin, parseImports } from "../grammar/grammar";
 import { VirtualFileSystem } from "../vfs/VirtualFileSystem";
+import { throwCompilationError } from "../errors";
 import { resolveLibrary } from "./resolveLibrary";
 
 export function resolveImports(args: {
@@ -16,13 +17,15 @@ export function resolveImports(args: {
 
     const stdlibTactPath = args.stdlib.resolve("stdlib.tact");
     if (!args.stdlib.exists(stdlibTactPath)) {
-        throw new Error(`Could not find stdlib.tact at ${stdlibTactPath}`);
+        throwCompilationError(
+            `Could not find stdlib.tact at ${stdlibTactPath}`,
+        );
     }
     const stdlibTact = args.stdlib.readFile(stdlibTactPath).toString();
 
     const codePath = args.project.resolve(args.entrypoint);
     if (!args.project.exists(codePath)) {
-        throw new Error(`Could not find entrypoint ${args.entrypoint}`);
+        throwCompilationError(`Could not find entrypoint ${args.entrypoint}`);
     }
     const code = args.project.readFile(codePath).toString();
 
@@ -47,7 +50,9 @@ export function resolveImports(args: {
                 stdlib: args.stdlib,
             });
             if (!resolved.ok) {
-                throw new Error(`Could not resolve import "${i}" in ${path}`);
+                throwCompilationError(
+                    `Could not resolve import "${i}" in ${path}`,
+                );
             }
 
             // Check if already imported
@@ -65,7 +70,9 @@ export function resolveImports(args: {
             const vfs =
                 resolved.source === "project" ? args.project : args.stdlib;
             if (!vfs.exists(resolved.path)) {
-                throw new Error(`Could not find source file ${resolved.path}`);
+                throwCompilationError(
+                    `Could not find source file ${resolved.path}`,
+                );
             }
             const code: string = vfs.readFile(resolved.path).toString();
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,1 +1,10 @@
 export { enableFeatures, build } from "./pipeline/build";
+export {
+    TactError,
+    TactParseError,
+    TactSyntaxError,
+    TactCompilationError,
+    TactInternalCompilerError,
+    TactConstEvalError,
+    TactErrorCollection,
+} from "./errors";

--- a/src/optimizer/util.ts
+++ b/src/optimizer/util.ts
@@ -7,6 +7,7 @@ import {
     isValue,
 } from "../grammar/ast";
 import { dummySrcInfo } from "../grammar/grammar";
+import { throwInternalCompilerError } from "../errors";
 import { Value } from "../types/types";
 
 export function extractValue(ast: AstValue): Value {
@@ -56,7 +57,7 @@ export function makeValueExpression(value: Value): AstValue {
         });
         return result as AstValue;
     }
-    throw new Error(
+    throwInternalCompilerError(
         `structs, addresses, cells, and comment values are not supported at the moment.`,
     );
 }

--- a/src/prettyPrinter.ts
+++ b/src/prettyPrinter.ts
@@ -42,6 +42,7 @@ import {
     AstFuncId,
     idText,
 } from "./grammar/ast";
+import { throwInternalCompilerError } from "./errors";
 import JSONbig from "json-bigint";
 
 /**
@@ -728,7 +729,7 @@ export function prettyPrint(node: AstNode): string {
         case "import":
             return pp.ppAstImport(node);
         default:
-            throw new Error(
+            throwInternalCompilerError(
                 `Unsupported AST type: ${JSONbig.stringify(node, null, 2)}`,
             );
     }

--- a/src/storage/allocator.ts
+++ b/src/storage/allocator.ts
@@ -119,7 +119,9 @@ export function getAllocationOperationFromField(
                         optional: src.optional ? src.optional : false,
                     };
                 } else if (src.format !== null && src.format !== undefined) {
-                    throw Error("Unsupported int format " + src.format);
+                    throwInternalCompilerError(
+                        `Unsupported int format: ${src.format}`,
+                    );
                 }
                 return {
                     kind: "int",
@@ -170,7 +172,9 @@ export function getAllocationOperationFromField(
                         optional: src.optional ? src.optional : false,
                     };
                 } else if (src.format !== null && src.format !== undefined) {
-                    throw Error("Unsupported int format " + src.format);
+                    throwInternalCompilerError(
+                        `Unsupported int format: ${src.format}`,
+                    );
                 }
                 return {
                     kind: "uint",
@@ -180,7 +184,9 @@ export function getAllocationOperationFromField(
             }
             if (src.type === "bool") {
                 if (src.format !== null && src.format !== undefined) {
-                    throw Error("Unsupported bool format " + src.format);
+                    throwInternalCompilerError(
+                        `Unsupported bool format: ${src.format}`,
+                    );
                 }
                 return {
                     kind: "boolean",
@@ -195,7 +201,9 @@ export function getAllocationOperationFromField(
                         format: "remainder",
                     };
                 } else if (src.format !== null && src.format !== undefined) {
-                    throw Error("Unsupported cell format " + src.format);
+                    throwInternalCompilerError(
+                        `Unsupported cell format: ${src.format}`,
+                    );
                 }
                 return {
                     kind: "cell",
@@ -211,7 +219,9 @@ export function getAllocationOperationFromField(
                         format: "remainder",
                     };
                 } else if (src.format !== null && src.format !== undefined) {
-                    throw Error("Unsupported slice format " + src.format);
+                    throwInternalCompilerError(
+                        `Unsupported slice format: ${src.format}`,
+                    );
                 }
                 return {
                     kind: "slice",
@@ -227,7 +237,9 @@ export function getAllocationOperationFromField(
                         format: "remainder",
                     };
                 } else if (src.format !== null && src.format !== undefined) {
-                    throw Error("Unsupported slice format " + src.format);
+                    throwInternalCompilerError(
+                        `Unsupported slice format: ${src.format}`,
+                    );
                 }
                 return {
                     kind: "builder",
@@ -249,12 +261,16 @@ export function getAllocationOperationFromField(
                         optional: src.optional ? src.optional : false,
                     };
                 } else {
-                    throw Error("Unsupported fixed-bytes format " + src.format);
+                    throwInternalCompilerError(
+                        `Unsupported fixed-bytes format: ${src.format}`,
+                    );
                 }
             }
             if (src.type === "string") {
                 if (src.format !== null && src.format !== undefined) {
-                    throw Error("Unsupported string format " + src.format);
+                    throwInternalCompilerError(
+                        `Unsupported string format: ${src.format}`,
+                    );
                 }
                 return {
                     kind: "string",
@@ -273,7 +289,9 @@ export function getAllocationOperationFromField(
                     size,
                 };
             } else if (src.format !== undefined && src.format !== null) {
-                throw Error("Unsupported struct format " + src.format);
+                throwInternalCompilerError(
+                    `Unsupported struct format: ${src.format}`,
+                );
             } else {
                 return {
                     kind: "struct",
@@ -286,7 +304,9 @@ export function getAllocationOperationFromField(
         }
         case "dict": {
             if (src.format !== null && src.format !== undefined) {
-                throw Error("Unsupported map format " + src.format);
+                throwInternalCompilerError(
+                    `Unsupported map format: ${src.format}`,
+                );
             }
             return { kind: "map" };
         }

--- a/src/storage/allocator.ts
+++ b/src/storage/allocator.ts
@@ -302,6 +302,9 @@ export function getAllocationOperationFromField(
                 };
             }
         }
+        // NOTE: That's false positive in ESLint on how it handles nested if-else
+        // constructions: https://github.com/tact-lang/tact/pull/669/files#r1709420045
+        // eslint-disable-next-line no-fallthrough
         case "dict": {
             if (src.format !== null && src.format !== undefined) {
                 throwInternalCompilerError(

--- a/src/storage/allocator.ts
+++ b/src/storage/allocator.ts
@@ -4,6 +4,7 @@ import {
     AllocationOperation,
     AllocationOperationType,
 } from "./operation";
+import { throwInternalCompilerError } from "../errors";
 
 const ALLOCATOR_RESERVE_BIT = 1;
 const ALLOCATOR_RESERVE_REF = 1;
@@ -36,7 +37,7 @@ function getOperationSize(src: AllocationOperationType): {
                     }
                     case "remainder": {
                         if (src.optional) {
-                            throw new Error(
+                            throwInternalCompilerError(
                                 "Remainder cell cannot be optional",
                             );
                         }

--- a/src/storage/resolveAllocation.ts
+++ b/src/storage/resolveAllocation.ts
@@ -7,6 +7,7 @@ import { AllocationOperation } from "./operation";
 import { allocate, getAllocationOperationFromField } from "./allocator";
 import { createABITypeRefFromTypeRef } from "../types/resolveABITypeRef";
 import { funcInitIdOf } from "../generator/writers/id";
+import { throwInternalCompilerError } from "../errors";
 import { idText } from "../grammar/ast";
 
 const store = createContextStore<StorageAllocation>();
@@ -14,7 +15,7 @@ const store = createContextStore<StorageAllocation>();
 export function getAllocation(ctx: CompilerContext, name: string) {
     const t = store.get(ctx, name);
     if (!t) {
-        throw Error("Allocation for " + name + " not found");
+        throwInternalCompilerError(`Allocation for ${name} not found`);
     }
     return t;
 }

--- a/src/types/resolveABITypeRef.ts
+++ b/src/types/resolveABITypeRef.ts
@@ -408,7 +408,7 @@ export function createABITypeRefFromTypeRef(
             return { kind: "simple", type: "string", optional: src.optional };
         }
         if (src.name === "StringBuilder") {
-            throw Error(`Unsupported type "${src.name}"`);
+            throwInternalCompilerError(`Unsupported type "${src.name}"`);
         }
 
         // Structs
@@ -444,7 +444,7 @@ export function createABITypeRefFromTypeRef(
                 );
             }
         } else {
-            throw Error(`Unsupported map key type "${src.key}"`);
+            throwInternalCompilerError(`Unsupported map key type "${src.key}"`);
         }
 
         // Resolve value type
@@ -479,7 +479,9 @@ export function createABITypeRefFromTypeRef(
                 );
             }
         } else if (src.value === "Slice") {
-            throw Error(`Unsupported map value type "${src.value}"`);
+            throwInternalCompilerError(
+                `Unsupported map value type "${src.value}"`,
+            );
         } else if (src.value === "Address") {
             value = "address";
             if (src.valueAs) {
@@ -489,9 +491,13 @@ export function createABITypeRefFromTypeRef(
                 );
             }
         } else if (src.value === "String") {
-            throw Error(`Unsupported map value type "${src.value}"`);
+            throwInternalCompilerError(
+                `Unsupported map value type "${src.value}"`,
+            );
         } else if (src.value === "StringBuilder" || src.value === "Builder") {
-            throw Error(`Unsupported map value type "${src.value}"`);
+            throwInternalCompilerError(
+                `Unsupported map value type "${src.value}"`,
+            );
         } else {
             value = src.value;
             valueFormat = "ref";
@@ -507,8 +513,8 @@ export function createABITypeRefFromTypeRef(
     }
 
     if (src.kind === "ref_bounced") {
-        throw Error("Unexpected bounced reference");
+        throwInternalCompilerError("Unexpected bounced reference");
     }
 
-    throw Error(`Unsupported type`);
+    throwInternalCompilerError(`Unsupported type`);
 }

--- a/src/types/resolveDescriptors.ts
+++ b/src/types/resolveDescriptors.ts
@@ -906,7 +906,9 @@ export function resolveDescriptors(ctx: CompilerContext) {
                 if (d.kind === "function_def" || d.kind === "function_decl") {
                     const f = resolveFunctionDescriptor(s.name, d, s.origin);
                     if (f.self !== s.name) {
-                        throw Error("Function self must be " + s.name); // Impossible
+                        throwInternalCompilerError(
+                            `Function self must be ${s.name}`,
+                        ); // Impossible
                     }
                     if (s.functions.has(f.name)) {
                         throwCompilationError(
@@ -1818,7 +1820,7 @@ export function getType(
     const name = typeof ident === "string" ? ident : idText(ident);
     const r = store.get(ctx, name);
     if (!r) {
-        throw Error("Type " + name + " not found");
+        throwInternalCompilerError(`Type ${name} not found`);
     }
     return r;
 }
@@ -1839,7 +1841,7 @@ export function getStaticFunction(
 ): FunctionDescription {
     const r = staticFunctionsStore.get(ctx, name);
     if (!r) {
-        throw Error("Static function " + name + " not found");
+        throwInternalCompilerError(`Static function ${name} not found`);
     }
     return r;
 }
@@ -1854,7 +1856,7 @@ export function getStaticConstant(
 ): ConstantDescription {
     const r = staticConstantsStore.get(ctx, name);
     if (!r) {
-        throw Error("Static constant " + name + " not found");
+        throwInternalCompilerError(`Static constant ${name} not found`);
     }
     return r;
 }

--- a/src/types/resolveErrors.ts
+++ b/src/types/resolveErrors.ts
@@ -3,6 +3,7 @@ import { CompilerContext, createContextStore } from "../context";
 import { AstNode, isRequire } from "../grammar/ast";
 import { traverse } from "../grammar/iterators";
 import { evalConstantExpression } from "../constEval";
+import { throwInternalCompilerError } from "../errors";
 import {
     getAllStaticConstants,
     getAllStaticFunctions,
@@ -34,7 +35,9 @@ function resolveStringsInAST(ast: AstNode, ctx: CompilerContext) {
                 if (
                     Object.values(exceptions.all(ctx)).find((v) => v.id === id)
                 ) {
-                    throw new Error(`Duplicate error id: "${resolved}"`);
+                    throwInternalCompilerError(
+                        `Duplicate error id: "${resolved}"`,
+                    );
                 }
                 ctx = exceptions.set(ctx, resolved, { value: resolved, id });
             }
@@ -92,7 +95,7 @@ export function getAllErrors(ctx: CompilerContext) {
 export function getErrorId(value: string, ctx: CompilerContext) {
     const ex = exceptions.get(ctx, value);
     if (!ex) {
-        throw new Error(`Error not found: ${value}`);
+        throwInternalCompilerError(`Error not found: ${value}`);
     }
     return ex.id;
 }

--- a/src/types/resolveExpression.ts
+++ b/src/types/resolveExpression.ts
@@ -35,6 +35,7 @@ import { StatementContext } from "./resolveStatements";
 import { MapFunctions } from "../abi/map";
 import { GlobalFunctions } from "../abi/global";
 import { isAssignable, moreGeneralType } from "./subtyping";
+import { throwInternalCompilerError } from "../errors";
 import { StructFunctions } from "../abi/struct";
 
 const store = createContextStore<{
@@ -45,7 +46,7 @@ const store = createContextStore<{
 export function getExpType(ctx: CompilerContext, exp: AstExpression) {
     const t = store.get(ctx, exp.id);
     if (!t) {
-        throw Error("Expression " + exp.id + " not found");
+        throwInternalCompilerError(`Expression ${exp.id} not found`);
     }
     return t.description;
 }
@@ -60,7 +61,7 @@ function registerExpType(
         if (typeRefEquals(ex.description, description)) {
             return ctx;
         }
-        throw Error("Expression " + exp.id + " already has a type");
+        throwInternalCompilerError(`Expression ${exp.id} already has a type`);
     }
     return store.set(ctx, exp.id, { ast: exp, description });
 }

--- a/src/types/resolveSignatures.ts
+++ b/src/types/resolveSignatures.ts
@@ -3,6 +3,7 @@ import { ABIField } from "@ton/core";
 import { CompilerContext } from "../context";
 import { idToHex } from "../utils/idToHex";
 import { newMessageId } from "../utils/newMessageId";
+import { throwInternalCompilerError } from "../errors";
 import { getAllTypes, getType } from "./resolveDescriptors";
 import {
     BinaryReceiverSelector,
@@ -27,7 +28,7 @@ export function resolveSignatures(ctx: CompilerContext) {
             if (typeof format === "number") {
                 return `int${format}`;
             } else if (format !== null) {
-                throw Error("Unsupported int format " + format);
+                throwInternalCompilerError(`Unsupported int format: ${format}`);
             }
             return `int`;
         } else if (type === "uint") {
@@ -36,17 +37,23 @@ export function resolveSignatures(ctx: CompilerContext) {
             } else if (format === "coins") {
                 return `coins`;
             } else if (format !== null) {
-                throw Error("Unsupported uint format " + format);
+                throwInternalCompilerError(
+                    `Unsupported uint format: ${format}`,
+                );
             }
             return `uint`;
         } else if (type === "bool") {
             if (format !== null) {
-                throw Error("Unsupported bool format " + format);
+                throwInternalCompilerError(
+                    `Unsupported bool format: ${format}`,
+                );
             }
             return "bool";
         } else if (type === "address") {
             if (format !== null) {
-                throw Error("Unsupported address format " + format);
+                throwInternalCompilerError(
+                    `Unsupported address format: ${format}`,
+                );
             }
             return "address";
         } else if (type === "cell") {
@@ -56,7 +63,9 @@ export function resolveSignatures(ctx: CompilerContext) {
                 return "^cell";
             }
             if (format !== null) {
-                throw Error("Unsupported cell format " + format);
+                throwInternalCompilerError(
+                    `Unsupported cell format: ${format}`,
+                );
             }
             return "^cell";
         } else if (type === "slice") {
@@ -65,7 +74,9 @@ export function resolveSignatures(ctx: CompilerContext) {
             } else if (format === "ref") {
                 return "^slice";
             } else if (format !== null) {
-                throw Error("Unsupported slice format " + format);
+                throwInternalCompilerError(
+                    `Unsupported slice format: ${format}`,
+                );
             }
             return "^slice";
         } else if (type === "builder") {
@@ -74,33 +85,39 @@ export function resolveSignatures(ctx: CompilerContext) {
             } else if (format === "ref") {
                 return "^slice";
             } else if (format !== null) {
-                throw Error("Unsupported builder format " + format);
+                throwInternalCompilerError(
+                    `Unsupported builder format: ${format}`,
+                );
             }
             return "^builder";
         } else if (type === "string") {
             if (format !== null) {
-                throw Error("Unsupported builder format " + format);
+                throwInternalCompilerError(
+                    `Unsupported builder format: ${format}`,
+                );
             }
             return "^string";
         } else if (type === "fixed-bytes") {
             if (typeof format === "number") {
                 return `fixed_bytes${format}`;
             } else if (format !== null) {
-                throw Error("Unsupported fixed-bytes format " + format);
+                throwInternalCompilerError(
+                    `Unsupported fixed-bytes format: ${format}`,
+                );
             }
-            throw Error("Missing fixed-bytes format");
+            throwInternalCompilerError("Missing fixed-bytes format");
         }
 
         // Struct types
         const t = getType(ctx, type);
         if (t.kind !== "struct") {
-            throw Error("Unsupported type " + type);
+            throwInternalCompilerError(`Unsupported type: ${type}`);
         }
         const s = createTupleSignature(type);
         if (format === "ref") {
             return `^${s.signature}`;
         } else if (format !== null) {
-            throw Error("Unsupported struct format " + format);
+            throwInternalCompilerError(`Unsupported struct format: ${format}`);
         }
         return s.signature;
     }
@@ -119,7 +136,9 @@ export function resolveSignatures(ctx: CompilerContext) {
             }
             case "dict": {
                 if (src.type.format !== null && src.type.format !== undefined) {
-                    throw Error("Unsupported map format " + src.type.format);
+                    throwInternalCompilerError(
+                        `Unsupported map format: ${src.type.format}`,
+                    );
                 }
                 const key = createTypeFormat(
                     src.type.key,
@@ -144,7 +163,7 @@ export function resolveSignatures(ctx: CompilerContext) {
         }
         const t = getType(ctx, name);
         if (t.kind !== "struct") {
-            throw Error("Unsupported type " + name);
+            throwInternalCompilerError(`Unsupported type: ${name}`);
         }
         const fields = t.fields.map((v) => createTLBField(v.abi));
 

--- a/src/types/resolveStatements.ts
+++ b/src/types/resolveStatements.ts
@@ -10,7 +10,11 @@ import {
     selfId,
 } from "../grammar/ast";
 import { isAssignable } from "./subtyping";
-import { idTextErr, throwCompilationError } from "../errors";
+import {
+    idTextErr,
+    throwCompilationError,
+    throwInternalCompilerError,
+} from "../errors";
 import {
     getAllStaticFunctions,
     getAllTypes,
@@ -52,7 +56,7 @@ function addRequiredVariables(
     src: StatementContext,
 ): StatementContext {
     if (src.requiredFields.find((v) => v === name)) {
-        throw Error("Variable already exists: " + name); // Should happen earlier
+        throwInternalCompilerError(`Variable already exists: ${name}`); // Should happen earlier
     }
     return {
         ...src,
@@ -65,7 +69,7 @@ function removeRequiredVariable(
     src: StatementContext,
 ): StatementContext {
     if (!src.requiredFields.find((v) => v === name)) {
-        throw Error("Variable is not required: " + name); // Should happen earlier
+        throwInternalCompilerError(`Variable is not required: ${name}`); // Should happen earlier
     }
     const filtered = src.requiredFields.filter((v) => v !== name);
     return {
@@ -132,11 +136,12 @@ function processCondition(
     ) {
         // if-else if
         const r = processCondition(condition.elseif, initialCtx, ctx);
+
         ctx = r.ctx;
         processedCtx.push(r.sctx);
         returnAlwaysReachableInAllBranches.push(r.returnAlwaysReachable);
     } else {
-        throw Error("Impossible");
+        throwInternalCompilerError("Impossible");
     }
 
     // Merge statement contexts

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -7,7 +7,7 @@ export function topologicalSort<T>(src: T[], references: (src: T) => T[]) {
     const visiting: Set<T> = new Set();
     const visit = (src: T) => {
         if (visiting.has(src)) {
-            throw Error("Cycle detected");
+            throwInternalCompilerError("Cycle detected");
         }
         if (!visited.has(src)) {
             visiting.add(src);

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -1,4 +1,5 @@
 import { crc16 } from "./crc16";
+import { throwInternalCompilerError } from "../errors";
 
 export function topologicalSort<T>(src: T[], references: (src: T) => T[]) {
     const result: T[] = [];


### PR DESCRIPTION
Closes #645

I have replaced `throw Error` with `throwInternalCompilerError` in most cases, as that's essentially how the compiler should behave. If the user encounters an "impossible" case, they should definitely be encouraged to report it.

Otherwise, if we encounter this kind of error while using the compiler API in a tool, we should understand that we are using it incorrectly.

Note that I didn't modify the old backend, as it will be rewritten anyway.

- [x] I have updated CHANGELOG.md
- [ ] ~~I have documented my contribution in Tact Docs: https://github.com/tact-lang/tact-docs/pull/PR-NUMBER~~
- [ ] ~~I have added tests to demonstrate the contribution is correctly implemented: this usually includes both positive and negative tests, showing the happy path(s) and featuring intentionally broken cases~~
- [x] I have run all the tests locally and no test failure was reported
- [x] I have run the linter, formatter and spellchecker
- [x] I did not do unrelated and/or undiscussed refactorings
