### PR TITLE
fix: do not allow assignments to constants

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Typechecking for optional types when the argument type is not an equality type: PR [#650](https://github.com/tact-lang/tact/pull/650)
 - Getters now return flattened types for structs as before: PR [#679](https://github.com/tact-lang/tact/pull/679)
 - New bindings cannot shadow global constants: PR [#680](https://github.com/tact-lang/tact/pull/680)
+- Disallow using assignment operators on constants: PR [#682](https://github.com/tact-lang/tact/pull/682)
 
 ## [1.4.1] - 2024-07-26
 

--- a/src/types/__snapshots__/resolveStatements.spec.ts.snap
+++ b/src/types/__snapshots__/resolveStatements.spec.ts.snap
@@ -1,5 +1,85 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`resolveStatements should fail statements for assign-augmented-const-contract 1`] = `
+"<unknown>:8:9: Modifications of constant expressions are not allowed
+Line 8, col 9:
+  7 |     fun bar() {
+> 8 |         self.foo += 1 // <-- trying to assign to a constant
+              ^~~~~~~~
+  9 |     }
+"
+`;
+
+exports[`resolveStatements should fail statements for assign-augmented-const-global 1`] = `
+"<unknown>:6:5: Modifications of constant expressions are not allowed
+Line 6, col 5:
+  5 | fun bar() {
+> 6 |     foo += 1 // <-- trying to assign to a constant
+          ^~~
+  7 | }
+"
+`;
+
+exports[`resolveStatements should fail statements for assign-augmented-const-struct-contract 1`] = `
+"<unknown>:12:9: Modifications of constant expressions are not allowed
+Line 12, col 9:
+  11 |         self.baz.x += 1; // ok
+> 12 |         self.foo.y -= 1 // <-- trying to assign to a constant
+               ^~~~~~~~~~
+  13 |     }
+"
+`;
+
+exports[`resolveStatements should fail statements for assign-augmented-const-struct-global 1`] = `
+"<unknown>:10:5: Modifications of constant expressions are not allowed
+Line 10, col 5:
+   9 |     baz.x += 1; // ok
+> 10 |     foo.y -= 1 // <-- trying to assign to a constant
+           ^~~~~
+  11 | }
+"
+`;
+
+exports[`resolveStatements should fail statements for assign-const-contract 1`] = `
+"<unknown>:8:9: Modifications of constant expressions are not allowed
+Line 8, col 9:
+  7 |     fun bar() {
+> 8 |         self.foo = 43 // <-- trying to assign to a constant
+              ^~~~~~~~
+  9 |     }
+"
+`;
+
+exports[`resolveStatements should fail statements for assign-const-global 1`] = `
+"<unknown>:6:5: Modifications of constant expressions are not allowed
+Line 6, col 5:
+  5 | fun bar() {
+> 6 |     foo = 43 // <-- trying to assign to a constant
+          ^~~
+  7 | }
+"
+`;
+
+exports[`resolveStatements should fail statements for assign-const-struct-contract 1`] = `
+"<unknown>:12:9: Modifications of constant expressions are not allowed
+Line 12, col 9:
+  11 |         self.baz.x = 1; // ok
+> 12 |         self.foo.y = 42 // <-- trying to assign to a constant
+               ^~~~~~~~~~
+  13 |     }
+"
+`;
+
+exports[`resolveStatements should fail statements for assign-const-struct-global 1`] = `
+"<unknown>:10:5: Modifications of constant expressions are not allowed
+Line 10, col 5:
+   9 |     baz.x = 1; // ok
+> 10 |     foo.y = 42 // <-- trying to assign to a constant
+           ^~~~~
+  11 | }
+"
+`;
+
 exports[`resolveStatements should fail statements for bounced-type-is-smaller 1`] = `
 "<unknown>:23:22: Type bounced<"A"> does not have a field named "c"
 Line 23, col 22:
@@ -1083,6 +1163,31 @@ Line 9, col 12:
                   ^
   10 | }
 "
+`;
+
+exports[`resolveStatements should resolve statements for assign-self-mutating-method 1`] = `
+[
+  [
+    "self",
+    "IntWrapper",
+  ],
+  [
+    "self.x",
+    "Int",
+  ],
+  [
+    "42",
+    "Int",
+  ],
+  [
+    "self",
+    "Int",
+  ],
+  [
+    "42",
+    "Int",
+  ],
+]
 `;
 
 exports[`resolveStatements should resolve statements for contract-receiver-bounced 1`] = `

--- a/src/types/stmts-failed/assign-augmented-const-contract.tact
+++ b/src/types/stmts-failed/assign-augmented-const-contract.tact
@@ -1,0 +1,10 @@
+primitive Int;
+trait BaseTrait { }
+
+contract Test {
+    const foo: Int = 42;
+
+    fun bar() {
+        self.foo += 1 // <-- trying to assign to a constant
+    }
+}

--- a/src/types/stmts-failed/assign-augmented-const-global.tact
+++ b/src/types/stmts-failed/assign-augmented-const-global.tact
@@ -1,0 +1,7 @@
+primitive Int;
+
+const foo: Int = 42;
+
+fun bar() {
+    foo += 1 // <-- trying to assign to a constant
+}

--- a/src/types/stmts-failed/assign-augmented-const-struct-contract.tact
+++ b/src/types/stmts-failed/assign-augmented-const-struct-contract.tact
@@ -1,0 +1,14 @@
+primitive Int;
+trait BaseTrait { }
+
+struct Foo {x: Int; y: Int}
+
+contract Test {
+    const foo: Foo = Foo {x: 42, y: 43};
+    baz: Foo = Foo {x: 42, y: 43};
+
+    fun bar() {
+        self.baz.x += 1; // ok
+        self.foo.y -= 1 // <-- trying to assign to a constant
+    }
+}

--- a/src/types/stmts-failed/assign-augmented-const-struct-global.tact
+++ b/src/types/stmts-failed/assign-augmented-const-struct-global.tact
@@ -1,0 +1,11 @@
+primitive Int;
+
+struct Foo {x: Int; y: Int}
+
+const foo: Foo = Foo {x: 42, y: 43};
+
+fun bar() {
+    let baz: Foo = Foo {x: 42, y: 43};
+    baz.x += 1; // ok
+    foo.y -= 1 // <-- trying to assign to a constant
+}

--- a/src/types/stmts-failed/assign-const-contract.tact
+++ b/src/types/stmts-failed/assign-const-contract.tact
@@ -1,0 +1,10 @@
+primitive Int;
+trait BaseTrait { }
+
+contract Test {
+    const foo: Int = 42;
+
+    fun bar() {
+        self.foo = 43 // <-- trying to assign to a constant
+    }
+}

--- a/src/types/stmts-failed/assign-const-global.tact
+++ b/src/types/stmts-failed/assign-const-global.tact
@@ -1,0 +1,7 @@
+primitive Int;
+
+const foo: Int = 42;
+
+fun bar() {
+    foo = 43 // <-- trying to assign to a constant
+}

--- a/src/types/stmts-failed/assign-const-struct-contract.tact
+++ b/src/types/stmts-failed/assign-const-struct-contract.tact
@@ -1,0 +1,14 @@
+primitive Int;
+trait BaseTrait { }
+
+struct Foo {x: Int; y: Int}
+
+contract Test {
+    const foo: Foo = Foo {x: 42, y: 43};
+    baz: Foo = Foo {x: 42, y: 43};
+
+    fun bar() {
+        self.baz.x = 1; // ok
+        self.foo.y = 42 // <-- trying to assign to a constant
+    }
+}

--- a/src/types/stmts-failed/assign-const-struct-global.tact
+++ b/src/types/stmts-failed/assign-const-struct-global.tact
@@ -1,0 +1,11 @@
+primitive Int;
+
+struct Foo {x: Int; y: Int}
+
+const foo: Foo = Foo {x: 42, y: 43};
+
+fun bar() {
+    let baz: Foo = Foo {x: 42, y: 43};
+    baz.x = 1; // ok
+    foo.y = 42 // <-- trying to assign to a constant
+}

--- a/src/types/stmts/assign-self-mutating-method.tact
+++ b/src/types/stmts/assign-self-mutating-method.tact
@@ -1,0 +1,11 @@
+primitive Int;
+
+struct IntWrapper { x: Int }
+
+extends mutates fun foo(self: IntWrapper) {
+    self.x = 42
+}
+
+extends mutates fun bar(self: Int) {
+    self = 42
+}


### PR DESCRIPTION
Closes #681

<!--
IMPORTANT:
If your PR doesn't close a particular issue, please, create the issue first and describe the whole context: what you're adding/changing and why you're doing so. And only then open the Pull Request, which would close that issue!

In case you are adding a new language feature, a standard library function or introducing other user-facing changes, you need to document them via a new PR to tact-docs.
-->

- [x] I have updated CHANGELOG.md
- ~[] I have documented my contribution in Tact Docs: https://github.com/tact-lang/tact-docs/pull/PR-NUMBER~
- [x] I have added tests to demonstrate the contribution is correctly implemented: this usually includes both positive and negative tests, showing the happy path(s) and featuring intentionally broken cases
- [x] I have run all the tests locally and no test failure was reported
- [x] I have run the linter, formatter and spellchecker
- [x] I did not do unrelated and/or undiscussed refactorings
