### PR TITLE
chore: categorized PR templates

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/CI.md
+++ b/.github/PULL_REQUEST_TEMPLATE/CI.md
@@ -1,0 +1,14 @@
+<!--
+IMPORTANT:
+If your PR doesn't close a particular issue, please, create the issue first and describe the whole context: what you're adding/changing and why you're doing so. And only then open the Pull Request, which would close that issue!
+-->
+
+## Issue
+
+Closes issue #number.
+
+## Checklist
+
+- [ ] I have updated CHANGELOG.md
+- [ ] I have run the linter, formatter and spellchecker
+- [ ] I did not do unrelated and/or undiscussed refactorings

--- a/.github/PULL_REQUEST_TEMPLATE/api.md
+++ b/.github/PULL_REQUEST_TEMPLATE/api.md
@@ -10,7 +10,7 @@ Closes issue #number.
 ## Checklist
 
 - [ ] I have updated CHANGELOG.md
-- [ ] This part of API is exported from `src/index.ts`
+- [ ] This part of API is exported from the corresponding `index.ts`
 - [ ] I have run all the tests locally and no test failure was reported
 - [ ] I have run the linter, formatter and spellchecker
 - [ ] I did not do unrelated and/or undiscussed refactorings

--- a/.github/PULL_REQUEST_TEMPLATE/api.md
+++ b/.github/PULL_REQUEST_TEMPLATE/api.md
@@ -1,0 +1,16 @@
+<!--
+IMPORTANT:
+If your PR doesn't close a particular issue, please, create the issue first and describe the whole context: what you're adding/changing and why you're doing so. And only then open the Pull Request, which would close that issue!
+-->
+
+## Issue
+
+Closes issue #number.
+
+## Checklist
+
+- [ ] I have updated CHANGELOG.md
+- [ ] This part of API is exported from `src/index.ts`
+- [ ] I have run all the tests locally and no test failure was reported
+- [ ] I have run the linter, formatter and spellchecker
+- [ ] I did not do unrelated and/or undiscussed refactorings

--- a/.github/PULL_REQUEST_TEMPLATE/bugfix.md
+++ b/.github/PULL_REQUEST_TEMPLATE/bugfix.md
@@ -1,0 +1,16 @@
+<!--
+IMPORTANT:
+If your PR doesn't close a particular issue, please, create the issue first and describe the whole context: what you're adding/changing and why you're doing so. And only then open the Pull Request, which would close that issue!
+-->
+
+## Issue
+
+Closes issue #number.
+
+## Checklist
+
+- [ ] I have updated CHANGELOG.md
+- [ ] I have added tests to demonstrate the contribution is correctly implemented: this usually includes both positive and negative tests, showing the happy path(s) and featuring intentionally broken cases
+- [ ] I have run all the tests locally and no test failure was reported
+- [ ] I have run the linter, formatter and spellchecker
+- [ ] I did not do unrelated and/or undiscussed refactorings

--- a/.github/PULL_REQUEST_TEMPLATE/code-quality.md
+++ b/.github/PULL_REQUEST_TEMPLATE/code-quality.md
@@ -1,0 +1,18 @@
+<!--
+IMPORTANT:
+If your PR doesn't close a particular issue, please, create the issue first and describe the whole context: what you're adding/changing and why you're doing so. And only then open the Pull Request, which would close that issue!
+
+IMPORTANT:
+In general, the Tact team does not accept refactorings from external contributors unless those were previously discussed and you the green light to do change things without adding new functionality or fixing something broken. Language features, bugfixes, doc improvements are more than welcome!
+-->
+
+## Issue
+
+Closes issue #number.
+
+## Checklist
+
+- [ ] I have updated CHANGELOG.md
+- [ ] I have run all the tests locally and no test failure was reported
+- [ ] I have run the linter, formatter and spellchecker
+- [ ] I did not do unrelated and/or undiscussed refactorings

--- a/.github/PULL_REQUEST_TEMPLATE/codegen.md
+++ b/.github/PULL_REQUEST_TEMPLATE/codegen.md
@@ -1,0 +1,16 @@
+<!--
+IMPORTANT:
+If your PR doesn't close a particular issue, please, create the issue first and describe the whole context: what you're adding/changing and why you're doing so. And only then open the Pull Request, which would close that issue!
+-->
+
+## Issue
+
+Closes issue #number.
+
+## Checklist
+
+- [ ] I have updated CHANGELOG.md
+- [ ] I have added tests to demonstrate the contribution is correctly implemented: it reduces gas consumption for the common cases, makes storage improvements, etc. and does not have too much negative impact for the rest of the use-cases
+- [ ] I have run all the tests locally and no test failure was reported
+- [ ] I have run the linter, formatter and spellchecker
+- [ ] I did not do unrelated and/or undiscussed refactorings

--- a/.github/PULL_REQUEST_TEMPLATE/compiler-documentation.md
+++ b/.github/PULL_REQUEST_TEMPLATE/compiler-documentation.md
@@ -1,0 +1,14 @@
+<!--
+IMPORTANT:
+If your PR doesn't close a particular issue, please, create the issue first and describe the whole context: what you're adding/changing and why you're doing so. And only then open the Pull Request, which would close that issue!
+-->
+
+## Issue
+
+Closes issue #number.
+
+## Checklist
+
+- [ ] I have updated CHANGELOG.md
+- [ ] I have run the linter, formatter and spellchecker
+- [ ] I did not do unrelated and/or undiscussed refactorings

--- a/.github/PULL_REQUEST_TEMPLATE/dependencies.md
+++ b/.github/PULL_REQUEST_TEMPLATE/dependencies.md
@@ -1,0 +1,15 @@
+<!--
+IMPORTANT:
+If your PR doesn't close a particular issue, please, create the issue first and describe the whole context: what you're adding/changing and why you're doing so. And only then open the Pull Request, which would close that issue!
+-->
+
+## Issue
+
+Closes issue #number.
+
+## Checklist
+
+- [ ] I have updated CHANGELOG.md
+- [ ] I have run all the tests locally and no test failure was reported
+- [ ] I have run the linter, formatter and spellchecker
+- [ ] I did not do unrelated and/or undiscussed refactorings

--- a/.github/PULL_REQUEST_TEMPLATE/language-feature.md
+++ b/.github/PULL_REQUEST_TEMPLATE/language-feature.md
@@ -1,0 +1,17 @@
+<!--
+IMPORTANT:
+If your PR doesn't close a particular issue, please, create the issue first and describe the whole context: what you're adding/changing and why you're doing so. And only then open the Pull Request, which would close that issue!
+-->
+
+## Issue
+
+Closes issue #number.
+
+## Checklist
+
+- [ ] I have updated CHANGELOG.md
+- [ ] I have documented my contribution in Tact Docs: https://github.com/tact-lang/tact-docs/pull/PR-NUMBER
+- [ ] I have added tests to demonstrate the contribution is correctly implemented: this usually includes both positive and negative tests, showing the happy path(s) and featuring intentionally broken cases
+- [ ] I have run all the tests locally and no test failure was reported
+- [ ] I have run the linter, formatter and spellchecker
+- [ ] I did not do unrelated and/or undiscussed refactorings

--- a/.github/PULL_REQUEST_TEMPLATE/linters.md
+++ b/.github/PULL_REQUEST_TEMPLATE/linters.md
@@ -1,0 +1,13 @@
+<!--
+IMPORTANT:
+If your PR doesn't close a particular issue, please, create the issue first and describe the whole context: what you're adding/changing and why you're doing so. And only then open the Pull Request, which would close that issue!
+-->
+
+## Issue
+
+Closes issue #number.
+
+## Checklist
+
+- [ ] I have run the linter, formatter and spellchecker
+- [ ] I did not do unrelated and/or undiscussed refactorings

--- a/.github/PULL_REQUEST_TEMPLATE/policies.md
+++ b/.github/PULL_REQUEST_TEMPLATE/policies.md
@@ -1,0 +1,7 @@
+## Issue
+
+Closes issue #number.
+
+## Checklist
+
+- [ ] I have run the linter, formatter and spellchecker

--- a/.github/PULL_REQUEST_TEMPLATE/release.md
+++ b/.github/PULL_REQUEST_TEMPLATE/release.md
@@ -1,0 +1,9 @@
+## Issue
+
+Towards issue #number.
+
+## Checklist
+
+- [ ] I have improved and updated CHANGELOG.md
+- [ ] I have updated `package.json` with the new version
+- [ ] I have run the linter, formatter and spellchecker

--- a/.github/PULL_REQUEST_TEMPLATE/tests.md
+++ b/.github/PULL_REQUEST_TEMPLATE/tests.md
@@ -1,0 +1,15 @@
+<!--
+IMPORTANT:
+If your PR doesn't close a particular issue, please, create the issue first and describe the whole context: what you're adding/changing and why you're doing so. And only then open the Pull Request, which would close that issue!
+-->
+
+## Issue
+
+Closes issue #number.
+
+## Checklist
+
+- [ ] I have updated CHANGELOG.md
+- [ ] I have run all the tests locally and no test failure was reported
+- [ ] I have run the linter, formatter and spellchecker
+- [ ] I did not do unrelated and/or undiscussed refactorings

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,15 +1,14 @@
-Closes #number
+Click the `Preview` tab and select a PR template:
 
-<!--
-IMPORTANT:
-If your PR doesn't close a particular issue, please, create the issue first and describe the whole context: what you're adding/changing and why you're doing so. And only then open the Pull Request, which would close that issue!
-
-In case you are adding a new language feature, a standard library function or introducing other user-facing changes, you need to document them via a new PR to tact-docs.
--->
-
-- [ ] I have updated CHANGELOG.md
-- [ ] I have documented my contribution in Tact Docs: https://github.com/tact-lang/tact-docs/pull/PR-NUMBER
-- [ ] I have added tests to demonstrate the contribution is correctly implemented: this usually includes both positive and negative tests, showing the happy path(s) and featuring intentionally broken cases
-- [ ] I have run all the tests locally and no test failure was reported
-- [ ] I have run the linter, formatter and spellchecker
-- [ ] I did not do unrelated and/or undiscussed refactorings
+- [New language feature](?expand=1&template=language-feature.md)
+- [Bugfix](?expand=1&template=bugfix.md)
+- [Optimization of generated code](?expand=1&template=codegen.md)
+- [API for third-party tools](?expand=1&template=api.md)
+- [Project dependencies: updating, porting to another library, etc.](?expand=1&template=dependencies.md)
+- [CI](?expand=1&template=CI.md)
+- [Linters: adding more lints or changing the existing ones](?expand=1&template=linters.md)
+- [Compiler documentation](?expand=1&template=compiler-documentation.md)
+- [Improve compiler tests by adding new ones or modifying the existing tests](?expand=1&template=tests.md)
+- [Tact release](?expand=1&template=release.md)
+- [Project policies](?expand=1&template=policies.md)
+- [Code quality improvement](?expand=1&code-quality.md)


### PR DESCRIPTION
GitHub does not have native support for PR templates in its frontend, this employes the hack described here:
https://github.com/kenji-miyake/test-pr-template.

You can see a screencast of how it works here: https://github.com/orgs/community/discussions/4620#discussioncomment-3383383.

## Issue

Closes issue #726.

## Checklist

- [x] I have run the linter, formatter and spellchecker
