### PR TITLE
fix: better error message if constant shadows stdlib identifier

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Parsing of optional nested struct fields does not cause the `Not a tuple` error anymore: PR [#692](https://github.com/tact-lang/tact/pull/692)
 - Disallow shadowing of recursive function names: PR [#693](https://github.com/tact-lang/tact/pull/693)
+- Better error message for the case when a constant shadows an stdlib identifier: PR [#694](https://github.com/tact-lang/tact/pull/694)
 
 ## [1.4.2] - 2024-08-13
 

--- a/src/test/compilation-failed/contracts/scope-const-shadows-stdlib-ident.tact
+++ b/src/test/compilation-failed/contracts/scope-const-shadows-stdlib-ident.tact
@@ -1,0 +1,1 @@
+const b: Int = 42;

--- a/src/test/compilation-failed/scope-errors.spec.ts
+++ b/src/test/compilation-failed/scope-errors.spec.ts
@@ -1,0 +1,14 @@
+import { __DANGER_resetNodeId } from "../../grammar/ast";
+import { itShouldNotCompile } from "./util";
+
+describe("scope-errors", () => {
+    beforeEach(() => {
+        __DANGER_resetNodeId();
+    });
+
+    itShouldNotCompile({
+        testName: "scope-const-shadows-stdlib-ident",
+        errorMessage:
+            'Constant "b" is shadowing an identifier defined in the Tact standard library: pick a different constant name',
+    });
+});

--- a/src/test/compilation-failed/tact.config.json
+++ b/src/test/compilation-failed/tact.config.json
@@ -136,6 +136,11 @@
       "name": "func-function-does-not-exist",
       "path": "./contracts/func-function-does-not-exist.tact",
       "output": "./contracts/output"
+    },
+    {
+      "name": "scope-const-shadows-stdlib-ident",
+      "path": "./contracts/scope-const-shadows-stdlib-ident.tact",
+      "output": "./contracts/output"
     }
   ]
 }

--- a/src/types/resolveStatements.ts
+++ b/src/types/resolveStatements.ts
@@ -20,6 +20,7 @@ import {
 import {
     getAllStaticFunctions,
     getAllTypes,
+    getStaticConstant,
     getType,
     hasStaticConstant,
     resolveTypeRef,
@@ -68,10 +69,18 @@ function checkVariableExists(
         );
     }
     if (hasStaticConstant(ctx, idText(name))) {
-        throwCompilationError(
-            `Variable ${idTextErr(name)} is trying to shadow an existing constant with the same name`,
-            name.loc,
-        );
+        if (name.loc.origin === "stdlib") {
+            const constLoc = getStaticConstant(ctx, idText(name)).loc;
+            throwCompilationError(
+                `Constant ${idTextErr(name)} is shadowing an identifier defined in the Tact standard library: pick a different constant name`,
+                constLoc,
+            );
+        } else {
+            throwCompilationError(
+                `Variable ${idTextErr(name)} is trying to shadow an existing constant with the same name`,
+                name.loc,
+            );
+        }
     }
 }
 


### PR DESCRIPTION
Closes #691

<!--
IMPORTANT:
If your PR doesn't close a particular issue, please, create the issue first and describe the whole context: what you're adding/changing and why you're doing so. And only then open the Pull Request, which would close that issue!

In case you are adding a new language feature, a standard library function or introducing other user-facing changes, you need to document them via a new PR to tact-docs.
-->

- [x] I have updated CHANGELOG.md
- ~[ ] I have documented my contribution in Tact Docs: https://github.com/tact-lang/tact-docs/pull/PR-NUMBER~
- [x] I have added tests to demonstrate the contribution is correctly implemented: this usually includes both positive and negative tests, showing the happy path(s) and featuring intentionally broken cases
- [x] I have run all the tests locally and no test failure was reported
- [x] I have run the linter, formatter and spellchecker
- [x] I did not do unrelated and/or undiscussed refactorings
