### PR TITLE
"Monadish" refactoring of interpreter

### DIFF
--- a/src/constEval.ts
+++ b/src/constEval.ts
@@ -18,12 +18,13 @@ import {
 import { ExpressionTransformer } from "./optimizer/types";
 import { StandardOptimizer } from "./optimizer/standardOptimizer";
 import {
-    Interpreter,
     ensureInt,
     evalBinaryOp,
     evalUnaryOp,
-    throwNonFatalErrorConstEval,
-} from "./interpreter";
+    StandardSemantics,
+} from "./interpreterSemantics/standardSemantics";
+import { Interpreter } from "./interpreter";
+import { throwNonFatalErrorConstEval } from "./interpreterSemantics/util";
 
 // The optimizer that applies the rewriting rules during partial evaluation.
 // For the moment we use an optimizer that respects overflows.
@@ -86,7 +87,7 @@ export function evalConstantExpression(
     ast: AstExpression,
     ctx: CompilerContext,
 ): Value {
-    const interpreter = new Interpreter(ctx);
+    const interpreter = new Interpreter(new StandardSemantics(ctx));
     const result = interpreter.interpretExpression(ast);
     return result;
 }
@@ -95,7 +96,7 @@ export function partiallyEvalExpression(
     ast: AstExpression,
     ctx: CompilerContext,
 ): AstExpression {
-    const interpreter = new Interpreter(ctx);
+    const interpreter = new Interpreter(new StandardSemantics(ctx));
     switch (ast.kind) {
         case "id":
             try {

--- a/src/interpreter.ts
+++ b/src/interpreter.ts
@@ -1,15 +1,7 @@
-import { Address, Cell, toNano } from "@ton/core";
 import { evalConstantExpression } from "./constEval";
 import { CompilerContext } from "./context";
+import { TactConstEvalError, TactParseError, idTextErr } from "./errors";
 import {
-    TactConstEvalError,
-    TactParseError,
-    idTextErr,
-    throwConstEvalError,
-    throwInternalCompilerError,
-} from "./errors";
-import {
-    AstBinaryOperation,
     AstBoolean,
     AstCondition,
     AstConditional,
@@ -46,525 +38,16 @@ import {
     AstStructDecl,
     AstStructInstance,
     AstTrait,
-    AstUnaryOperation,
-    eqNames,
     idText,
-    isSelfId,
 } from "./grammar/ast";
-import { SrcInfo, dummySrcInfo, parseExpression } from "./grammar/grammar";
-import { divFloor, modFloor } from "./optimizer/util";
-import {
-    getStaticConstant,
-    getStaticFunction,
-    getType,
-    hasStaticConstant,
-    hasStaticFunction,
-} from "./types/resolveDescriptors";
-import { getExpType } from "./types/resolveExpression";
-import {
-    CommentValue,
-    StructValue,
-    TypeRef,
-    Value,
-    showValue,
-} from "./types/types";
-import { sha256_sync } from "@ton/crypto";
-import { enabledMasterchain } from "./config/features";
+import { parseExpression } from "./grammar/grammar";
+import { InterpreterSemantics } from "./interpreterSemantics/types";
+import { throwNonFatalErrorConstEval } from "./interpreterSemantics/util";
+import { Value } from "./types/types";
 
-// TVM integers are signed 257-bit integers
-const minTvmInt: bigint = -(2n ** 256n);
-const maxTvmInt: bigint = 2n ** 256n - 1n;
-
-// Range allowed in repeat statements
-const minRepeatStatement: bigint = -(2n ** 256n); // Note it is the same as minimum for TVM
-const maxRepeatStatement: bigint = 2n ** 31n - 1n;
-
-// Throws a non-fatal const-eval error, in the sense that const-eval as a compiler
-// optimization cannot be applied, e.g. to `let`-statements.
-// Note that for const initializers this is a show-stopper.
-export function throwNonFatalErrorConstEval(
-    msg: string,
-    source: SrcInfo,
-): never {
-    throwConstEvalError(
-        `Cannot evaluate expression to a constant: ${msg}`,
-        false,
-        source,
-    );
-}
-
-// Throws a fatal const-eval, meaning this is a meaningless program,
-// so compilation should be aborted in all cases
-function throwErrorConstEval(msg: string, source: SrcInfo): never {
-    throwConstEvalError(
-        `Cannot evaluate expression to a constant: ${msg}`,
-        true,
-        source,
-    );
-}
 type EvalResult =
     | { kind: "ok"; value: Value }
     | { kind: "error"; message: string };
-
-export function ensureInt(val: Value, source: SrcInfo): bigint {
-    if (typeof val !== "bigint") {
-        throwErrorConstEval(
-            `integer expected, but got '${showValue(val)}'`,
-            source,
-        );
-    }
-    if (minTvmInt <= val && val <= maxTvmInt) {
-        return val;
-    } else {
-        throwErrorConstEval(
-            `integer '${showValue(val)}' does not fit into TVM Int type`,
-            source,
-        );
-    }
-}
-
-function ensureRepeatInt(val: Value, source: SrcInfo): bigint {
-    if (typeof val !== "bigint") {
-        throwErrorConstEval(
-            `integer expected, but got '${showValue(val)}'`,
-            source,
-        );
-    }
-    if (minRepeatStatement <= val && val <= maxRepeatStatement) {
-        return val;
-    } else {
-        throwErrorConstEval(
-            `repeat argument must be a number between -2^256 (inclusive) and 2^31 - 1 (inclusive)`,
-            source,
-        );
-    }
-}
-
-function ensureBoolean(val: Value, source: SrcInfo): boolean {
-    if (typeof val !== "boolean") {
-        throwErrorConstEval(
-            `boolean expected, but got '${showValue(val)}'`,
-            source,
-        );
-    }
-    return val;
-}
-
-function ensureString(val: Value, source: SrcInfo): string {
-    if (typeof val !== "string") {
-        throwErrorConstEval(
-            `string expected, but got '${showValue(val)}'`,
-            source,
-        );
-    }
-    return val;
-}
-
-function ensureFunArity(arity: number, args: AstExpression[], source: SrcInfo) {
-    if (args.length !== arity) {
-        throwErrorConstEval(
-            `function expects ${arity} argument(s), but got ${args.length}`,
-            source,
-        );
-    }
-}
-
-function ensureMethodArity(
-    arity: number,
-    args: AstExpression[],
-    source: SrcInfo,
-) {
-    if (args.length !== arity) {
-        throwErrorConstEval(
-            `method expects ${arity} argument(s), but got ${args.length}`,
-            source,
-        );
-    }
-}
-
-export function evalUnaryOp(
-    op: AstUnaryOperation,
-    valOperand: Value,
-    operandLoc: SrcInfo = dummySrcInfo,
-    source: SrcInfo = dummySrcInfo,
-): Value {
-    switch (op) {
-        case "+":
-            return ensureInt(valOperand, operandLoc);
-        case "-":
-            return ensureInt(-ensureInt(valOperand, operandLoc), source);
-        case "~":
-            return ~ensureInt(valOperand, operandLoc);
-        case "!":
-            return !ensureBoolean(valOperand, operandLoc);
-        case "!!":
-            if (valOperand === null) {
-                throwErrorConstEval(
-                    "non-null value expected but got null",
-                    operandLoc,
-                );
-            }
-            return valOperand;
-    }
-}
-
-export function evalBinaryOp(
-    op: AstBinaryOperation,
-    valLeft: Value,
-    valRight: Value,
-    locLeft: SrcInfo = dummySrcInfo,
-    locRight: SrcInfo = dummySrcInfo,
-    source: SrcInfo = dummySrcInfo,
-): Value {
-    switch (op) {
-        case "+":
-            return ensureInt(
-                ensureInt(valLeft, locLeft) + ensureInt(valRight, locRight),
-                source,
-            );
-        case "-":
-            return ensureInt(
-                ensureInt(valLeft, locLeft) - ensureInt(valRight, locRight),
-                source,
-            );
-        case "*":
-            return ensureInt(
-                ensureInt(valLeft, locLeft) * ensureInt(valRight, locRight),
-                source,
-            );
-        case "/": {
-            // The semantics of integer division for TVM (and by extension in Tact)
-            // is a non-conventional one: by default it rounds towards negative infinity,
-            // meaning, for instance, -1 / 5 = -1 and not zero, as in many mainstream languages.
-            // Still, the following holds: a / b * b + a % b == a, for all b != 0.
-            const r = ensureInt(valRight, locRight);
-            if (r === 0n)
-                throwErrorConstEval(
-                    "divisor expression must be non-zero",
-                    locRight,
-                );
-            return ensureInt(divFloor(ensureInt(valLeft, locLeft), r), source);
-        }
-        case "%": {
-            // Same as for division, see the comment above
-            // Example: -1 % 5 = 4
-            const r = ensureInt(valRight, locRight);
-            if (r === 0n)
-                throwErrorConstEval(
-                    "divisor expression must be non-zero",
-                    locRight,
-                );
-            return ensureInt(modFloor(ensureInt(valLeft, locLeft), r), source);
-        }
-        case "&":
-            return ensureInt(valLeft, locLeft) & ensureInt(valRight, locRight);
-        case "|":
-            return ensureInt(valLeft, locLeft) | ensureInt(valRight, locRight);
-        case "^":
-            return ensureInt(valLeft, locLeft) ^ ensureInt(valRight, locRight);
-        case "<<": {
-            const valNum = ensureInt(valLeft, locLeft);
-            const valBits = ensureInt(valRight, locRight);
-            if (0n > valBits || valBits > 256n) {
-                throwErrorConstEval(
-                    `the number of bits shifted ('${valBits}') must be within [0..256] range`,
-                    locRight,
-                );
-            }
-            try {
-                return ensureInt(valNum << valBits, source);
-            } catch (e) {
-                if (e instanceof RangeError)
-                    // this actually should not happen
-                    throwErrorConstEval(
-                        `integer does not fit into TVM Int type`,
-                        source,
-                    );
-                throw e;
-            }
-        }
-        case ">>": {
-            const valNum = ensureInt(valLeft, locLeft);
-            const valBits = ensureInt(valRight, locRight);
-            if (0n > valBits || valBits > 256n) {
-                throwErrorConstEval(
-                    `the number of bits shifted ('${valBits}') must be within [0..256] range`,
-                    locRight,
-                );
-            }
-            try {
-                return ensureInt(valNum >> valBits, source);
-            } catch (e) {
-                if (e instanceof RangeError)
-                    // this is actually should not happen
-                    throwErrorConstEval(
-                        `integer does not fit into TVM Int type`,
-                        source,
-                    );
-                throw e;
-            }
-        }
-        case ">":
-            return ensureInt(valLeft, locLeft) > ensureInt(valRight, locRight);
-        case "<":
-            return ensureInt(valLeft, locLeft) < ensureInt(valRight, locRight);
-        case ">=":
-            return ensureInt(valLeft, locLeft) >= ensureInt(valRight, locRight);
-        case "<=":
-            return ensureInt(valLeft, locLeft) <= ensureInt(valRight, locRight);
-        case "==":
-            // the null comparisons account for optional types, e.g.
-            // a const x: Int? = 42 can be compared to null
-            if (
-                typeof valLeft !== typeof valRight &&
-                valLeft !== null &&
-                valRight !== null
-            ) {
-                throwErrorConstEval(
-                    "operands of `==` must have same type",
-                    source,
-                );
-            }
-            return valLeft === valRight;
-        case "!=":
-            if (typeof valLeft !== typeof valRight) {
-                throwErrorConstEval(
-                    "operands of `!=` must have same type",
-                    source,
-                );
-            }
-            return valLeft !== valRight;
-        case "&&":
-            return (
-                ensureBoolean(valLeft, locLeft) &&
-                ensureBoolean(valRight, locRight)
-            );
-        case "||":
-            return (
-                ensureBoolean(valLeft, locLeft) ||
-                ensureBoolean(valRight, locRight)
-            );
-    }
-}
-
-function interpretEscapeSequences(stringLiteral: string, source: SrcInfo) {
-    return stringLiteral.replace(
-        /\\\\|\\"|\\n|\\r|\\t|\\v|\\b|\\f|\\u{([0-9A-Fa-f]{1,6})}|\\u([0-9A-Fa-f]{4})|\\x([0-9A-Fa-f]{2})/g,
-        (match, unicodeCodePoint, unicodeEscape, hexEscape) => {
-            switch (match) {
-                case "\\\\":
-                    return "\\";
-                case '\\"':
-                    return '"';
-                case "\\n":
-                    return "\n";
-                case "\\r":
-                    return "\r";
-                case "\\t":
-                    return "\t";
-                case "\\v":
-                    return "\v";
-                case "\\b":
-                    return "\b";
-                case "\\f":
-                    return "\f";
-                default:
-                    // Handle Unicode code point escape
-                    if (unicodeCodePoint) {
-                        const codePoint = parseInt(unicodeCodePoint, 16);
-                        if (codePoint > 0x10ffff) {
-                            throwErrorConstEval(
-                                `unicode code point is outside of valid range 000000-10FFFF: ${stringLiteral}`,
-                                source,
-                            );
-                        }
-                        return String.fromCodePoint(codePoint);
-                    }
-                    // Handle Unicode escape
-                    if (unicodeEscape) {
-                        const codeUnit = parseInt(unicodeEscape, 16);
-                        return String.fromCharCode(codeUnit);
-                    }
-                    // Handle hex escape
-                    if (hexEscape) {
-                        const hexValue = parseInt(hexEscape, 16);
-                        return String.fromCharCode(hexValue);
-                    }
-                    return match;
-            }
-        },
-    );
-}
-
-class ReturnSignal extends Error {
-    private value?: Value;
-
-    constructor(value?: Value) {
-        super();
-        this.value = value;
-    }
-
-    public getValue(): Value | undefined {
-        return this.value;
-    }
-}
-
-type InterpreterConfig = {
-    // Options that tune the interpreter's behavior.
-
-    // Maximum number of iterations inside a loop before a time out is issued.
-    // This option only applies to: do...until and while loops
-    maxLoopIterations: bigint;
-};
-
-const WILDCARD_NAME: string = "_";
-
-type Environment = { values: Map<string, Value>; parent?: Environment };
-
-class EnvironmentStack {
-    private currentEnv: Environment;
-
-    constructor() {
-        this.currentEnv = { values: new Map() };
-    }
-
-    private findBindingMap(name: string): Map<string, Value> | undefined {
-        let env: Environment | undefined = this.currentEnv;
-        while (env !== undefined) {
-            if (env.values.has(name)) {
-                return env.values;
-            } else {
-                env = env.parent;
-            }
-        }
-        return undefined;
-    }
-
-    /*
-    Sets a binding for "name" in the **current** environment of the stack.
-    If a binding for "name" already exists in the current environment, it 
-    overwrites the binding with the provided value.
-    As a special case, name "_" is ignored.
-
-    Note that this method does not check if binding "name" already exists in 
-    a parent environment.
-    This means that if binding "name" already exists in a parent environment, 
-    it will be shadowed by the provided value in the current environment.
-    This shadowing behavior is useful for modelling recursive function calls.
-    For example, consider the recursive implementation of factorial 
-    (for simplification purposes, it returns 1 for the factorial of 
-    negative numbers):
-
-    1  fun factorial(a: Int): Int {
-    2  if (a <= 1) {
-    3     return 1;
-    4  } else {
-    5     return a * factorial(a - 1);
-    6  }
-
-    Just before factorial(4) finishes its execution, the environment stack will
-    look as follows (the arrows point to their parent environment):
-
-    a = 4 <------- a = 3 <-------- a = 2 <------- a = 1
-
-    Note how each child environment shadows variable a, because each
-    recursive call to factorial at line 5 creates a child
-    environment with a new binding for a.
-
-    When factorial(1) = 1 finishes execution, the environment at the top
-    of the stack is popped:
-    
-    a = 4 <------- a = 3 <-------- a = 2
-
-    and execution resumes at line 5 in the environment where a = 2,
-    so that the return at line 5 is 2 * 1 = 2.
-
-    This in turn causes the stack to pop the environment at the top:
-
-    a = 4 <------- a = 3
-
-    so that the return at line 5 (now in the environment a = 3) will 
-    produce 3 * 2 = 6, and so on.
-    */
-    public setNewBinding(name: string, val: Value) {
-        if (name !== WILDCARD_NAME) {
-            this.currentEnv.values.set(name, val);
-        }
-    }
-
-    /*
-    Searches the binding "name" in the stack, starting at the current
-    environment and moving towards the parent environments. 
-    If it finds the binding, it updates its value
-    to "val". If it does not find "name", the stack is unchanged.
-    As a special case, name "_" is always ignored.
-    */
-    public updateBinding(name: string, val: Value) {
-        if (name !== WILDCARD_NAME) {
-            const bindings = this.findBindingMap(name);
-            if (bindings !== undefined) {
-                bindings.set(name, val);
-            }
-        }
-    }
-
-    /*
-    Searches the binding "name" in the stack, starting at the current
-    environment and moving towards the parent environments. 
-    If it finds "name", it returns its value.
-    If it does not find "name", it returns undefined.
-    As a special case, name "_" always returns undefined.
-    */
-    public getBinding(name: string): Value | undefined {
-        if (name === WILDCARD_NAME) {
-            return undefined;
-        }
-        const bindings = this.findBindingMap(name);
-        if (bindings !== undefined) {
-            return bindings.get(name);
-        } else {
-            return undefined;
-        }
-    }
-
-    public selfInEnvironment(): boolean {
-        return this.findBindingMap("self") !== undefined;
-    }
-
-    /*
-    Executes "code" in a fresh environment that is placed at the top
-    of the environment stack. The fresh environment is initialized
-    with the bindings in "initialBindings". Once "code" finishes
-    execution, the new environment is automatically popped from 
-    the stack. 
-    
-    This method is useful for starting a new local variables scope, 
-    like in a function call.
-    */
-    public executeInNewEnvironment<T>(
-        code: () => T,
-        initialBindings: { names: string[]; values: Value[] } = {
-            names: [],
-            values: [],
-        },
-    ): T {
-        const names = initialBindings.names;
-        const values = initialBindings.values;
-
-        const oldEnv = this.currentEnv;
-        this.currentEnv = { values: new Map(), parent: oldEnv };
-
-        names.forEach((name, index) => {
-            this.setNewBinding(name, values[index]!);
-        }, this);
-
-        try {
-            return code();
-        } finally {
-            this.currentEnv = oldEnv;
-        }
-    }
-}
 
 export function parseAndEvalExpression(sourceCode: string): EvalResult {
     try {
@@ -584,62 +67,34 @@ export function parseAndEvalExpression(sourceCode: string): EvalResult {
     }
 }
 
-const defaultInterpreterConfig: InterpreterConfig = {
-    // We set the default max number of loop iterations
-    // to the maximum number allowed for repeat loops
-    maxLoopIterations: maxRepeatStatement,
-};
-
 /*
-Interprets Tact AST trees. 
-The constructor receives an optional CompilerContext which includes 
-all external declarations that the interpreter will use during interpretation.
-If no CompilerContext is provided, the interpreter will use an empty 
-CompilerContext.
+A parameterizable Tact interpreter. It receives a concrete semantics in the constructor. 
+The concrete semantics attaches custom behaviors to the interpreter. 
+For example, for instantiating an interpreter with the standard Tact semantics:
 
-**IMPORTANT**: if a custom CompilerContext is provided, it should be the 
-CompilerContext provided by the typechecker. 
+const interpreter = new Interpreter(new StandardSemantics(ctx));
 
-The reason for requiring a CompilerContext is that the interpreter should work 
-in the use case where the interpreter only knows part of the code.
-For example, consider the following code (I marked with brackets [ ] the places 
-where the interpreter gets called during expression simplification in the 
-compilation phase):
-
-const C: Int = [1];
-
-contract TestContract {
-
-   get fun test(): Int {
-      return [C + 1];
-   }
-}
-
-When the interpreter gets called inside the brackets, it does not know what 
-other code is surrounding those brackets, because the interpreter did not execute the 
-code outside the brackets. Hence, it relies on the typechecker to receive the 
-CompilerContext that includes the declarations in the code 
-(the constant C for example).
-
-Since the interpreter relies on the typechecker, it assumes that the given AST tree
-is already a valid Tact program.
-
-Internally, the interpreter uses a stack of environments to keep track of
-variables at different scopes. Each environment in the stack contains a map
-that binds a variable name to its corresponding value.
+Generic type T is the expressions' result type. Generic type S the statements' result type.
 */
-export class Interpreter {
-    private envStack: EnvironmentStack;
-    private context: CompilerContext;
-    private config: InterpreterConfig;
+export class Interpreter<T, S> {
+    private semantics: InterpreterSemantics<T, S>;
 
-    constructor(
-        context: CompilerContext = new CompilerContext(),
-        config: InterpreterConfig = defaultInterpreterConfig,
-    ) {
-        this.envStack = new EnvironmentStack();
-        this.context = context;
-        this.config = config;
+    constructor(semantics: InterpreterSemantics<T, S>) {
+        this.semantics = semantics;
+    }
+
+    private executeStatements(
+        statements: AstStatement[],
+        initial: S = this.semantics.emptyStatementResult(),
+    ): S {
+        return statements.reduce(
+            (prev, currStmt) =>
+                this.semantics.joinStatementResults(
+                    prev,
+                    this.interpretStatement(currStmt),
+                ),
+            initial,
+        );
     }
 
     public interpretModuleItem(ast: AstModuleItem): void {
@@ -727,7 +182,7 @@ export class Interpreter {
         );
     }
 
-    public interpretExpression(ast: AstExpression): Value {
+    public interpretExpression(ast: AstExpression): T {
         switch (ast.kind) {
             case "id":
                 return this.interpretName(ast);
@@ -758,542 +213,173 @@ export class Interpreter {
         }
     }
 
-    public interpretName(ast: AstId): Value {
-        if (hasStaticConstant(this.context, idText(ast))) {
-            const constant = getStaticConstant(this.context, idText(ast));
-            if (constant.value !== undefined) {
-                return constant.value;
-            } else {
-                throwErrorConstEval(
-                    `cannot evaluate declared constant ${idTextErr(ast)} as it does not have a body`,
-                    ast.loc,
-                );
-            }
-        }
-        const variableBinding = this.envStack.getBinding(idText(ast));
-        if (variableBinding !== undefined) {
-            return variableBinding;
-        }
-        throwNonFatalErrorConstEval("cannot evaluate a variable", ast.loc);
+    public interpretName(ast: AstId): T {
+        return this.semantics.lookupBinding(ast);
     }
 
-    public interpretMethodCall(ast: AstMethodCall): Value {
-        switch (idText(ast.method)) {
-            case "asComment": {
-                ensureMethodArity(0, ast.args, ast.loc);
-                const comment = ensureString(
-                    this.interpretExpression(ast.self),
-                    ast.self.loc,
-                );
-                return new CommentValue(comment);
-            }
-            default:
-                throwNonFatalErrorConstEval(
-                    `calls of ${idTextErr(ast.method)} are not supported at this moment`,
-                    ast.loc,
-                );
+    public interpretMethodCall(ast: AstMethodCall): T {
+        const selfValue = this.interpretExpression(ast.self);
+        const argValues = ast.args.map(this.interpretExpression, this);
+
+        const builtinResult = this.semantics.evalBuiltinOnSelf(
+            ast,
+            selfValue,
+            argValues,
+        );
+        if (builtinResult !== undefined) {
+            return builtinResult;
         }
+
+        // We have a call to a user-defined function.
+
+        throwNonFatalErrorConstEval(
+            `calls of ${idTextErr(ast.method)} are not supported at this moment`,
+            ast.loc,
+        );
     }
 
-    public interpretInitOf(ast: AstInitOf): Value {
+    public interpretInitOf(ast: AstInitOf): T {
         throwNonFatalErrorConstEval(
             "initOf is not supported at this moment",
             ast.loc,
         );
     }
 
-    public interpretNull(_ast: AstNull): null {
-        return null;
+    public interpretNull(ast: AstNull): T {
+        return this.semantics.evalNull(ast);
     }
 
-    public interpretBoolean(ast: AstBoolean): boolean {
-        return ast.value;
+    public interpretBoolean(ast: AstBoolean): T {
+        return this.semantics.evalBoolean(ast);
     }
 
-    public interpretNumber(ast: AstNumber): bigint {
-        return ensureInt(ast.value, ast.loc);
+    public interpretNumber(ast: AstNumber): T {
+        return this.semantics.evalInteger(ast);
     }
 
-    public interpretString(ast: AstString): string {
-        return ensureString(
-            interpretEscapeSequences(ast.value, ast.loc),
-            ast.loc,
-        );
+    public interpretString(ast: AstString): T {
+        return this.semantics.evalString(ast);
     }
 
-    public interpretUnaryOp(ast: AstOpUnary): Value {
-        // Tact grammar does not have negative integer literals,
-        // so in order to avoid errors for `-115792089237316195423570985008687907853269984665640564039457584007913129639936`
-        // which is `-(2**256)` we need to have a special case for it
-
-        if (ast.operand.kind === "number" && ast.op === "-") {
-            // emulating negative integer literals
-            return ensureInt(-ast.operand.value, ast.loc);
-        }
-
-        const valOperand = this.interpretExpression(ast.operand);
-
-        return evalUnaryOp(ast.op, valOperand, ast.operand.loc, ast.loc);
+    public interpretUnaryOp(ast: AstOpUnary): T {
+        // Instead of immediately evaluating the operand, we surround the
+        // operand evaluation in a continuation, because some
+        // unary operators need to perform some previous checks before
+        // evaluating the operand.
+        const operandEvaluator = () => this.interpretExpression(ast.operand);
+        return this.semantics.evalUnaryOp(ast, operandEvaluator);
     }
 
-    public interpretBinaryOp(ast: AstOpBinary): Value {
-        const valLeft = this.interpretExpression(ast.left);
-        const valRight = this.interpretExpression(ast.right);
+    public interpretBinaryOp(ast: AstOpBinary): T {
+        const leftValue = this.interpretExpression(ast.left);
 
-        return evalBinaryOp(
-            ast.op,
-            valLeft,
-            valRight,
-            ast.left.loc,
-            ast.right.loc,
-            ast.loc,
-        );
+        // As done with unary operators, we surround the evaluation
+        // of the right argument in a continuation, just in case
+        // the semantics need to do some special action before evaluating
+        // the right argument, like short-circuiting, for example.
+        const rightEvaluator = () => this.interpretExpression(ast.right);
+
+        return this.semantics.evalBinaryOp(ast, leftValue, rightEvaluator);
     }
 
-    public interpretConditional(ast: AstConditional): Value {
-        // here we rely on the typechecker that both branches have the same type
-        const valCond = ensureBoolean(
+    public interpretConditional(ast: AstConditional): T {
+        const conditionValue = this.semantics.toBoolean(
             this.interpretExpression(ast.condition),
             ast.condition.loc,
         );
-        if (valCond) {
+        if (conditionValue) {
             return this.interpretExpression(ast.thenBranch);
         } else {
             return this.interpretExpression(ast.elseBranch);
         }
     }
 
-    public interpretStructInstance(ast: AstStructInstance): StructValue {
-        const structTy = getType(this.context, ast.type);
-
-        // initialize the resulting struct value with
-        // the default values for fields with initializers
-        // or null for uninitialized optional fields
-        const resultWithDefaultFields: StructValue = structTy.fields.reduce(
-            (resObj, field) => {
-                if (field.default !== undefined) {
-                    resObj[field.name] = field.default;
-                } else {
-                    if (field.type.kind === "ref" && field.type.optional) {
-                        resObj[field.name] = null;
-                    }
-                }
-                return resObj;
-            },
-            { $tactStruct: idText(ast.type) } as StructValue,
+    public interpretStructInstance(ast: AstStructInstance): T {
+        // Make each of the field initializers a continuation
+        const argEvaluators = ast.args.map(
+            (fieldWithInit) => () =>
+                this.interpretExpression(fieldWithInit.initializer),
+            this,
         );
 
-        // this will override default fields set above
-        return ast.args.reduce((resObj, fieldWithInit) => {
-            resObj[idText(fieldWithInit.field)] = this.interpretExpression(
-                fieldWithInit.initializer,
-            );
-            return resObj;
-        }, resultWithDefaultFields);
+        return this.semantics.evalStructInstance(ast, argEvaluators);
     }
 
-    public interpretFieldAccess(ast: AstFieldAccess): Value {
-        // special case for contract/trait constant accesses via `self.constant`
-        // interpret "self" as a contract/trait access only if "self"
-        // is not already assigned in the environment (this would mean
-        // we are executing inside an extends function)
-        if (
-            ast.aggregate.kind === "id" &&
-            isSelfId(ast.aggregate) &&
-            !this.envStack.selfInEnvironment()
-        ) {
-            const selfTypeRef = getExpType(this.context, ast.aggregate);
-            if (selfTypeRef.kind === "ref") {
-                const contractTypeDescription = getType(
-                    this.context,
-                    selfTypeRef.name,
-                );
-                const foundContractConst =
-                    contractTypeDescription.constants.find((constId) =>
-                        eqNames(ast.field, constId.name),
-                    );
-                if (foundContractConst === undefined) {
-                    // not a constant, e.g. `self.storageVariable`
-                    throwNonFatalErrorConstEval(
-                        "cannot evaluate non-constant self field access",
-                        ast.aggregate.loc,
-                    );
-                }
-                if (foundContractConst.value !== undefined) {
-                    return foundContractConst.value;
-                } else {
-                    throwErrorConstEval(
-                        `cannot evaluate declared contract/trait constant ${idTextErr(ast.field)} as it does not have a body`,
-                        ast.field.loc,
-                    );
-                }
-            }
-        }
-        const valStruct = this.interpretExpression(ast.aggregate);
-        if (
-            valStruct === null ||
-            typeof valStruct !== "object" ||
-            !("$tactStruct" in valStruct)
-        ) {
-            throwErrorConstEval(
-                `constant struct expected, but got ${showValue(valStruct)}`,
-                ast.aggregate.loc,
-            );
-        }
-        if (idText(ast.field) in valStruct) {
-            return valStruct[idText(ast.field)]!;
-        } else {
-            // this cannot happen in a well-typed program
-            throwInternalCompilerError(
-                `struct field ${idTextErr(ast.field)} is missing`,
-                ast.aggregate.loc,
-            );
-        }
+    public interpretFieldAccess(ast: AstFieldAccess): T {
+        const aggregateEvaluator = () =>
+            this.interpretExpression(ast.aggregate);
+
+        return this.semantics.evalFieldAccess(ast, aggregateEvaluator);
     }
 
-    public interpretStaticCall(ast: AstStaticCall): Value {
-        switch (idText(ast.function)) {
-            case "ton": {
-                ensureFunArity(1, ast.args, ast.loc);
-                const tons = ensureString(
-                    this.interpretExpression(ast.args[0]!),
-                    ast.args[0]!.loc,
-                );
-                try {
-                    return ensureInt(
-                        BigInt(toNano(tons).toString(10)),
-                        ast.loc,
-                    );
-                } catch (e) {
-                    if (e instanceof Error && e.message === "Invalid number") {
-                        throwErrorConstEval(
-                            `invalid ${idTextErr(ast.function)} argument`,
-                            ast.loc,
-                        );
-                    }
-                    throw e;
-                }
-            }
-            case "pow": {
-                ensureFunArity(2, ast.args, ast.loc);
-                const valBase = ensureInt(
-                    this.interpretExpression(ast.args[0]!),
-                    ast.args[0]!.loc,
-                );
-                const valExp = ensureInt(
-                    this.interpretExpression(ast.args[1]!),
-                    ast.args[1]!.loc,
-                );
-                if (valExp < 0n) {
-                    throwErrorConstEval(
-                        `${idTextErr(ast.function)} builtin called with negative exponent ${valExp}`,
-                        ast.loc,
-                    );
-                }
-                try {
-                    return ensureInt(valBase ** valExp, ast.loc);
-                } catch (e) {
-                    if (e instanceof RangeError) {
-                        // even TS bigint type cannot hold it
-                        throwErrorConstEval(
-                            "integer does not fit into TVM Int type",
-                            ast.loc,
-                        );
-                    }
-                    throw e;
-                }
-            }
-            case "pow2": {
-                ensureFunArity(1, ast.args, ast.loc);
-                const valExponent = ensureInt(
-                    this.interpretExpression(ast.args[0]!),
-                    ast.args[0]!.loc,
-                );
-                if (valExponent < 0n) {
-                    throwErrorConstEval(
-                        `${idTextErr(ast.function)} builtin called with negative exponent ${valExponent}`,
-                        ast.loc,
-                    );
-                }
-                try {
-                    return ensureInt(2n ** valExponent, ast.loc);
-                } catch (e) {
-                    if (e instanceof RangeError) {
-                        // even TS bigint type cannot hold it
-                        throwErrorConstEval(
-                            "integer does not fit into TVM Int type",
-                            ast.loc,
-                        );
-                    }
-                    throw e;
-                }
-            }
-            case "sha256": {
-                ensureFunArity(1, ast.args, ast.loc);
-                const str = ensureString(
-                    this.interpretExpression(ast.args[0]!),
-                    ast.args[0]!.loc,
-                );
-                const dataSize = Buffer.from(str).length;
-                if (dataSize > 128) {
-                    throwErrorConstEval(
-                        `data is too large for sha256 hash, expected up to 128 bytes, got ${dataSize}`,
-                        ast.loc,
-                    );
-                }
-                return BigInt("0x" + sha256_sync(str).toString("hex"));
-            }
-            case "emptyMap": {
-                ensureFunArity(0, ast.args, ast.loc);
-                return null;
-            }
-            case "cell":
-                {
-                    ensureFunArity(1, ast.args, ast.loc);
-                    const str = ensureString(
-                        this.interpretExpression(ast.args[0]!),
-                        ast.args[0]!.loc,
-                    );
-                    try {
-                        return Cell.fromBase64(str);
-                    } catch (_) {
-                        throwErrorConstEval(
-                            `invalid base64 encoding for a cell: ${str}`,
-                            ast.loc,
-                        );
-                    }
-                }
-                break;
-            case "address":
-                {
-                    ensureFunArity(1, ast.args, ast.loc);
-                    const str = ensureString(
-                        this.interpretExpression(ast.args[0]!),
-                        ast.args[0]!.loc,
-                    );
-                    try {
-                        const address = Address.parse(str);
-                        if (
-                            address.workChain !== 0 &&
-                            address.workChain !== -1
-                        ) {
-                            throwErrorConstEval(
-                                `${str} is invalid address`,
-                                ast.loc,
-                            );
-                        }
-                        if (
-                            !enabledMasterchain(this.context) &&
-                            address.workChain !== 0
-                        ) {
-                            throwErrorConstEval(
-                                `address ${str} is from masterchain which is not enabled for this contract`,
-                                ast.loc,
-                            );
-                        }
-                        return address;
-                    } catch (_) {
-                        throwErrorConstEval(
-                            `invalid address encoding: ${str}`,
-                            ast.loc,
-                        );
-                    }
-                }
-                break;
-            case "newAddress": {
-                ensureFunArity(2, ast.args, ast.loc);
-                const wc = ensureInt(
-                    this.interpretExpression(ast.args[0]!),
-                    ast.args[0]!.loc,
-                );
-                const addr = Buffer.from(
-                    ensureInt(
-                        this.interpretExpression(ast.args[1]!),
-                        ast.args[1]!.loc,
-                    )
-                        .toString(16)
-                        .padStart(64, "0"),
-                    "hex",
-                );
-                if (wc !== 0n && wc !== -1n) {
-                    throwErrorConstEval(
-                        `expected workchain of an address to be equal 0 or -1, received: ${wc}`,
-                        ast.loc,
-                    );
-                }
-                if (!enabledMasterchain(this.context) && wc !== 0n) {
-                    throwErrorConstEval(
-                        `${wc}:${addr.toString("hex")} address is from masterchain which is not enabled for this contract`,
-                        ast.loc,
-                    );
-                }
-                return new Address(Number(wc), addr);
-            }
-            default:
-                if (hasStaticFunction(this.context, idText(ast.function))) {
-                    const functionDescription = getStaticFunction(
-                        this.context,
-                        idText(ast.function),
-                    );
-                    switch (functionDescription.ast.kind) {
-                        case "function_def":
-                            // Currently, no attribute is supported
-                            if (functionDescription.ast.attributes.length > 0) {
-                                throwNonFatalErrorConstEval(
-                                    "calls to functions with attributes are currently not supported",
-                                    ast.loc,
-                                );
-                            }
-                            return this.evalStaticFunction(
-                                functionDescription.ast,
-                                ast.args,
-                                functionDescription.returns,
-                            );
+    public interpretStaticCall(ast: AstStaticCall): T {
+        const argValues = ast.args.map(this.interpretExpression, this);
 
-                        case "function_decl":
-                            throwNonFatalErrorConstEval(
-                                `${idTextErr(ast.function)} cannot be interpreted because it does not have a body`,
-                                ast.loc,
-                            );
-                            break;
-                        case "native_function_decl":
-                            throwNonFatalErrorConstEval(
-                                "native function calls are currently not supported",
-                                ast.loc,
-                            );
-                            break;
-                    }
-                } else {
-                    throwNonFatalErrorConstEval(
-                        `function ${idTextErr(ast.function)} is not declared`,
-                        ast.loc,
-                    );
-                }
+        const builtinResult = this.semantics.evalBuiltin(ast, argValues);
+        if (builtinResult !== undefined) {
+            return builtinResult;
         }
-    }
 
-    private evalStaticFunction(
-        functionCode: AstFunctionDef,
-        args: AstExpression[],
-        returns: TypeRef,
-    ): Value {
-        // Evaluate the arguments in the current environment
-        const argValues = args.map(this.interpretExpression, this);
+        // We have a call to a user-defined function.
+
+        const functionDef = this.semantics.lookupFunction(ast);
+
         // Extract the parameter names
-        const paramNames = functionCode.params.map((param) =>
+        const paramNames = functionDef.params.map((param) =>
             idText(param.name),
         );
-        // Check parameter names do not shadow constants
-        if (
-            paramNames.some((paramName) =>
-                hasStaticConstant(this.context, paramName),
-            )
-        ) {
-            throwInternalCompilerError(
-                `some parameter of function ${idText(functionCode.name)} shadows a constant with the same name`,
-                functionCode.loc,
-            );
-        }
-        // Call function inside a new environment
-        return this.envStack.executeInNewEnvironment(
-            () => {
-                // Interpret all the statements
-                try {
-                    functionCode.statements.forEach(
-                        this.interpretStatement,
-                        this,
-                    );
-                    // At this point, the function did not execute a return.
-                    // Execution continues after the catch.
-                } catch (e) {
-                    if (e instanceof ReturnSignal) {
-                        const val = e.getValue();
-                        if (val !== undefined) {
-                            return val;
-                        }
-                        // The function executed a return without a value.
-                        // Execution continues after the catch.
-                    } else {
-                        throw e;
-                    }
-                }
-                // If execution reaches this point, it means that
-                // the function had no return statement or executed a return
-                // without a value. This is an error only if the return type of the
-                // function is not void
-                if (returns.kind !== "void") {
-                    throwInternalCompilerError(
-                        `function ${idText(functionCode.name)} must return a value`,
-                        functionCode.loc,
-                    );
-                } else {
-                    // The function does not return a value.
-                    // We rely on the typechecker so that the function is called as a statement.
-                    // Hence, we can return a dummy null, since the null will be discarded anyway.
-                    return null;
-                }
-            },
+
+        // Transform the statements into continuations
+        const statementsEvaluator = () =>
+            this.executeStatements(functionDef.statements);
+
+        // Now call the function
+        return this.semantics.evalStaticCall(
+            ast,
+            functionDef,
+            statementsEvaluator,
             { names: paramNames, values: argValues },
         );
     }
 
-    public interpretStatement(ast: AstStatement): void {
+    public interpretStatement(ast: AstStatement): S {
         switch (ast.kind) {
             case "statement_let":
-                this.interpretLetStatement(ast);
-                break;
+                return this.interpretLetStatement(ast);
             case "statement_assign":
-                this.interpretAssignStatement(ast);
-                break;
+                return this.interpretAssignStatement(ast);
             case "statement_augmentedassign":
-                this.interpretAugmentedAssignStatement(ast);
-                break;
+                return this.interpretAugmentedAssignStatement(ast);
             case "statement_condition":
-                this.interpretConditionStatement(ast);
-                break;
+                return this.interpretConditionStatement(ast);
             case "statement_expression":
-                this.interpretExpressionStatement(ast);
-                break;
+                return this.interpretExpressionStatement(ast);
             case "statement_foreach":
-                this.interpretForEachStatement(ast);
-                break;
+                return this.interpretForEachStatement(ast);
             case "statement_repeat":
-                this.interpretRepeatStatement(ast);
-                break;
+                return this.interpretRepeatStatement(ast);
             case "statement_return":
-                this.interpretReturnStatement(ast);
-                break;
+                return this.interpretReturnStatement(ast);
             case "statement_try":
-                this.interpretTryStatement(ast);
-                break;
+                return this.interpretTryStatement(ast);
             case "statement_try_catch":
-                this.interpretTryCatchStatement(ast);
-                break;
+                return this.interpretTryCatchStatement(ast);
             case "statement_until":
-                this.interpretUntilStatement(ast);
-                break;
+                return this.interpretUntilStatement(ast);
             case "statement_while":
-                this.interpretWhileStatement(ast);
-                break;
+                return this.interpretWhileStatement(ast);
         }
     }
 
-    public interpretLetStatement(ast: AstStatementLet) {
-        if (hasStaticConstant(this.context, idText(ast.name))) {
-            // Attempt of shadowing a constant in a let declaration
-            throwInternalCompilerError(
-                `declaration of ${idText(ast.name)} shadows a constant with the same name`,
-                ast.loc,
-            );
-        }
+    public interpretLetStatement(ast: AstStatementLet): S {
         const val = this.interpretExpression(ast.expression);
-        this.envStack.setNewBinding(idText(ast.name), val);
+        return this.semantics.storeNewBinding(ast, val);
     }
 
-    public interpretAssignStatement(ast: AstStatementAssign) {
+    public interpretAssignStatement(ast: AstStatementAssign): S {
         if (ast.path.kind === "id") {
             const val = this.interpretExpression(ast.expression);
-            this.envStack.updateBinding(idText(ast.path), val);
+            return this.semantics.updateBinding(ast.path, val);
         } else {
             throwNonFatalErrorConstEval(
                 "only identifiers are currently supported as path expressions",
@@ -1302,25 +388,19 @@ export class Interpreter {
         }
     }
 
-    public interpretAugmentedAssignStatement(ast: AstStatementAugmentedAssign) {
+    public interpretAugmentedAssignStatement(
+        ast: AstStatementAugmentedAssign,
+    ): S {
         if (ast.path.kind === "id") {
-            const updateVal = this.interpretExpression(ast.expression);
-            const currentPathValue = this.envStack.getBinding(idText(ast.path));
-            if (currentPathValue === undefined) {
-                throwNonFatalErrorConstEval(
-                    "undeclared identifier",
-                    ast.path.loc,
-                );
-            }
-            const newVal = evalBinaryOp(
-                ast.op,
+            const updateEvaluator = () =>
+                this.interpretExpression(ast.expression);
+            const currentPathValue = this.semantics.lookupBinding(ast.path);
+            const newVal = this.semantics.evalBinaryOpInAugmentedAssign(
+                ast,
                 currentPathValue,
-                updateVal,
-                ast.path.loc,
-                ast.expression.loc,
-                ast.loc,
+                updateEvaluator,
             );
-            this.envStack.updateBinding(idText(ast.path), newVal);
+            return this.semantics.updateBinding(ast.path, newVal);
         } else {
             throwNonFatalErrorConstEval(
                 "only identifiers are currently supported as path expressions",
@@ -1329,32 +409,36 @@ export class Interpreter {
         }
     }
 
-    public interpretConditionStatement(ast: AstCondition) {
-        const condition = ensureBoolean(
+    public interpretConditionStatement(ast: AstCondition): S {
+        const condition = this.semantics.toBoolean(
             this.interpretExpression(ast.condition),
             ast.condition.loc,
         );
         if (condition) {
-            this.envStack.executeInNewEnvironment(() => {
-                ast.trueStatements.forEach(this.interpretStatement, this);
-            });
+            return this.semantics.runInNewEnvironment(() =>
+                this.executeStatements(ast.trueStatements),
+            );
         } else if (ast.falseStatements !== null) {
-            this.envStack.executeInNewEnvironment(() => {
-                ast.falseStatements!.forEach(this.interpretStatement, this);
-            });
+            return this.semantics.runInNewEnvironment(() =>
+                this.executeStatements(ast.falseStatements!),
+            );
+        } else {
+            return this.semantics.emptyStatementResult();
         }
     }
 
-    public interpretExpressionStatement(ast: AstStatementExpression) {
-        this.interpretExpression(ast.expression);
+    public interpretExpressionStatement(ast: AstStatementExpression): S {
+        return this.semantics.toStatementResult(
+            this.interpretExpression(ast.expression),
+        );
     }
 
-    public interpretForEachStatement(ast: AstStatementForEach) {
+    public interpretForEachStatement(ast: AstStatementForEach): S {
         throwNonFatalErrorConstEval("foreach currently not supported", ast.loc);
     }
 
-    public interpretRepeatStatement(ast: AstStatementRepeat) {
-        const iterations = ensureRepeatInt(
+    public interpretRepeatStatement(ast: AstStatementRepeat): S {
+        const iterations = this.semantics.toRepeatInteger(
             this.interpretExpression(ast.iterations),
             ast.iterations.loc,
         );
@@ -1365,96 +449,124 @@ export class Interpreter {
             // the loop. Also, the language requires that all declared variables inside the
             // loop be initialized, which means that we can overwrite its value in the environment
             // in each iteration.
-            this.envStack.executeInNewEnvironment(() => {
-                for (let i = 1; i <= iterations; i++) {
-                    ast.statements.forEach(this.interpretStatement, this);
+            return this.semantics.runInNewEnvironment(() => {
+                let result = this.semantics.emptyStatementResult();
+
+                for (let i = 1n; i <= iterations; i++) {
+                    result = this.semantics.runOneIteration(i, ast.loc, () =>
+                        this.executeStatements(ast.statements, result),
+                    );
                 }
+
+                return result;
             });
+        } else {
+            return this.semantics.emptyStatementResult();
         }
     }
 
-    public interpretReturnStatement(ast: AstStatementReturn) {
+    public interpretReturnStatement(ast: AstStatementReturn): S {
         if (ast.expression !== null) {
             const val = this.interpretExpression(ast.expression);
-            throw new ReturnSignal(val);
+            return this.semantics.evalReturn(val);
         } else {
-            throw new ReturnSignal();
+            return this.semantics.evalReturn();
         }
     }
 
-    public interpretTryStatement(ast: AstStatementTry) {
+    public interpretTryStatement(ast: AstStatementTry): S {
         throwNonFatalErrorConstEval(
             "try statements currently not supported",
             ast.loc,
         );
     }
 
-    public interpretTryCatchStatement(ast: AstStatementTryCatch) {
+    public interpretTryCatchStatement(ast: AstStatementTryCatch): S {
         throwNonFatalErrorConstEval(
             "try-catch statements currently not supported",
             ast.loc,
         );
     }
 
-    public interpretUntilStatement(ast: AstStatementUntil) {
-        let condition;
-        let iterCount = 0;
+    public interpretUntilStatement(ast: AstStatementUntil): S {
+        let condition: boolean;
+        let iterCount = 1n;
         // We can create a single environment for all the iterations in the loop
         // (instead of a fresh environment for each iteration)
         // because the typechecker ensures that variables do not leak outside
         // the loop. Also, the language requires that all declared variables inside the
         // loop be initialized, which means that we can overwrite its value in the environment
         // in each iteration.
-        this.envStack.executeInNewEnvironment(() => {
+        return this.semantics.runInNewEnvironment(() => {
+            let result = this.semantics.emptyStatementResult();
             do {
-                ast.statements.forEach(this.interpretStatement, this);
+                result = this.semantics.runOneIteration(
+                    iterCount,
+                    ast.loc,
+                    () => {
+                        const r = this.executeStatements(
+                            ast.statements,
+                            result,
+                        );
+
+                        // The typechecker ensures that the condition does not refer to
+                        // variables declared inside the loop.
+                        condition = this.semantics.toBoolean(
+                            this.interpretExpression(ast.condition),
+                            ast.condition.loc,
+                        );
+
+                        return r;
+                    },
+                );
 
                 iterCount++;
-                if (iterCount >= this.config.maxLoopIterations) {
-                    throwNonFatalErrorConstEval(
-                        "loop timeout reached",
-                        ast.loc,
-                    );
-                }
-                // The typechecker ensures that the condition does not refer to
-                // variables declared inside the loop.
-                condition = ensureBoolean(
-                    this.interpretExpression(ast.condition),
-                    ast.condition.loc,
-                );
             } while (!condition);
+
+            return result;
         });
     }
 
-    public interpretWhileStatement(ast: AstStatementWhile) {
-        let condition;
-        let iterCount = 0;
+    public interpretWhileStatement(ast: AstStatementWhile): S {
+        let condition = this.semantics.toBoolean(
+            this.interpretExpression(ast.condition),
+            ast.condition.loc,
+        );
+
+        let iterCount = 1n;
         // We can create a single environment for all the iterations in the loop
         // (instead of a fresh environment for each iteration)
         // because the typechecker ensures that variables do not leak outside
         // the loop. Also, the language requires that all declared variables inside the
         // loop be initialized, which means that we can overwrite its value in the environment
         // in each iteration.
-        this.envStack.executeInNewEnvironment(() => {
-            do {
-                // The typechecker ensures that the condition does not refer to
-                // variables declared inside the loop.
-                condition = ensureBoolean(
-                    this.interpretExpression(ast.condition),
-                    ast.condition.loc,
-                );
-                if (condition) {
-                    ast.statements.forEach(this.interpretStatement, this);
-
-                    iterCount++;
-                    if (iterCount >= this.config.maxLoopIterations) {
-                        throwNonFatalErrorConstEval(
-                            "loop timeout reached",
-                            ast.loc,
+        return this.semantics.runInNewEnvironment(() => {
+            let result = this.semantics.emptyStatementResult();
+            while (condition) {
+                result = this.semantics.runOneIteration(
+                    iterCount,
+                    ast.loc,
+                    () => {
+                        const r = this.executeStatements(
+                            ast.statements,
+                            result,
                         );
-                    }
-                }
-            } while (condition);
+
+                        // The typechecker ensures that the condition does not refer to
+                        // variables declared inside the loop.
+                        condition = this.semantics.toBoolean(
+                            this.interpretExpression(ast.condition),
+                            ast.condition.loc,
+                        );
+
+                        return r;
+                    },
+                );
+
+                iterCount++;
+            }
+
+            return result;
         });
     }
 }

--- a/src/interpreterSemantics/standardSemantics.ts
+++ b/src/interpreterSemantics/standardSemantics.ts
@@ -1,0 +1,1112 @@
+import { Address, Cell, toNano } from "@ton/core";
+import { CompilerContext } from "../context";
+import { idTextErr, throwInternalCompilerError } from "../errors";
+import {
+    AstBinaryOperation,
+    AstBoolean,
+    AstExpression,
+    AstFieldAccess,
+    AstFunctionDef,
+    AstId,
+    AstMethodCall,
+    AstNull,
+    AstNumber,
+    AstOpBinary,
+    AstOpUnary,
+    AstStatementAugmentedAssign,
+    AstStatementLet,
+    AstStaticCall,
+    AstString,
+    AstStructInstance,
+    AstUnaryOperation,
+    eqNames,
+    idText,
+    isSelfId,
+    SrcInfo,
+} from "../grammar/ast";
+import {
+    getStaticConstant,
+    getStaticFunction,
+    getType,
+    hasStaticConstant,
+    hasStaticFunction,
+} from "../types/resolveDescriptors";
+import { getExpType } from "../types/resolveExpression";
+import { CommentValue, showValue, StructValue, Value } from "../types/types";
+import { InterpreterSemantics } from "./types";
+import { sha256_sync } from "@ton/crypto";
+import { enabledMasterchain } from "../config/features";
+import { dummySrcInfo } from "../grammar/grammar";
+import {
+    divFloor,
+    modFloor,
+    throwErrorConstEval,
+    throwNonFatalErrorConstEval,
+} from "./util";
+
+// TVM integers are signed 257-bit integers
+const minTvmInt: bigint = -(2n ** 256n);
+const maxTvmInt: bigint = 2n ** 256n - 1n;
+
+// Range allowed in repeat statements
+const minRepeatStatement: bigint = -(2n ** 256n); // Note it is the same as minimum for TVM
+const maxRepeatStatement: bigint = 2n ** 31n - 1n;
+
+class ReturnSignal extends Error {
+    private value?: Value;
+
+    constructor(value?: Value) {
+        super();
+        this.value = value;
+    }
+
+    public getValue(): Value | undefined {
+        return this.value;
+    }
+}
+
+type InterpreterConfig = {
+    // Options that tune the interpreter's behavior.
+
+    // Maximum number of iterations inside a loop before a time out is issued.
+    // This option only applies to: do...until and while loops
+    maxLoopIterations: bigint;
+};
+
+const WILDCARD_NAME: string = "_";
+
+/* An Environment consists of a map of variable names to their values 
+(which have the generic type V), and a reference to the (optional) parent 
+environment. In other words, an Environment acts as a node in the linked list
+representing the environments stack.
+
+The elements in the map are called "bindings".
+*/
+type Environment<V> = { values: Map<string, V>; parent?: Environment<V> };
+
+/*
+An environment stack is a linked list of Environment nodes. 
+
+The type of the values stored in the environments is represented by the 
+generic type V.
+*/
+class EnvironmentStack<V> {
+    private currentEnv: Environment<V>;
+
+    constructor() {
+        this.currentEnv = { values: new Map() };
+    }
+
+    private findBindingMap(name: string): Map<string, V> | undefined {
+        let env: Environment<V> | undefined = this.currentEnv;
+        while (env !== undefined) {
+            if (env.values.has(name)) {
+                return env.values;
+            } else {
+                env = env.parent;
+            }
+        }
+        return undefined;
+    }
+
+    /*
+    Sets a binding for "name" in the **current** environment of the stack.
+    If a binding for "name" already exists in the current environment, it 
+    overwrites the binding with the provided value.
+    As a special case, name "_" is ignored.
+
+    Note that this method does not check if binding "name" already exists in 
+    a parent environment.
+    This means that if binding "name" already exists in a parent environment, 
+    it will be shadowed by the provided value in the current environment.
+    This shadowing behavior is useful for modelling recursive function calls.
+    For example, consider the recursive implementation of factorial 
+    (for simplification purposes, it returns 1 for the factorial of 
+    negative numbers):
+
+    1  fun factorial(a: Int): Int {
+    2  if (a <= 1) {
+    3     return 1;
+    4  } else {
+    5     return a * factorial(a - 1);
+    6  }
+
+    Just before factorial(4) finishes its execution, the environment stack will
+    look as follows (the arrows point to their parent environment):
+
+    a = 4 <------- a = 3 <-------- a = 2 <------- a = 1
+
+    Note how each child environment shadows variable a, because each
+    recursive call to factorial at line 5 creates a child
+    environment with a new binding for a.
+
+    When factorial(1) = 1 finishes execution, the environment at the top
+    of the stack is popped:
+    
+    a = 4 <------- a = 3 <-------- a = 2
+
+    and execution resumes at line 5 in the environment where a = 2,
+    so that the return at line 5 is 2 * 1 = 2.
+
+    This in turn causes the stack to pop the environment at the top:
+
+    a = 4 <------- a = 3
+
+    so that the return at line 5 (now in the environment a = 3) will 
+    produce 3 * 2 = 6, and so on.
+    */
+    public setNewBinding(name: string, val: V) {
+        if (name !== WILDCARD_NAME) {
+            this.currentEnv.values.set(name, val);
+        }
+    }
+
+    /*
+    Searches the binding "name" in the stack, starting at the current
+    environment and moving towards the parent environments. 
+    If it finds the binding, it updates its value
+    to "val". If it does not find "name", the stack is unchanged.
+    As a special case, name "_" is always ignored.
+    */
+    public updateBinding(name: string, val: V) {
+        if (name !== WILDCARD_NAME) {
+            const bindings = this.findBindingMap(name);
+            if (bindings !== undefined) {
+                bindings.set(name, val);
+            }
+        }
+    }
+
+    /*
+    Searches the binding "name" in the stack, starting at the current
+    environment and moving towards the parent environments. 
+    If it finds "name", it returns its value.
+    If it does not find "name", it returns undefined.
+    As a special case, name "_" always returns undefined.
+    */
+    public getBinding(name: string): V | undefined {
+        if (name === WILDCARD_NAME) {
+            return undefined;
+        }
+        const bindings = this.findBindingMap(name);
+        if (bindings !== undefined) {
+            return bindings.get(name);
+        } else {
+            return undefined;
+        }
+    }
+
+    public selfInEnvironment(): boolean {
+        return this.findBindingMap("self") !== undefined;
+    }
+
+    /*
+    Executes "code" in a fresh environment that is placed at the top
+    of the environment stack. The fresh environment is initialized
+    with the bindings in "initialBindings". Once "code" finishes
+    execution, the new environment is automatically popped from 
+    the stack. 
+    
+    This method is useful for starting a new local variables scope, 
+    like in a function call.
+    */
+    public executeInNewEnvironment<T>(
+        code: () => T,
+        initialBindings: { names: string[]; values: V[] } = {
+            names: [],
+            values: [],
+        },
+    ): T {
+        const names = initialBindings.names;
+        const values = initialBindings.values;
+
+        const oldEnv = this.currentEnv;
+        this.currentEnv = { values: new Map(), parent: oldEnv };
+
+        names.forEach((name, index) => {
+            this.setNewBinding(name, values[index]!);
+        }, this);
+
+        try {
+            return code();
+        } finally {
+            this.currentEnv = oldEnv;
+        }
+    }
+}
+
+const defaultInterpreterConfig: InterpreterConfig = {
+    // We set the default max number of loop iterations
+    // to the maximum number allowed for repeat loops
+    maxLoopIterations: maxRepeatStatement,
+};
+
+/*
+The standard semantics for the Tact interpreter. See Interpreter class
+for ways of instantiating interpreters with different semantics.
+
+The constructor receives an optional CompilerContext which includes 
+all external declarations that the interpreter will use during interpretation.
+If no CompilerContext is provided, the semantics will use an empty 
+CompilerContext.
+
+**IMPORTANT**: if a custom CompilerContext is provided, it should be the 
+CompilerContext provided by the typechecker. 
+
+The reason for requiring a CompilerContext is that the interpreter should work 
+in the use case where the interpreter only knows part of the code.
+For example, consider the following code (I marked with brackets [ ] the places 
+where the interpreter gets called during expression simplification in the 
+compilation phase):
+
+const C: Int = [1];
+
+contract TestContract {
+
+   get fun test(): Int {
+      return [C + 1];
+   }
+}
+
+When the interpreter gets called inside the brackets, it does not know what 
+other code is surrounding those brackets, because the interpreter did not execute the 
+code outside the brackets. Hence, it relies on the typechecker to receive the 
+CompilerContext that includes the declarations in the code 
+(the constant C for example).
+
+Since the interpreter relies on the typechecker, this semantics assume that the 
+interpreter will only be called on AST trees
+that are already valid Tact programs.
+
+Internally, the semantics use a stack of environments to keep track of
+variables at different scopes. Each environment in the stack contains a map
+that binds a variable name to its corresponding value.
+
+In the standard semantics, statements do not produce results, as such I use type "undefined"
+as the generic type for statement's results.
+*/
+export class StandardSemantics extends InterpreterSemantics<Value, undefined> {
+    private envStack: EnvironmentStack<Value>;
+    private context: CompilerContext;
+    private config: InterpreterConfig;
+
+    constructor(
+        context: CompilerContext = new CompilerContext(),
+        config: InterpreterConfig = defaultInterpreterConfig,
+    ) {
+        super();
+        this.envStack = new EnvironmentStack();
+        this.context = context;
+        this.config = config;
+    }
+
+    public lookupBinding(name: AstId): Value {
+        if (hasStaticConstant(this.context, idText(name))) {
+            const constant = getStaticConstant(this.context, idText(name));
+            if (constant.value !== undefined) {
+                return constant.value;
+            } else {
+                throwErrorConstEval(
+                    `cannot evaluate declared constant ${idText(name)} as it does not have a body`,
+                    name.loc,
+                );
+            }
+        }
+        const variableBinding = this.envStack.getBinding(idText(name));
+        if (variableBinding !== undefined) {
+            return variableBinding;
+        }
+        throwNonFatalErrorConstEval("cannot evaluate a variable", name.loc);
+    }
+
+    public evalBuiltinOnSelf(
+        ast: AstMethodCall,
+        self: Value,
+        _argValues: Value[],
+    ): Value | undefined {
+        switch (idText(ast.method)) {
+            case "asComment": {
+                ensureMethodArity(0, ast.args, ast.loc);
+                const comment = ensureString(self, ast.self.loc);
+                return new CommentValue(comment);
+            }
+            default:
+                return undefined;
+        }
+    }
+
+    public evalCallOnSelf(
+        ast: AstMethodCall,
+        _self: Value,
+        _argValues: Value[],
+    ): Value {
+        throwNonFatalErrorConstEval(
+            `calls of ${idTextErr(ast.method)} are not supported at this moment`,
+            ast.loc,
+        );
+    }
+
+    public evalNull(_ast: AstNull): Value {
+        return null;
+    }
+
+    public evalBoolean(ast: AstBoolean): Value {
+        return ast.value;
+    }
+
+    public evalInteger(ast: AstNumber): Value {
+        return ensureInt(ast.value, ast.loc);
+    }
+
+    public evalString(ast: AstString): Value {
+        return ensureString(
+            interpretEscapeSequences(ast.value, ast.loc),
+            ast.loc,
+        );
+    }
+
+    public evalUnaryOp(ast: AstOpUnary, operandEvaluator: () => Value): Value {
+        // Tact grammar does not have negative integer literals,
+        // so in order to avoid errors for `-115792089237316195423570985008687907853269984665640564039457584007913129639936`
+        // which is `-(2**256)` we need to have a special case for it
+
+        if (ast.operand.kind === "number" && ast.op === "-") {
+            // emulating negative integer literals
+            return ensureInt(-ast.operand.value, ast.loc);
+        }
+
+        return evalUnaryOp(
+            ast.op,
+            operandEvaluator(),
+            ast.operand.loc,
+            ast.loc,
+        );
+    }
+
+    public evalBinaryOp(
+        ast: AstOpBinary,
+        leftValue: Value,
+        rightEvaluator: () => Value,
+    ): Value {
+        return evalBinaryOp(
+            ast.op,
+            leftValue,
+            rightEvaluator(), // There is actually a bug in the current implementation of the semantics:
+            // boolean operators do not short-circuit in this implementation
+            // The evalBinaryOp function should receive the rightEvaluator, instead of executing
+            // rightEvaluator and pass the result as a parameter.
+            // This implies we need to change the the signature of the evalBinaryOp function
+            // (the one outside the class).
+            ast.left.loc,
+            ast.right.loc,
+            ast.loc,
+        );
+    }
+
+    public evalBinaryOpInAugmentedAssign(
+        ast: AstStatementAugmentedAssign,
+        leftValue: Value,
+        rightEvaluator: () => Value,
+    ): Value {
+        return evalBinaryOp(
+            ast.op,
+            leftValue,
+            rightEvaluator(), // There is actually a bug in the current implementation of the semantics:
+            // boolean operators do not short-circuit in this implementation
+            // The evalBinaryOp function should receive the rightEvaluator continuation, instead of executing
+            // rightEvaluator and pass the result as a parameter.
+            // This implies we need to change the the signature of the evalBinaryOp function
+            // (the one outside the class).
+            ast.path.loc,
+            ast.expression.loc,
+            ast.loc,
+        );
+    }
+
+    public toBoolean(value: Value, src: SrcInfo): boolean {
+        return ensureBoolean(value, src);
+    }
+
+    public evalStructInstance(
+        ast: AstStructInstance,
+        initializerEvaluators: (() => Value)[],
+    ): Value {
+        if (ast.args.length !== initializerEvaluators.length) {
+            throwInternalCompilerError(
+                "Number of arguments in ast must match the number of argument evaluators.",
+            );
+        }
+
+        const structTy = getType(this.context, ast.type);
+
+        // initialize the resulting struct value with
+        // the default values for fields with initializers
+        // or null for uninitialized optional fields
+        const resultWithDefaultFields: StructValue = structTy.fields.reduce(
+            (resObj, field) => {
+                if (field.default !== undefined) {
+                    resObj[field.name] = field.default;
+                } else {
+                    if (field.type.kind === "ref" && field.type.optional) {
+                        resObj[field.name] = null;
+                    }
+                }
+                return resObj;
+            },
+            { $tactStruct: idText(ast.type) } as StructValue,
+        );
+
+        // this will override default fields set above
+        return ast.args.reduce((resObj, fieldWithInit, index) => {
+            resObj[idText(fieldWithInit.field)] =
+                initializerEvaluators[index]!();
+            return resObj;
+        }, resultWithDefaultFields);
+    }
+
+    public evalFieldAccess(
+        ast: AstFieldAccess,
+        aggregateEvaluator: () => Value,
+    ): Value {
+        // special case for contract/trait constant accesses via `self.constant`
+        // interpret "self" as a contract/trait access only if "self"
+        // is not already assigned in the environment (this would mean
+        // we are executing inside an extends function)
+        if (
+            ast.aggregate.kind === "id" &&
+            isSelfId(ast.aggregate) &&
+            !this.envStack.selfInEnvironment()
+        ) {
+            const selfTypeRef = getExpType(this.context, ast.aggregate);
+            if (selfTypeRef.kind === "ref") {
+                const contractTypeDescription = getType(
+                    this.context,
+                    selfTypeRef.name,
+                );
+                const foundContractConst =
+                    contractTypeDescription.constants.find((constId) =>
+                        eqNames(ast.field, constId.name),
+                    );
+                if (foundContractConst === undefined) {
+                    // not a constant, e.g. `self.storageVariable`
+                    throwNonFatalErrorConstEval(
+                        "cannot evaluate non-constant self field access",
+                        ast.aggregate.loc,
+                    );
+                }
+                if (foundContractConst.value !== undefined) {
+                    return foundContractConst.value;
+                } else {
+                    throwErrorConstEval(
+                        `cannot evaluate declared contract/trait constant ${idTextErr(ast.field)} as it does not have a body`,
+                        ast.field.loc,
+                    );
+                }
+            }
+        }
+        const valStruct = aggregateEvaluator();
+        if (
+            valStruct === null ||
+            typeof valStruct !== "object" ||
+            !("$tactStruct" in valStruct)
+        ) {
+            throwErrorConstEval(
+                `constant struct expected, but got ${showValue(valStruct)}`,
+                ast.aggregate.loc,
+            );
+        }
+        if (idText(ast.field) in valStruct) {
+            return valStruct[idText(ast.field)]!;
+        } else {
+            // this cannot happen in a well-typed program
+            throwInternalCompilerError(
+                `struct field ${idTextErr(ast.field)} is missing`,
+                ast.aggregate.loc,
+            );
+        }
+    }
+
+    public evalBuiltin(
+        ast: AstStaticCall,
+        argValues: Value[],
+    ): Value | undefined {
+        switch (idText(ast.function)) {
+            case "ton": {
+                ensureFunArity(1, ast.args, ast.loc);
+                const tons = ensureString(argValues[0]!, ast.args[0]!.loc);
+                try {
+                    return ensureInt(
+                        BigInt(toNano(tons).toString(10)),
+                        ast.loc,
+                    );
+                } catch (e) {
+                    if (e instanceof Error && e.message === "Invalid number") {
+                        throwErrorConstEval(
+                            `invalid ${idTextErr(ast.function)} argument`,
+                            ast.loc,
+                        );
+                    }
+                    throw e;
+                }
+            }
+            case "pow": {
+                ensureFunArity(2, ast.args, ast.loc);
+                const valBase = ensureInt(argValues[0]!, ast.args[0]!.loc);
+                const valExp = ensureInt(argValues[1]!, ast.args[1]!.loc);
+                if (valExp < 0n) {
+                    throwErrorConstEval(
+                        `${idTextErr(ast.function)} builtin called with negative exponent ${valExp}`,
+                        ast.loc,
+                    );
+                }
+                try {
+                    return ensureInt(valBase ** valExp, ast.loc);
+                } catch (e) {
+                    if (e instanceof RangeError) {
+                        // even TS bigint type cannot hold it
+                        throwErrorConstEval(
+                            "integer does not fit into TVM Int type",
+                            ast.loc,
+                        );
+                    }
+                    throw e;
+                }
+            }
+            case "pow2": {
+                ensureFunArity(1, ast.args, ast.loc);
+                const valExponent = ensureInt(argValues[0]!, ast.args[0]!.loc);
+                if (valExponent < 0n) {
+                    throwErrorConstEval(
+                        `${idTextErr(ast.function)} builtin called with negative exponent ${valExponent}`,
+                        ast.loc,
+                    );
+                }
+                try {
+                    return ensureInt(2n ** valExponent, ast.loc);
+                } catch (e) {
+                    if (e instanceof RangeError) {
+                        // even TS bigint type cannot hold it
+                        throwErrorConstEval(
+                            "integer does not fit into TVM Int type",
+                            ast.loc,
+                        );
+                    }
+                    throw e;
+                }
+            }
+            case "sha256": {
+                ensureFunArity(1, ast.args, ast.loc);
+                const str = ensureString(argValues[0]!, ast.args[0]!.loc);
+                const dataSize = Buffer.from(str).length;
+                if (dataSize > 128) {
+                    throwErrorConstEval(
+                        `data is too large for sha256 hash, expected up to 128 bytes, got ${dataSize}`,
+                        ast.loc,
+                    );
+                }
+                return BigInt("0x" + sha256_sync(str).toString("hex"));
+            }
+            case "emptyMap": {
+                ensureFunArity(0, ast.args, ast.loc);
+                return null;
+            }
+            case "cell":
+                {
+                    ensureFunArity(1, ast.args, ast.loc);
+                    const str = ensureString(argValues[0]!, ast.args[0]!.loc);
+                    try {
+                        return Cell.fromBase64(str);
+                    } catch (_) {
+                        throwErrorConstEval(
+                            `invalid base64 encoding for a cell: ${str}`,
+                            ast.loc,
+                        );
+                    }
+                }
+                break;
+            case "address":
+                {
+                    ensureFunArity(1, ast.args, ast.loc);
+                    const str = ensureString(argValues[0]!, ast.args[0]!.loc);
+                    try {
+                        const address = Address.parse(str);
+                        if (
+                            address.workChain !== 0 &&
+                            address.workChain !== -1
+                        ) {
+                            throwErrorConstEval(
+                                `${str} is invalid address`,
+                                ast.loc,
+                            );
+                        }
+                        if (
+                            !enabledMasterchain(this.context) &&
+                            address.workChain !== 0
+                        ) {
+                            throwErrorConstEval(
+                                `address ${str} is from masterchain which is not enabled for this contract`,
+                                ast.loc,
+                            );
+                        }
+                        return address;
+                    } catch (_) {
+                        throwErrorConstEval(
+                            `invalid address encoding: ${str}`,
+                            ast.loc,
+                        );
+                    }
+                }
+                break;
+            case "newAddress": {
+                ensureFunArity(2, ast.args, ast.loc);
+                const wc = ensureInt(argValues[0]!, ast.args[0]!.loc);
+                const addr = Buffer.from(
+                    ensureInt(argValues[1]!, ast.args[1]!.loc)
+                        .toString(16)
+                        .padStart(64, "0"),
+                    "hex",
+                );
+                if (wc !== 0n && wc !== -1n) {
+                    throwErrorConstEval(
+                        `expected workchain of an address to be equal 0 or -1, received: ${wc}`,
+                        ast.loc,
+                    );
+                }
+                if (!enabledMasterchain(this.context) && wc !== 0n) {
+                    throwErrorConstEval(
+                        `${wc}:${addr.toString("hex")} address is from masterchain which is not enabled for this contract`,
+                        ast.loc,
+                    );
+                }
+                return new Address(Number(wc), addr);
+            }
+            default:
+                return undefined;
+        }
+    }
+
+    public lookupFunction(ast: AstStaticCall): AstFunctionDef {
+        if (hasStaticFunction(this.context, idText(ast.function))) {
+            const functionDescription = getStaticFunction(
+                this.context,
+                idText(ast.function),
+            );
+            switch (functionDescription.ast.kind) {
+                case "function_def":
+                    // Currently, no attribute is supported
+                    if (functionDescription.ast.attributes.length > 0) {
+                        throwNonFatalErrorConstEval(
+                            "calls to functions with attributes are currently not supported",
+                            ast.loc,
+                        );
+                    }
+                    return functionDescription.ast;
+
+                case "function_decl":
+                    throwNonFatalErrorConstEval(
+                        `${idTextErr(ast.function)} cannot be interpreted because it does not have a body`,
+                        ast.loc,
+                    );
+                    break;
+                case "native_function_decl":
+                    throwNonFatalErrorConstEval(
+                        "native function calls are currently not supported",
+                        ast.loc,
+                    );
+                    break;
+            }
+        } else {
+            throwNonFatalErrorConstEval(
+                `function ${idTextErr(ast.function)} is not declared`,
+                ast.loc,
+            );
+        }
+    }
+
+    public evalStaticCall(
+        _ast: AstStaticCall,
+        _functionDef: AstFunctionDef,
+        functionBodyEvaluator: () => undefined,
+        args: { names: string[]; values: Value[] },
+    ): Value {
+        // Call function inside a new environment
+        return this.envStack.executeInNewEnvironment(
+            () => {
+                // Interpret all the statements
+                try {
+                    functionBodyEvaluator();
+                    // At this point, the function did not execute a return.
+                    // Execution continues after the catch.
+                } catch (e) {
+                    if (e instanceof ReturnSignal) {
+                        const val = e.getValue();
+                        if (val !== undefined) {
+                            return val;
+                        }
+                        // The function executed a return without a value.
+                        // Execution continues after the catch.
+                    } else {
+                        throw e;
+                    }
+                }
+                // If execution reaches this point, it means that
+                // the function had no return statement or executed a return
+                // without a value. In summary, the function does not return a value.
+                // We rely on the typechecker so that the function is called as a statement.
+                // Hence, we can return a dummy null, since the null will be discarded anyway.
+                return null;
+            },
+            { names: args.names, values: args.values },
+        );
+    }
+
+    public storeNewBinding(ast: AstStatementLet, exprValue: Value): undefined {
+        if (hasStaticConstant(this.context, idText(ast.name))) {
+            // Attempt of shadowing a constant in a let declaration
+            throwInternalCompilerError(
+                `declaration of ${idText(ast.name)} shadows a constant with the same name`,
+                ast.loc,
+            );
+        }
+
+        this.envStack.setNewBinding(idText(ast.name), exprValue);
+    }
+
+    public updateBinding(id: AstId, exprValue: Value): undefined {
+        this.envStack.updateBinding(idText(id), exprValue);
+    }
+
+    public runInNewEnvironment(
+        statementsEvaluator: () => undefined,
+    ): undefined {
+        this.envStack.executeInNewEnvironment(statementsEvaluator);
+    }
+
+    public joinStatementResults(
+        _first: undefined,
+        _second: undefined,
+    ): undefined {
+        // Do nothing: statements do not return values, so there is nothing to join.
+    }
+
+    public emptyStatementResult(): undefined {
+        // Do nothing
+    }
+
+    public toStatementResult(_val: Value): undefined {
+        // Do nothing: values returned from expressions are ignored when the expression is executed as statement.
+    }
+
+    public toInteger(value: Value, src: SrcInfo): bigint {
+        return ensureInt(value, src);
+    }
+
+    public evalReturn(val?: Value): undefined {
+        throw new ReturnSignal(val);
+    }
+
+    public runOneIteration(
+        iterationNumber: bigint,
+        src: SrcInfo,
+        iterationEvaluator: () => undefined,
+    ): undefined {
+        iterationEvaluator();
+        if (iterationNumber >= this.config.maxLoopIterations) {
+            throwNonFatalErrorConstEval("loop timeout reached", src);
+        }
+    }
+
+    public toRepeatInteger(value: Value, src: SrcInfo): bigint {
+        return ensureRepeatInt(value, src);
+    }
+}
+
+export function ensureInt(val: Value, source: SrcInfo): bigint {
+    if (typeof val !== "bigint") {
+        throwErrorConstEval(
+            `integer expected, but got '${showValue(val)}'`,
+            source,
+        );
+    }
+    if (minTvmInt <= val && val <= maxTvmInt) {
+        return val;
+    } else {
+        throwErrorConstEval(
+            `integer '${showValue(val)}' does not fit into TVM Int type`,
+            source,
+        );
+    }
+}
+
+function ensureRepeatInt(val: Value, source: SrcInfo): bigint {
+    if (typeof val !== "bigint") {
+        throwErrorConstEval(
+            `integer expected, but got '${showValue(val)}'`,
+            source,
+        );
+    }
+    if (minRepeatStatement <= val && val <= maxRepeatStatement) {
+        return val;
+    } else {
+        throwErrorConstEval(
+            `repeat argument must be a number between -2^256 (inclusive) and 2^31 - 1 (inclusive)`,
+            source,
+        );
+    }
+}
+
+function ensureBoolean(val: Value, source: SrcInfo): boolean {
+    if (typeof val !== "boolean") {
+        throwErrorConstEval(
+            `boolean expected, but got '${showValue(val)}'`,
+            source,
+        );
+    }
+    return val;
+}
+
+function ensureString(val: Value, source: SrcInfo): string {
+    if (typeof val !== "string") {
+        throwErrorConstEval(
+            `string expected, but got '${showValue(val)}'`,
+            source,
+        );
+    }
+    return val;
+}
+
+function ensureFunArity(arity: number, args: AstExpression[], source: SrcInfo) {
+    if (args.length !== arity) {
+        throwErrorConstEval(
+            `function expects ${arity} argument(s), but got ${args.length}`,
+            source,
+        );
+    }
+}
+
+function ensureMethodArity(
+    arity: number,
+    args: AstExpression[],
+    source: SrcInfo,
+) {
+    if (args.length !== arity) {
+        throwErrorConstEval(
+            `method expects ${arity} argument(s), but got ${args.length}`,
+            source,
+        );
+    }
+}
+
+export function evalUnaryOp(
+    op: AstUnaryOperation,
+    valOperand: Value,
+    operandLoc: SrcInfo = dummySrcInfo,
+    source: SrcInfo = dummySrcInfo,
+): Value {
+    switch (op) {
+        case "+":
+            return ensureInt(valOperand, operandLoc);
+        case "-":
+            return ensureInt(-ensureInt(valOperand, operandLoc), source);
+        case "~":
+            return ~ensureInt(valOperand, operandLoc);
+        case "!":
+            return !ensureBoolean(valOperand, operandLoc);
+        case "!!":
+            if (valOperand === null) {
+                throwErrorConstEval(
+                    "non-null value expected but got null",
+                    operandLoc,
+                );
+            }
+            return valOperand;
+    }
+}
+
+export function evalBinaryOp(
+    op: AstBinaryOperation,
+    valLeft: Value,
+    valRight: Value,
+    locLeft: SrcInfo = dummySrcInfo,
+    locRight: SrcInfo = dummySrcInfo,
+    source: SrcInfo = dummySrcInfo,
+): Value {
+    switch (op) {
+        case "+":
+            return ensureInt(
+                ensureInt(valLeft, locLeft) + ensureInt(valRight, locRight),
+                source,
+            );
+        case "-":
+            return ensureInt(
+                ensureInt(valLeft, locLeft) - ensureInt(valRight, locRight),
+                source,
+            );
+        case "*":
+            return ensureInt(
+                ensureInt(valLeft, locLeft) * ensureInt(valRight, locRight),
+                source,
+            );
+        case "/": {
+            // The semantics of integer division for TVM (and by extension in Tact)
+            // is a non-conventional one: by default it rounds towards negative infinity,
+            // meaning, for instance, -1 / 5 = -1 and not zero, as in many mainstream languages.
+            // Still, the following holds: a / b * b + a % b == a, for all b != 0.
+            const r = ensureInt(valRight, locRight);
+            if (r === 0n)
+                throwErrorConstEval(
+                    "divisor expression must be non-zero",
+                    locRight,
+                );
+            return ensureInt(divFloor(ensureInt(valLeft, locLeft), r), source);
+        }
+        case "%": {
+            // Same as for division, see the comment above
+            // Example: -1 % 5 = 4
+            const r = ensureInt(valRight, locRight);
+            if (r === 0n)
+                throwErrorConstEval(
+                    "divisor expression must be non-zero",
+                    locRight,
+                );
+            return ensureInt(modFloor(ensureInt(valLeft, locLeft), r), source);
+        }
+        case "&":
+            return ensureInt(valLeft, locLeft) & ensureInt(valRight, locRight);
+        case "|":
+            return ensureInt(valLeft, locLeft) | ensureInt(valRight, locRight);
+        case "^":
+            return ensureInt(valLeft, locLeft) ^ ensureInt(valRight, locRight);
+        case "<<": {
+            const valNum = ensureInt(valLeft, locLeft);
+            const valBits = ensureInt(valRight, locRight);
+            if (0n > valBits || valBits > 256n) {
+                throwErrorConstEval(
+                    `the number of bits shifted ('${valBits}') must be within [0..256] range`,
+                    locRight,
+                );
+            }
+            try {
+                return ensureInt(valNum << valBits, source);
+            } catch (e) {
+                if (e instanceof RangeError)
+                    // this actually should not happen
+                    throwErrorConstEval(
+                        `integer does not fit into TVM Int type`,
+                        source,
+                    );
+                throw e;
+            }
+        }
+        case ">>": {
+            const valNum = ensureInt(valLeft, locLeft);
+            const valBits = ensureInt(valRight, locRight);
+            if (0n > valBits || valBits > 256n) {
+                throwErrorConstEval(
+                    `the number of bits shifted ('${valBits}') must be within [0..256] range`,
+                    locRight,
+                );
+            }
+            try {
+                return ensureInt(valNum >> valBits, source);
+            } catch (e) {
+                if (e instanceof RangeError)
+                    // this is actually should not happen
+                    throwErrorConstEval(
+                        `integer does not fit into TVM Int type`,
+                        source,
+                    );
+                throw e;
+            }
+        }
+        case ">":
+            return ensureInt(valLeft, locLeft) > ensureInt(valRight, locRight);
+        case "<":
+            return ensureInt(valLeft, locLeft) < ensureInt(valRight, locRight);
+        case ">=":
+            return ensureInt(valLeft, locLeft) >= ensureInt(valRight, locRight);
+        case "<=":
+            return ensureInt(valLeft, locLeft) <= ensureInt(valRight, locRight);
+        case "==":
+            // the null comparisons account for optional types, e.g.
+            // a const x: Int? = 42 can be compared to null
+            if (
+                typeof valLeft !== typeof valRight &&
+                valLeft !== null &&
+                valRight !== null
+            ) {
+                throwErrorConstEval(
+                    "operands of `==` must have same type",
+                    source,
+                );
+            }
+            return valLeft === valRight;
+        case "!=":
+            if (typeof valLeft !== typeof valRight) {
+                throwErrorConstEval(
+                    "operands of `!=` must have same type",
+                    source,
+                );
+            }
+            return valLeft !== valRight;
+        case "&&":
+            return (
+                ensureBoolean(valLeft, locLeft) &&
+                ensureBoolean(valRight, locRight)
+            );
+        case "||":
+            return (
+                ensureBoolean(valLeft, locLeft) ||
+                ensureBoolean(valRight, locRight)
+            );
+    }
+}
+
+function interpretEscapeSequences(stringLiteral: string, source: SrcInfo) {
+    return stringLiteral.replace(
+        /\\\\|\\"|\\n|\\r|\\t|\\v|\\b|\\f|\\u{([0-9A-Fa-f]{1,6})}|\\u([0-9A-Fa-f]{4})|\\x([0-9A-Fa-f]{2})/g,
+        (match, unicodeCodePoint, unicodeEscape, hexEscape) => {
+            switch (match) {
+                case "\\\\":
+                    return "\\";
+                case '\\"':
+                    return '"';
+                case "\\n":
+                    return "\n";
+                case "\\r":
+                    return "\r";
+                case "\\t":
+                    return "\t";
+                case "\\v":
+                    return "\v";
+                case "\\b":
+                    return "\b";
+                case "\\f":
+                    return "\f";
+                default:
+                    // Handle Unicode code point escape
+                    if (unicodeCodePoint) {
+                        const codePoint = parseInt(unicodeCodePoint, 16);
+                        if (codePoint > 0x10ffff) {
+                            throwErrorConstEval(
+                                `unicode code point is outside of valid range 000000-10FFFF: ${stringLiteral}`,
+                                source,
+                            );
+                        }
+                        return String.fromCodePoint(codePoint);
+                    }
+                    // Handle Unicode escape
+                    if (unicodeEscape) {
+                        const codeUnit = parseInt(unicodeEscape, 16);
+                        return String.fromCharCode(codeUnit);
+                    }
+                    // Handle hex escape
+                    if (hexEscape) {
+                        const hexValue = parseInt(hexEscape, 16);
+                        return String.fromCharCode(hexValue);
+                    }
+                    return match;
+            }
+        },
+    );
+}

--- a/src/interpreterSemantics/types.ts
+++ b/src/interpreterSemantics/types.ts
@@ -1,0 +1,164 @@
+import {
+    AstId,
+    AstMethodCall,
+    AstNull,
+    AstBoolean,
+    AstNumber,
+    AstString,
+    AstOpUnary,
+    AstOpBinary,
+    AstStructInstance,
+    AstFieldAccess,
+    AstStaticCall,
+    AstFunctionDef,
+    AstStatementLet,
+    AstStatementAugmentedAssign,
+} from "../grammar/ast";
+import { SrcInfo } from "../grammar/grammar";
+
+/*
+Implementations of this abstract class represent concrete semantics or behaviors for the interpreter. 
+This is useful for attaching special code during the execution of the interpreter.
+For example, the standard semantics for the Tact interpreter are implemented by class StandardSemantics.
+
+Generic type V represents the type of expressions' results. Generic type S 
+the type of statements' results.
+*/
+export abstract class InterpreterSemantics<V, S> {
+    public abstract lookupBinding(name: AstId): V;
+
+    /*
+    Executes calls to built-in functions of the form self.method(args).
+    Should return "undefined" if method is not a built-in function. 
+    */
+    public abstract evalBuiltinOnSelf(
+        ast: AstMethodCall,
+        self: V,
+        argValues: V[],
+    ): V | undefined;
+
+    public abstract evalNull(ast: AstNull): V;
+
+    public abstract evalBoolean(ast: AstBoolean): V;
+
+    public abstract evalInteger(ast: AstNumber): V;
+
+    public abstract evalString(ast: AstString): V;
+
+    /*
+    Evaluates the unary operation. Parameter operandEvaluator is a continuation 
+    that computes the operator's operand. The reason for using a continuation
+    is that certain operators may execute some logic **before** evaluation 
+    of the operand.
+    */
+    public abstract evalUnaryOp(ast: AstOpUnary, operandEvaluator: () => V): V;
+
+    /*
+    Evaluates the binary operator. Parameter rightEvaluator is a continuation
+    that computes the value of the right operand. The reason for using a continuation
+    is that certain operators may execute some logic **before** evaluation 
+    of the right operand (for example, short-circuiting).
+    */
+    public abstract evalBinaryOp(
+        ast: AstOpBinary,
+        leftValue: V,
+        rightEvaluator: () => V,
+    ): V;
+
+    public abstract toBoolean(value: V, src: SrcInfo): boolean;
+
+    /*
+    Evaluates the struct instance. Parameter initializerEvaluators is a list of continuations.
+    Each continuation computes the result of executing the initializer.
+    */
+    public abstract evalStructInstance(
+        ast: AstStructInstance,
+        initializerEvaluators: (() => V)[],
+    ): V;
+
+    /*
+    Evaluates a field access of the form "path.field". Parameter aggregateEvaluator is a continuation.
+    The continuation computes the value of "path".
+    */
+    public abstract evalFieldAccess(
+        ast: AstFieldAccess,
+        aggregateEvaluator: () => V,
+    ): V;
+
+    /*
+    Executes calls to built-in functions of the form method(args).
+    Should return "undefined" if method is not a built-in function. 
+    */
+    public abstract evalBuiltin(
+        ast: AstStaticCall,
+        argValues: V[],
+    ): V | undefined;
+
+    public abstract lookupFunction(ast: AstStaticCall): AstFunctionDef;
+
+    /*
+    Calls function "functionDef" using parameters "args". The body of "functionDef" can be
+    executed by invoking continuation "functionBodyEvaluator". 
+    */
+    public abstract evalStaticCall(
+        ast: AstStaticCall,
+        functionDef: AstFunctionDef,
+        functionBodyEvaluator: () => S,
+        args: { names: string[]; values: V[] },
+    ): V;
+
+    /*
+    Evaluates the binary operator implicit in an augment assignment. 
+    Parameter rightEvaluator is a continuation
+    that computes the value of the right operand. The reason for using a continuation
+    is that certain operators may execute some logic **before** evaluation 
+    of the right operand (for example, short-circuiting).
+    */
+    public abstract evalBinaryOpInAugmentedAssign(
+        ast: AstStatementAugmentedAssign,
+        leftValue: V,
+        rightEvaluator: () => V,
+    ): V;
+
+    public abstract storeNewBinding(ast: AstStatementLet, exprValue: V): S;
+
+    public abstract updateBinding(ast: AstId, exprValue: V): S;
+
+    /*
+    Runs the continuation statementsEvaluator in a new environment.
+    In the standard semantics, this means opening a new environment in 
+    the stack and closing the environment when statementsEvaluator finishes execution.
+    */
+    public abstract runInNewEnvironment(statementsEvaluator: () => S): S;
+
+    /*
+    Join the results of two statements. In the standard semantics, this
+    function is trivial (i.e., does nothing) because statements do not return values.
+    */
+    public abstract joinStatementResults(first: S, second: S): S;
+
+    /*
+    The result of the "do nothing" statement. In the standard semantics,
+    this function does nothing, because statements do not return values.
+    */
+    public abstract emptyStatementResult(): S;
+
+    public abstract toStatementResult(val: V): S;
+
+    public abstract toInteger(value: V, src: SrcInfo): bigint;
+
+    public abstract toRepeatInteger(value: V, src: SrcInfo): bigint;
+
+    public abstract evalReturn(val?: V): S;
+
+    /*
+    Runs one iteration of the body of a loop. The body of the loop is executed by 
+    calling the continuation "iterationEvaluator". The iteration number is provided 
+    for further custom logic.
+    */
+    public abstract runOneIteration(
+        iterationNumber: bigint,
+        src: SrcInfo,
+        iterationEvaluator: () => S,
+    ): S;
+}

--- a/src/interpreterSemantics/util.ts
+++ b/src/interpreterSemantics/util.ts
@@ -1,0 +1,55 @@
+// Throws a non-fatal const-eval error, in the sense that const-eval as a compiler
+// optimization cannot be applied, e.g. to `let`-statements.
+
+import { throwConstEvalError } from "../errors";
+import { SrcInfo } from "../grammar/ast";
+
+// Note that for const initializers this is a show-stopper.
+export function throwNonFatalErrorConstEval(
+    msg: string,
+    source: SrcInfo,
+): never {
+    throwConstEvalError(
+        `Cannot evaluate expression to a constant: ${msg}`,
+        false,
+        source,
+    );
+}
+
+// Throws a fatal const-eval, meaning this is a meaningless program,
+// so compilation should be aborted in all cases
+export function throwErrorConstEval(msg: string, source: SrcInfo): never {
+    throwConstEvalError(
+        `Cannot evaluate expression to a constant: ${msg}`,
+        true,
+        source,
+    );
+}
+
+// bigint arithmetic
+
+// precondition: the divisor is not zero
+// rounds the division result towards negative infinity
+export function divFloor(a: bigint, b: bigint): bigint {
+    const almostSameSign = a > 0n === b > 0n;
+    if (almostSameSign) {
+        return a / b;
+    }
+    return a / b + (a % b === 0n ? 0n : -1n);
+}
+
+export function abs(a: bigint): bigint {
+    return a < 0n ? -a : a;
+}
+
+export function sign(a: bigint): bigint {
+    if (a === 0n) return 0n;
+    else return a < 0n ? -1n : 1n;
+}
+
+// precondition: the divisor is not zero
+// rounds the result towards negative infinity
+// Uses the fact that a / b * b + a % b == a, for all b != 0.
+export function modFloor(a: bigint, b: bigint): bigint {
+    return a - divFloor(a, b) * b;
+}

--- a/src/optimizer/associative.ts
+++ b/src/optimizer/associative.ts
@@ -7,18 +7,17 @@ import {
     AstValue,
     isValue,
 } from "../grammar/ast";
-import { evalBinaryOp } from "../interpreter";
+import { evalBinaryOp } from "../interpreterSemantics/standardSemantics";
+import { abs, sign } from "../interpreterSemantics/util";
 import { Value } from "../types/types";
 import { ExpressionTransformer, Rule } from "./types";
 import {
-    abs,
     checkIsBinaryOpNode,
     checkIsBinaryOp_With_RightValue,
     checkIsBinaryOp_With_LeftValue,
     extractValue,
     makeBinaryExpression,
     makeValueExpression,
-    sign,
 } from "./util";
 
 type TransformData = {

--- a/src/optimizer/test/partial-eval.spec.ts
+++ b/src/optimizer/test/partial-eval.spec.ts
@@ -12,7 +12,10 @@ import { partiallyEvalExpression } from "../../constEval";
 import { CompilerContext } from "../../context";
 import { ExpressionTransformer, Rule } from "../types";
 import { AssociativeRule3 } from "../associative";
-import { evalBinaryOp, evalUnaryOp } from "../../interpreter";
+import {
+    evalBinaryOp,
+    evalUnaryOp,
+} from "../../interpreterSemantics/standardSemantics";
 
 const MAX: string =
     "115792089237316195423570985008687907853269984665640564039457584007913129639935";

--- a/src/optimizer/util.ts
+++ b/src/optimizer/util.ts
@@ -125,31 +125,3 @@ export function checkIsName(ast: AstExpression): boolean {
 export function checkIsBoolean(ast: AstExpression, b: boolean): boolean {
     return ast.kind === "boolean" ? ast.value == b : false;
 }
-
-// bigint arithmetic
-
-// precondition: the divisor is not zero
-// rounds the division result towards negative infinity
-export function divFloor(a: bigint, b: bigint): bigint {
-    const almostSameSign = a > 0n === b > 0n;
-    if (almostSameSign) {
-        return a / b;
-    }
-    return a / b + (a % b === 0n ? 0n : -1n);
-}
-
-export function abs(a: bigint): bigint {
-    return a < 0n ? -a : a;
-}
-
-export function sign(a: bigint): bigint {
-    if (a === 0n) return 0n;
-    else return a < 0n ? -1n : 1n;
-}
-
-// precondition: the divisor is not zero
-// rounds the result towards negative infinity
-// Uses the fact that a / b * b + a % b == a, for all b != 0.
-export function modFloor(a: bigint, b: bigint): bigint {
-    return a - divFloor(a, b) * b;
-}


### PR DESCRIPTION
Towards #720 

This PR does not introduce new functionality to the interpreter, it only refactors the interpreter to be able to change the semantics or add additional functionality to it.

At first, I was trying to do a monad-style interpreter, but TypeScript does not have do-notation, which can quickly produce unreadable code because of the bind functions. Although, there are some suggestions over the internet on how to emulate do-notation using generators, it looks ad-hoc, hacky, and unnatural. So, I decided to take the idea of monad and adapt it into an imperative flavor. The idea is to define the semantics of an interpreter as an abstract class parametric over two generic types: "V" (the type of expressions' results) and "S" (the type of statements' results).
At the moment, module level declarations do not have an associated generic type, but it will probably be added.

Specific semantics can be represented by implementing the abstract class. For example, to create an interpreter with the standard semantics, just write:
```
const interpreter = new Interpreter(new StandardSemantics(ctx));
```
If we want to change the behavior, for example, by collecting special values when statements execute, just pass another semantics:
```
const interpreter = new Interpreter(new YourCustomSemantics(ctx));
```
This is a first version of the "monadish" interpreter. As such, it probably will suffer changes as more semantics are added since they will probably force changes to the interface in the abstract class. 

You can see the abstract class interface in the file `src/interpreterSemantics/types.ts`.

- [ ] I have updated CHANGELOG.md
- [ ] ~~I have documented my contribution in Tact Docs: https://github.com/tact-lang/tact-docs/pull/PR-NUMBER~~
- [ ] ~~I have added tests to demonstrate the contribution is correctly implemented: this usually includes both positive and negative tests, showing the happy path(s) and featuring intentionally broken cases~~
- [X] I have run all the tests locally and no test failure was reported
- [X] I have run the linter, formatter and spellchecker
- [X] I did not do unrelated and/or undiscussed refactorings
