### PR TITLE
fix: disallow shadowing of recursive function names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Parsing of optional nested struct fields does not cause the `Not a tuple` error anymore: PR [#692](https://github.com/tact-lang/tact/pull/692)
+- Disallow shadowing of recursive function names: PR [#693](https://github.com/tact-lang/tact/pull/693)
 
 ## [1.4.2] - 2024-08-13
 

--- a/src/test/codegen/all-contracts.tact
+++ b/src/test/codegen/all-contracts.tact
@@ -5,3 +5,4 @@ import "./struct-field-func-keywords-name-clash";
 import "./message-opcode-parsing.tact";
 import "./struct-with-default-and-optional-fields";
 import "./mutating-method-on-non-lvalues";
+import "./var-scope-global-fun-shadowing-allowed";

--- a/src/test/codegen/var-scope-global-fun-shadowing-allowed.tact
+++ b/src/test/codegen/var-scope-global-fun-shadowing-allowed.tact
@@ -1,0 +1,5 @@
+contract TestGlobalFunctionShadowing {
+    receive("foo") {
+        let sender = sender();
+    }
+}

--- a/src/test/e2e-emulated/contracts/sample-jetton.tact
+++ b/src/test/e2e-emulated/contracts/sample-jetton.tact
@@ -277,11 +277,10 @@ contract JettonDefaultWallet {
     }
 
     get fun msgValue(value: Int): Int {
-        let msgValue: Int = value;
-        let tonBalanceBeforeMsg: Int = myBalance() - msgValue;
+        let tonBalanceBeforeMsg: Int = myBalance() - value;
         let storageFee: Int = self.minTonsForStorage - min(tonBalanceBeforeMsg, self.minTonsForStorage);
-        msgValue = msgValue - (storageFee + self.gasConsumption);
-        return msgValue;
+        value -= storageFee + self.gasConsumption;
+        return value;
     }
 
     receive(msg: TokenBurn) {

--- a/src/types/__snapshots__/resolveStatements.spec.ts.snap
+++ b/src/types/__snapshots__/resolveStatements.spec.ts.snap
@@ -1135,6 +1135,46 @@ Line 7, col 9:
 "
 `;
 
+exports[`resolveStatements should fail statements for var-scope-rec-fun-shadowing-catch 1`] = `
+"<unknown>:6:14: Variable cannot have the same name as its enclosing function: "rec"
+Line 6, col 14:
+  5 |         42/0;
+> 6 |     } catch (rec) {  // <-- shadowing
+                   ^~~
+  7 |         return rec;
+"
+`;
+
+exports[`resolveStatements should fail statements for var-scope-rec-fun-shadowing-foreach 1`] = `
+"<unknown>:5:14: Variable cannot have the same name as its enclosing function: "rec"
+Line 5, col 14:
+  4 |     let m: map<Int, Int> = null;
+> 5 |     foreach (rec, _ in m) {   // shadowing error
+                   ^~~
+  6 |         42/0;
+"
+`;
+
+exports[`resolveStatements should fail statements for var-scope-rec-fun-shadowing-fun-param 1`] = `
+"<unknown>:3:9: Variable cannot have the same name as its enclosing function: "rec"
+Line 3, col 9:
+  2 | 
+> 3 | fun rec(rec: Int): Int { // <-- shadowing
+              ^~~
+  4 |     return rec;
+"
+`;
+
+exports[`resolveStatements should fail statements for var-scope-rec-fun-shadowing-let 1`] = `
+"<unknown>:4:9: Variable cannot have the same name as its enclosing function: "rec"
+Line 4, col 9:
+  3 | fun rec(): Int {
+> 4 |     let rec: Int = 42;  // shadowing error
+              ^~~
+  5 |     return rec;
+"
+`;
+
 exports[`resolveStatements should fail statements for var-underscore-name-access 1`] = `
 "<unknown>:6:16: Wildcard variable name '_' cannot be accessed
 Line 6, col 16:

--- a/src/types/resolveDescriptors.ts
+++ b/src/types/resolveDescriptors.ts
@@ -1918,7 +1918,7 @@ function checkInitializerType(
     initializer: AstExpression,
     ctx: CompilerContext,
 ): CompilerContext {
-    const stmtCtx = emptyContext(initializer.loc, declTy);
+    const stmtCtx = emptyContext(initializer.loc, null, declTy);
     ctx = resolveExpression(initializer, stmtCtx, ctx);
     const initTy = getExpType(ctx, initializer);
     if (!isAssignable(initTy, declTy)) {

--- a/src/types/resolveStatements.ts
+++ b/src/types/resolveStatements.ts
@@ -29,6 +29,7 @@ import { printTypeRef, TypeRef } from "./types";
 
 export type StatementContext = {
     root: SrcInfo;
+    funName: string | null;
     returns: TypeRef;
     vars: Map<string, TypeRef>;
     requiredFields: string[];
@@ -36,10 +37,12 @@ export type StatementContext = {
 
 export function emptyContext(
     root: SrcInfo,
+    funName: string | null,
     returns: TypeRef,
 ): StatementContext {
     return {
         root,
+        funName,
         returns,
         vars: new Map(),
         requiredFields: [],
@@ -54,6 +57,13 @@ function checkVariableExists(
     if (sctx.vars.has(idText(name))) {
         throwCompilationError(
             `Variable already exists: ${idTextErr(name)}`,
+            name.loc,
+        );
+    }
+    // Check if the user tries to shadow the current function name
+    if (sctx.funName === idText(name)) {
+        throwCompilationError(
+            `Variable cannot have the same name as its enclosing function: ${idTextErr(name)}`,
             name.loc,
         );
     }
@@ -675,7 +685,7 @@ export function resolveStatements(ctx: CompilerContext) {
     for (const f of Object.values(getAllStaticFunctions(ctx))) {
         if (f.ast.kind === "function_def") {
             // Build statement context
-            let sctx = emptyContext(f.ast.loc, f.returns);
+            let sctx = emptyContext(f.ast.loc, f.name, f.returns);
             for (const p of f.params) {
                 sctx = addVariable(p.name, p.type, ctx, sctx);
             }
@@ -689,7 +699,7 @@ export function resolveStatements(ctx: CompilerContext) {
         // Process init
         if (t.init) {
             // Build statement context
-            let sctx = emptyContext(t.init.ast.loc, { kind: "void" });
+            let sctx = emptyContext(t.init.ast.loc, null, { kind: "void" });
 
             // Self
             sctx = addVariable(
@@ -723,7 +733,7 @@ export function resolveStatements(ctx: CompilerContext) {
         // Process receivers
         for (const f of Object.values(t.receivers)) {
             // Build statement context
-            let sctx = emptyContext(f.ast.loc, { kind: "void" });
+            let sctx = emptyContext(f.ast.loc, null, { kind: "void" });
             sctx = addVariable(
                 selfId,
                 { kind: "ref", name: t.name, optional: false },
@@ -812,7 +822,7 @@ export function resolveStatements(ctx: CompilerContext) {
                 f.ast.kind !== "function_decl"
             ) {
                 // Build statement context
-                let sctx = emptyContext(f.ast.loc, f.returns);
+                let sctx = emptyContext(f.ast.loc, f.name, f.returns);
                 sctx = addVariable(
                     selfId,
                     { kind: "ref", name: t.name, optional: false },

--- a/src/types/stmts-failed/var-scope-rec-fun-shadowing-catch.tact
+++ b/src/types/stmts-failed/var-scope-rec-fun-shadowing-catch.tact
@@ -1,0 +1,11 @@
+primitive Int;
+
+fun rec(): Int {
+    try {
+        42/0;
+    } catch (rec) {  // <-- shadowing
+        return rec;
+    }
+    return rec();
+}
+

--- a/src/types/stmts-failed/var-scope-rec-fun-shadowing-foreach.tact
+++ b/src/types/stmts-failed/var-scope-rec-fun-shadowing-foreach.tact
@@ -1,0 +1,9 @@
+primitive Int;
+
+fun rec(): Int {
+    let m: map<Int, Int> = null;
+    foreach (rec, _ in m) {   // shadowing error
+        42/0;
+    }
+    return rec();
+}

--- a/src/types/stmts-failed/var-scope-rec-fun-shadowing-fun-param.tact
+++ b/src/types/stmts-failed/var-scope-rec-fun-shadowing-fun-param.tact
@@ -1,0 +1,6 @@
+primitive Int;
+
+fun rec(rec: Int): Int { // <-- shadowing
+    return rec;
+}
+

--- a/src/types/stmts-failed/var-scope-rec-fun-shadowing-let.tact
+++ b/src/types/stmts-failed/var-scope-rec-fun-shadowing-let.tact
@@ -1,0 +1,6 @@
+primitive Int;
+
+fun rec(): Int {
+    let rec: Int = 42;  // shadowing error
+    return rec;
+}


### PR DESCRIPTION
Closes #307

<!--
IMPORTANT:
If your PR doesn't close a particular issue, please, create the issue first and describe the whole context: what you're adding/changing and why you're doing so. And only then open the Pull Request, which would close that issue!

In case you are adding a new language feature, a standard library function or introducing other user-facing changes, you need to document them via a new PR to tact-docs.
-->

- [x] I have updated CHANGELOG.md
- ~[ ] I have documented my contribution in Tact Docs: https://github.com/tact-lang/tact-docs/pull/PR-NUMBER~
- [x] I have added tests to demonstrate the contribution is correctly implemented: this usually includes both positive and negative tests, showing the happy path(s) and featuring intentionally broken cases
- [x] I have run all the tests locally and no test failure was reported
- [x] I have run the linter, formatter and spellchecker
- [x] I did not do unrelated and/or undiscussed refactorings
