### PR TITLE
fix: remove `.readTuple()` from non-opt tuple reading

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Parsing of optional nested struct fields does not cause the `Not a tuple` error anymore: PR [#692](https://github.com/tact-lang/tact/pull/692)
+
 ## [1.4.2] - 2024-08-13
 
 ### Changed

--- a/src/bindings/typescript/serializers.ts
+++ b/src/bindings/typescript/serializers.ts
@@ -585,9 +585,7 @@ const struct: Serializer<{ name: string; optional: boolean }> = {
                     `const ${field} = loadGetterTuple${v.name}(${reader});`,
                 );
             } else {
-                w.append(
-                    `const ${field} = loadTuple${v.name}(${reader}.readTuple());`,
-                );
+                w.append(`const ${field} = loadTuple${v.name}(${reader});`);
             }
         }
     },

--- a/src/test/e2e-emulated/__snapshots__/structs.spec.ts.snap
+++ b/src/test/e2e-emulated/__snapshots__/structs.spec.ts.snap
@@ -289,7 +289,7 @@ exports[`structs should implement structs correctly 13`] = `
     "events": [
       {
         "$type": "storage-charged",
-        "amount": "0.00000003",
+        "amount": "0.000000034",
       },
       {
         "$type": "received",
@@ -300,7 +300,7 @@ exports[`structs should implement structs correctly 13`] = `
           },
           "bounce": true,
           "from": "@treasure(treasure)",
-          "to": "kQBZ457fewz6VXFxt1pyO6__ahp6anUoNrSQIjpDZVXnlpJT",
+          "to": "kQA1LDdzadkUsxlM6-EvD2rMZ2-HuudKWuU-umho_Zw4Aoau",
           "type": "internal",
           "value": "10",
         },
@@ -318,7 +318,7 @@ exports[`structs should implement structs correctly 13`] = `
             "type": "cell",
           },
           "bounce": false,
-          "from": "kQBZ457fewz6VXFxt1pyO6__ahp6anUoNrSQIjpDZVXnlpJT",
+          "from": "kQA1LDdzadkUsxlM6-EvD2rMZ2-HuudKWuU-umho_Zw4Aoau",
           "to": "@treasure(treasure)",
           "type": "internal",
           "value": "9.988015",
@@ -1495,5 +1495,291 @@ TupleReader {
       "type": "tuple",
     },
   ],
+}
+`;
+
+exports[`structs should implement structs correctly 24`] = `
+{
+  "$$type": "Location",
+  "idx": 1n,
+  "line1": {
+    "$$type": "Line",
+    "end": {
+      "$$type": "Point",
+      "x": 3n,
+      "y": 4n,
+    },
+    "start": {
+      "$$type": "Point",
+      "x": 1n,
+      "y": 2n,
+    },
+  },
+  "line2": null,
+}
+`;
+
+exports[`structs should implement structs correctly 25`] = `
+{
+  "$$type": "Location",
+  "idx": 2n,
+  "line1": {
+    "$$type": "Line",
+    "end": {
+      "$$type": "Point",
+      "x": 3n,
+      "y": 4n,
+    },
+    "start": {
+      "$$type": "Point",
+      "x": 1n,
+      "y": 2n,
+    },
+  },
+  "line2": {
+    "$$type": "Line",
+    "end": {
+      "$$type": "Point",
+      "x": 3n,
+      "y": 4n,
+    },
+    "start": {
+      "$$type": "Point",
+      "x": 1n,
+      "y": 2n,
+    },
+  },
+}
+`;
+
+exports[`structs should implement structs correctly 26`] = `
+{
+  "$$type": "TripleNestedStructOpt",
+  "a": 1n,
+  "s": {
+    "$$type": "DoubleNestedStructOpt",
+    "a": 2n,
+    "s": {
+      "$$type": "MyStruct1",
+      "a": 3n,
+      "b": 4n,
+      "c": 5n,
+    },
+  },
+}
+`;
+
+exports[`structs should implement structs correctly 27`] = `
+{
+  "$$type": "TripleNestedStructOpt",
+  "a": 1n,
+  "s": null,
+}
+`;
+
+exports[`structs should implement structs correctly 28`] = `
+{
+  "$$type": "TripleNestedStructOpt",
+  "a": 1n,
+  "s": {
+    "$$type": "DoubleNestedStructOpt",
+    "a": 2n,
+    "s": null,
+  },
+}
+`;
+
+exports[`structs should implement structs correctly 29`] = `
+{
+  "$$type": "LongAndDeepNestedStruct",
+  "s1": {
+    "$$type": "TripleNestedStructOpt",
+    "a": 1n,
+    "s": {
+      "$$type": "DoubleNestedStructOpt",
+      "a": 2n,
+      "s": {
+        "$$type": "MyStruct1",
+        "a": 3n,
+        "b": 4n,
+        "c": 5n,
+      },
+    },
+  },
+  "s2": {
+    "$$type": "TripleNestedStructOpt",
+    "a": 6n,
+    "s": {
+      "$$type": "DoubleNestedStructOpt",
+      "a": 7n,
+      "s": {
+        "$$type": "MyStruct1",
+        "a": 8n,
+        "b": 9n,
+        "c": 10n,
+      },
+    },
+  },
+  "s3": null,
+  "s4": null,
+  "x1": 1n,
+  "x10": 10n,
+  "x11": 11n,
+  "x12": 12n,
+  "x13": 13n,
+  "x14": 14n,
+  "x15": 15n,
+  "x16": 16n,
+  "x2": 2n,
+  "x3": 3n,
+  "x4": 4n,
+  "x5": 5n,
+  "x6": 6n,
+  "x7": 7n,
+  "x8": 8n,
+  "x9": 9n,
+}
+`;
+
+exports[`structs should implement structs correctly 30`] = `
+{
+  "$$type": "LongAndDeepNestedStruct",
+  "s1": {
+    "$$type": "TripleNestedStructOpt",
+    "a": 1n,
+    "s": {
+      "$$type": "DoubleNestedStructOpt",
+      "a": 2n,
+      "s": {
+        "$$type": "MyStruct1",
+        "a": 3n,
+        "b": 4n,
+        "c": 5n,
+      },
+    },
+  },
+  "s2": {
+    "$$type": "TripleNestedStructOpt",
+    "a": 6n,
+    "s": {
+      "$$type": "DoubleNestedStructOpt",
+      "a": 7n,
+      "s": {
+        "$$type": "MyStruct1",
+        "a": 8n,
+        "b": 9n,
+        "c": 10n,
+      },
+    },
+  },
+  "s3": {
+    "$$type": "TripleNestedStructOpt",
+    "a": 11n,
+    "s": {
+      "$$type": "DoubleNestedStructOpt",
+      "a": 12n,
+      "s": {
+        "$$type": "MyStruct1",
+        "a": 13n,
+        "b": 14n,
+        "c": 15n,
+      },
+    },
+  },
+  "s4": {
+    "$$type": "TripleNestedStructOpt",
+    "a": 16n,
+    "s": {
+      "$$type": "DoubleNestedStructOpt",
+      "a": 17n,
+      "s": {
+        "$$type": "MyStruct1",
+        "a": 18n,
+        "b": 19n,
+        "c": 20n,
+      },
+    },
+  },
+  "x1": 1n,
+  "x10": 10n,
+  "x11": 11n,
+  "x12": 12n,
+  "x13": 13n,
+  "x14": 14n,
+  "x15": 15n,
+  "x16": 16n,
+  "x2": 2n,
+  "x3": 3n,
+  "x4": 4n,
+  "x5": 5n,
+  "x6": 6n,
+  "x7": 7n,
+  "x8": 8n,
+  "x9": 9n,
+}
+`;
+
+exports[`structs should implement structs correctly 31`] = `
+{
+  "$$type": "LongAndDeepNestedStruct",
+  "s1": {
+    "$$type": "TripleNestedStructOpt",
+    "a": 1n,
+    "s": {
+      "$$type": "DoubleNestedStructOpt",
+      "a": 2n,
+      "s": {
+        "$$type": "MyStruct1",
+        "a": 3n,
+        "b": 4n,
+        "c": 5n,
+      },
+    },
+  },
+  "s2": {
+    "$$type": "TripleNestedStructOpt",
+    "a": 6n,
+    "s": {
+      "$$type": "DoubleNestedStructOpt",
+      "a": 7n,
+      "s": {
+        "$$type": "MyStruct1",
+        "a": 8n,
+        "b": 9n,
+        "c": 10n,
+      },
+    },
+  },
+  "s3": null,
+  "s4": {
+    "$$type": "TripleNestedStructOpt",
+    "a": 16n,
+    "s": {
+      "$$type": "DoubleNestedStructOpt",
+      "a": 17n,
+      "s": {
+        "$$type": "MyStruct1",
+        "a": 18n,
+        "b": 19n,
+        "c": 20n,
+      },
+    },
+  },
+  "x1": 1n,
+  "x10": 10n,
+  "x11": 11n,
+  "x12": 12n,
+  "x13": 13n,
+  "x14": 14n,
+  "x15": 15n,
+  "x16": 16n,
+  "x2": 2n,
+  "x3": 3n,
+  "x4": 4n,
+  "x5": 5n,
+  "x6": 6n,
+  "x7": 7n,
+  "x8": 8n,
+  "x9": 9n,
 }
 `;

--- a/src/test/e2e-emulated/contracts/structs.tact
+++ b/src/test/e2e-emulated/contracts/structs.tact
@@ -165,6 +165,55 @@ struct LongNestedStructWithOpts {
     s3: LongStruct32?;
 }
 
+struct Point {
+    x: Int as int64;
+    y: Int as int64;
+}
+ 
+struct Line {
+    start: Point;
+    end: Point;
+}
+
+struct Location {
+    idx: Int;
+    line1: Line;
+    line2: Line?;
+}
+
+struct DoubleNestedStructOpt {
+    a: Int;
+    s: MyStruct1?;
+}
+
+struct TripleNestedStructOpt {
+    a: Int;
+    s: DoubleNestedStructOpt?;
+}
+
+struct LongAndDeepNestedStruct {
+    x1: Int;
+    x2: Int;
+    x3: Int;
+    x4: Int;
+    x5: Int;
+    x6: Int;
+    x7: Int;
+    x8: Int;
+    x9: Int;
+    x10: Int;
+    x11: Int;
+    x12: Int;
+    x13: Int;
+    x14: Int;
+    x15: Int;
+    x16: Int;
+    s1: TripleNestedStructOpt;
+    s2: TripleNestedStructOpt;
+    s3: TripleNestedStructOpt?;
+    s4: TripleNestedStructOpt?;
+}
+
 contract StructsTester {
     s1: S = S {a: false, b: 21 + 21};
     s2: S;
@@ -580,5 +629,225 @@ contract StructsTester {
     get fun longContractTest(): Int {
         return self.x1 + self.x2 + self.x3 + self.x4 + self.x5 + self.x6 + self.x7 + self.x8 + self.x9 + self.x10 +
                self.x11 + self.x12 + self.x13 + self.x14 + self.x15 + self.x16 + self.x17 + self.x18 + self.x19 + self.x20;
+    }
+
+    // https://github.com/tact-lang/tact/issues/690
+
+    get fun location1(): Location {
+        let start: Point = Point{ x: 1, y: 2};
+        let end: Point = Point{ x: 3, y: 4};
+
+        return Location {
+            idx: 1,
+            line1: Line {start: start, end: end},
+            line2: null
+        }
+    }
+
+    get fun location2(): Location {
+        let start: Point = Point{ x: 1, y: 2};
+        let end: Point = Point{ x: 3, y: 4};
+
+        return Location {
+            idx: 2,
+            line1: Line {start: start, end: end},
+            line2: Line {start: start, end: end}
+        }
+    }
+
+    get fun tripleNestedStructOpt1(): TripleNestedStructOpt {
+        return TripleNestedStructOpt {
+            a: 1,
+            s: DoubleNestedStructOpt {
+                a: 2,
+                s: MyStruct1 {
+                    a: 3,
+                    b: 4,
+                    c: 5
+                }
+            }
+        }
+    }
+
+    get fun tripleNestedStructOpt2(): TripleNestedStructOpt {
+        return TripleNestedStructOpt {
+            a: 1,
+            s: null
+        }
+    }
+
+    get fun tripleNestedStructOpt3(): TripleNestedStructOpt {
+        return TripleNestedStructOpt {
+            a: 1,
+            s: DoubleNestedStructOpt {
+                a: 2,
+                s: null
+            }
+        }
+    }
+
+    get fun longAndDeepNestedStruct1(): LongAndDeepNestedStruct {
+        return LongAndDeepNestedStruct {
+            x1: 1,
+            x2: 2,
+            x3: 3,
+            x4: 4,
+            x5: 5,
+            x6: 6,
+            x7: 7,
+            x8: 8,
+            x9: 9,
+            x10: 10,
+            x11: 11,
+            x12: 12,
+            x13: 13,
+            x14: 14,
+            x15: 15,
+            x16: 16,
+            s1: TripleNestedStructOpt {
+                a: 1,
+                s: DoubleNestedStructOpt {
+                    a: 2,
+                    s: MyStruct1 {
+                        a: 3,
+                        b: 4,
+                        c: 5
+                    }
+                }
+            },
+            s2: TripleNestedStructOpt {
+                a: 6,
+                s: DoubleNestedStructOpt {
+                    a: 7,
+                    s: MyStruct1 {
+                        a: 8,
+                        b: 9,
+                        c: 10
+                    }
+                }
+            },
+            s3: null,
+            s4: null
+        }
+    }
+
+    get fun longAndDeepNestedStruct2(): LongAndDeepNestedStruct {
+        return LongAndDeepNestedStruct {
+            x1: 1,
+            x2: 2,
+            x3: 3,
+            x4: 4,
+            x5: 5,
+            x6: 6,
+            x7: 7,
+            x8: 8,
+            x9: 9,
+            x10: 10,
+            x11: 11,
+            x12: 12,
+            x13: 13,
+            x14: 14,
+            x15: 15,
+            x16: 16,
+            s1: TripleNestedStructOpt {
+                a: 1,
+                s: DoubleNestedStructOpt {
+                    a: 2,
+                    s: MyStruct1 {
+                        a: 3,
+                        b: 4,
+                        c: 5
+                    }
+                }
+            },
+            s2: TripleNestedStructOpt {
+                a: 6,
+                s: DoubleNestedStructOpt {
+                    a: 7,
+                    s: MyStruct1 {
+                        a: 8,
+                        b: 9,
+                        c: 10
+                    }
+                }
+            },
+            s3: TripleNestedStructOpt {
+                a: 11,
+                s: DoubleNestedStructOpt {
+                    a: 12,
+                    s: MyStruct1 {
+                        a: 13,
+                        b: 14,
+                        c: 15
+                    }
+                }
+            },
+            s4: TripleNestedStructOpt {
+                a: 16,
+                s: DoubleNestedStructOpt {
+                    a: 17,
+                    s: MyStruct1 {
+                        a: 18,
+                        b: 19,
+                        c: 20
+                    }
+                }
+            }
+        }
+    }
+
+    get fun longAndDeepNestedStruct3(): LongAndDeepNestedStruct {
+        return LongAndDeepNestedStruct {
+            x1: 1,
+            x2: 2,
+            x3: 3,
+            x4: 4,
+            x5: 5,
+            x6: 6,
+            x7: 7,
+            x8: 8,
+            x9: 9,
+            x10: 10,
+            x11: 11,
+            x12: 12,
+            x13: 13,
+            x14: 14,
+            x15: 15,
+            x16: 16,
+            s1: TripleNestedStructOpt {
+                a: 1,
+                s: DoubleNestedStructOpt {
+                    a: 2,
+                    s: MyStruct1 {
+                        a: 3,
+                        b: 4,
+                        c: 5
+                    }
+                }
+            },
+            s2: TripleNestedStructOpt {
+                a: 6,
+                s: DoubleNestedStructOpt {
+                    a: 7,
+                    s: MyStruct1 {
+                        a: 8,
+                        b: 9,
+                        c: 10
+                    }
+                }
+            },
+            s3: null,
+            s4: TripleNestedStructOpt {
+                a: 16,
+                s: DoubleNestedStructOpt {
+                    a: 17,
+                    s: MyStruct1 {
+                        a: 18,
+                        b: 19,
+                        c: 20
+                    }
+                }
+            }
+        }
     }
 }

--- a/src/test/e2e-emulated/structs.spec.ts
+++ b/src/test/e2e-emulated/structs.spec.ts
@@ -271,5 +271,16 @@ describe("structs", () => {
                     .get("longNestedStructWithOptsTest", [])
             ).stack,
         ).toMatchSnapshot();
+
+        // https://github.com/tact-lang/tact/issues/690
+
+        expect(await contract.getLocation1()).toMatchSnapshot();
+        expect(await contract.getLocation2()).toMatchSnapshot();
+        expect(await contract.getTripleNestedStructOpt1()).toMatchSnapshot();
+        expect(await contract.getTripleNestedStructOpt2()).toMatchSnapshot();
+        expect(await contract.getTripleNestedStructOpt3()).toMatchSnapshot();
+        expect(await contract.getLongAndDeepNestedStruct1()).toMatchSnapshot();
+        expect(await contract.getLongAndDeepNestedStruct2()).toMatchSnapshot();
+        expect(await contract.getLongAndDeepNestedStruct3()).toMatchSnapshot();
     });
 });


### PR DESCRIPTION
Closes #690 

- [x] I have updated CHANGELOG.md
- [ ] ~~I have documented my contribution in Tact Docs: https://github.com/tact-lang/tact-docs/pull/PR-NUMBER~~
- [x] I have added tests to demonstrate the contribution is correctly implemented: this usually includes both positive and negative tests, showing the happy path(s) and featuring intentionally broken cases
- [x] I have run all the tests locally and no test failure was reported
- [x] I have run the linter, formatter and spellchecker
- [x] I did not do unrelated and/or undiscussed refactorings
