### PR TITLE
fix(codegen): maps from uint types to Bool

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Fix code generation bug for maps from unsigned integers to Boolean values: PR [#725](https://github.com/tact-lang/tact/pull/725)
+
 ## [1.4.4] - 2024-08-18
 
 ### Added

--- a/src/abi/map.ts
+++ b/src/abi/map.ts
@@ -271,7 +271,7 @@ export const MapFunctions: Map<string, AbiFunction> = new Map([
                         return `__tact_dict_get_${kind}_${vKind}(${resolved[0]}, ${bits}, ${resolved[1]}, ${vBits})`;
                     } else if (self.value === "Bool") {
                         ctx.used(`__tact_dict_get_${kind}_int`);
-                        return `__tact_dict_get_int_int(${resolved[0]}, ${bits}, ${resolved[1]}, 1)`;
+                        return `__tact_dict_get_${kind}_int(${resolved[0]}, ${bits}, ${resolved[1]}, 1)`;
                     } else if (self.value === "Cell") {
                         ctx.used(`__tact_dict_get_${kind}_cell`);
                         return `__tact_dict_get_${kind}_cell(${resolved[0]}, ${bits}, ${resolved[1]})`;

--- a/src/test/codegen/all-contracts.tact
+++ b/src/test/codegen/all-contracts.tact
@@ -6,3 +6,4 @@ import "./message-opcode-parsing.tact";
 import "./struct-with-default-and-optional-fields";
 import "./mutating-method-on-non-lvalues";
 import "./var-scope-global-fun-shadowing-allowed";
+import "./map-uint-bool-get";

--- a/src/test/codegen/map-uint-bool-get.tact
+++ b/src/test/codegen/map-uint-bool-get.tact
@@ -1,0 +1,9 @@
+contract MapUintBool {
+    m: map<Int as uint64, Bool>;
+
+    receive() {
+        nativeThrowUnless(1024, self.m.get(0) == null);
+        self.m.set(0, true);
+        self.m.del(0);
+    }
+}


### PR DESCRIPTION
Closes #722

<!--
IMPORTANT:
If your PR doesn't close a particular issue, please, create the issue first and describe the whole context: what you're adding/changing and why you're doing so. And only then open the Pull Request, which would close that issue!

In case you are adding a new language feature, a standard library function or introducing other user-facing changes, you need to document them via a new PR to tact-docs.
-->

- [x] I have updated CHANGELOG.md
- ~[ ] I have documented my contribution in Tact Docs: https://github.com/tact-lang/tact-docs/pull/PR-NUMBER~
- [x] I have added tests to demonstrate the contribution is correctly implemented: this usually includes both positive and negative tests, showing the happy path(s) and featuring intentionally broken cases
- [x] I have run all the tests locally and no test failure was reported
- [x] I have run the linter, formatter and spellchecker
- [x] I did not do unrelated and/or undiscussed refactorings
