### PR TITLE
fix: only generate non-modifying native functions once

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Defining two native functions from the same FunC function now does not fail compilation: PR [#699](https://github.com/tact-lang/tact/pull/699)
+
 ## [1.4.3] - 2024-08-16
 
 ### Fixed

--- a/src/generator/writers/writeFunction.ts
+++ b/src/generator/writers/writeFunction.ts
@@ -521,7 +521,7 @@ export function writeFunction(f: FunctionDescription, ctx: WriterContext) {
 
     // Do not write native functions
     if (f.ast.kind === "native_function_decl") {
-        if (f.isMutating) {
+        if (f.isMutating && !ctx.isRendered(idText(f.ast.nativeName))) {
             // Write same function in non-mutating form
             const nonMutName = ops.nonModifying(idText(f.ast.nativeName));
             ctx.fun(nonMutName, () => {
@@ -544,6 +544,7 @@ export function writeFunction(f: FunctionDescription, ctx: WriterContext) {
                     );
                 });
             });
+            ctx.markRendered(idText(f.ast.nativeName));
         }
         return;
     }


### PR DESCRIPTION
Closes #698 

- [x] I have updated CHANGELOG.md
- [ ] ~~I have documented my contribution in Tact Docs: https://github.com/tact-lang/tact-docs/pull/PR-NUMBER~~
- [x] I have added tests to demonstrate the contribution is correctly implemented: this usually includes both positive and negative tests, showing the happy path(s) and featuring intentionally broken cases
- [x] I have run all the tests locally and no test failure was reported
- [x] I have run the linter, formatter and spellchecker
- [x] I did not do unrelated and/or undiscussed refactorings
