### PR TITLE
chore: fix issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/01-feature-request.yml
+++ b/.github/ISSUE_TEMPLATE/01-feature-request.yml
@@ -1,6 +1,5 @@
 name: Feature Request
 description: File a feature request.
-title: ""
 labels: ["language feature", "triage"]
 body:
   - type: markdown

--- a/.github/ISSUE_TEMPLATE/02-bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/02-bug-report.yml
@@ -1,6 +1,5 @@
 name: Bug Report
 description: File a bug report.
-title: ""
 labels: ["bug", "triage"]
 body:
   - type: markdown

--- a/.github/ISSUE_TEMPLATE/03-other.yml
+++ b/.github/ISSUE_TEMPLATE/03-other.yml
@@ -1,6 +1,5 @@
 name: Other issue
 description: Other issue (except security reports, please file those in private!)
-title: ""
 labels: ["triage"]
 body:
   - type: markdown


### PR DESCRIPTION
According to the docs, the `title` field is optional: https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/syntax-for-issue-forms

Closes #741

<!--
IMPORTANT:
If your PR doesn't close a particular issue, please, create the issue first and describe the whole context: what you're adding/changing and why you're doing so. And only then open the Pull Request, which would close that issue!

In case you are adding a new language feature, a standard library function or introducing other user-facing changes, you need to document them via a new PR to tact-docs.
-->

- [x] I have run the linter, formatter and spellchecker
- [x] I did not do unrelated and/or undiscussed refactorings
