### PR TITLE
feat: `slice`, `rawSlice`, `ascii` and `crc32` built-in functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - The `deepEquals` method for the `Map` type: PR [#637](https://github.com/tact-lang/tact/pull/637)
 - `asm` bodies for module-level functions: PR [#769](https://github.com/tact-lang/tact/pull/769)
 - Corresponding stdlib functions for new TVM instructions from 2023.07 and 2024.04 upgrades: PR [#331](https://github.com/tact-lang/tact/pull/331)
+- `slice`, `rawSlcie`, `ascii` and `crc32` built-in functions: PR [#787](https://github.com/tact-lang/tact/pull/787)
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - The `deepEquals` method for the `Map` type: PR [#637](https://github.com/tact-lang/tact/pull/637)
 - `asm` bodies for module-level functions: PR [#769](https://github.com/tact-lang/tact/pull/769)
 - Corresponding stdlib functions for new TVM instructions from 2023.07 and 2024.04 upgrades: PR [#331](https://github.com/tact-lang/tact/pull/331)
-- `slice`, `rawSlcie`, `ascii` and `crc32` built-in functions: PR [#787](https://github.com/tact-lang/tact/pull/787)
+- `slice`, `rawSlice`, `ascii` and `crc32` built-in functions: PR [#787](https://github.com/tact-lang/tact/pull/787)
 
 ### Changed
 

--- a/cspell.json
+++ b/cspell.json
@@ -145,7 +145,8 @@
     "unixfs",
     "workchain",
     "xffff",
-    "привет"
+    "привет",
+    "abcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcd"
   ],
   "flagWords": [],
   "ignorePaths": [

--- a/cspell.json
+++ b/cspell.json
@@ -102,6 +102,7 @@
     "RANDU",
     "rangle",
     "RAWRESERVE",
+    "rawslice",
     "renamer",
     "rparen",
     "rugpull",

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "@ton/crypto": "^3.2.0",
     "blockstore-core": "1.0.5",
     "change-case": "^4.1.2",
+    "crc-32": "1.2.2",
     "ipfs-unixfs-importer": "9.0.10",
     "json-bigint": "^1.0.0",
     "meow": "^13.2.0",

--- a/src/abi/global.ts
+++ b/src/abi/global.ts
@@ -1,6 +1,10 @@
-import { Address, Cell, toNano } from "@ton/core";
+import { Address, beginCell, Cell, toNano } from "@ton/core";
 import { enabledDebug, enabledMasterchain } from "../config/features";
-import { writeAddress, writeCell } from "../generator/writers/writeConstant";
+import {
+    writeAddress,
+    writeCell,
+    writeSlice,
+} from "../generator/writers/writeConstant";
 import {
     writeExpression,
     writeValue,
@@ -395,6 +399,187 @@ export const GlobalFunctions: Map<string, AbiFunction> = new Map([
                     "sha256 expects string or slice argument",
                     ref,
                 );
+            },
+        },
+    ],
+    [
+        "slice",
+        {
+            name: "slice",
+            resolve: (ctx, args, ref) => {
+                if (args.length !== 1) {
+                    throwCompilationError("slice() expects one argument", ref);
+                }
+                const arg0 = args[0]!;
+                if (arg0.kind !== "ref") {
+                    throwCompilationError(
+                        "slice() expects string argument",
+                        ref,
+                    );
+                }
+                if (arg0.name !== "String") {
+                    throwCompilationError(
+                        "slice() expects string argument",
+                        ref,
+                    );
+                }
+                return { kind: "ref", name: "Slice", optional: false };
+            },
+            generate: (ctx, args, resolved, ref) => {
+                if (resolved.length !== 1) {
+                    throwCompilationError("slice() expects one argument", ref);
+                }
+
+                // Load slice data
+                const str = evalConstantExpression(
+                    resolved[0]!,
+                    ctx.ctx,
+                ) as string;
+                let c: Cell;
+                try {
+                    c = Cell.fromBase64(str);
+                } catch (e) {
+                    throwCompilationError(`Invalid slice ${str}`, ref);
+                }
+
+                const res = writeSlice(c.asSlice(), ctx);
+                ctx.used(res);
+                return `${res}()`;
+            },
+        },
+    ],
+    [
+        "rawSlice",
+        {
+            name: "rawSlice",
+            resolve: (ctx, args, ref) => {
+                if (args.length !== 1) {
+                    throwCompilationError(
+                        "rawSlice() expects one argument",
+                        ref,
+                    );
+                }
+                const arg0 = args[0]!;
+                if (arg0.kind !== "ref") {
+                    throwCompilationError(
+                        "rawSlice() expects string argument",
+                        ref,
+                    );
+                }
+                if (arg0.name !== "String") {
+                    throwCompilationError(
+                        "rawSlice() expects string argument",
+                        ref,
+                    );
+                }
+                return { kind: "ref", name: "Slice", optional: false };
+            },
+            generate: (ctx, args, resolved, ref) => {
+                if (resolved.length !== 1) {
+                    throwCompilationError(
+                        "rawSlice() expects one argument",
+                        ref,
+                    );
+                }
+
+                // Load slice data
+                const str = evalConstantExpression(
+                    resolved[0]!,
+                    ctx.ctx,
+                ) as string;
+                let c: Cell;
+                try {
+                    c = beginCell().storeBuffer(Buffer.from(str)).endCell();
+                } catch (e) {
+                    throwCompilationError(`Invalid slice data ${str}`, ref);
+                }
+
+                const res = writeSlice(c.asSlice(), ctx);
+                ctx.used(res);
+                return `${res}()`;
+            },
+        },
+    ],
+    [
+        "ascii",
+        {
+            name: "ascii",
+            resolve: (ctx, args, ref) => {
+                if (args.length !== 1) {
+                    throwCompilationError("ascii() expects one argument", ref);
+                }
+                const arg0 = args[0]!;
+                if (arg0.kind !== "ref") {
+                    throwCompilationError(
+                        "ascii() expects string argument",
+                        ref,
+                    );
+                }
+                if (arg0.name !== "String") {
+                    throwCompilationError(
+                        "ascii() expects string argument",
+                        ref,
+                    );
+                }
+                return { kind: "ref", name: "Int", optional: false };
+            },
+            generate: (ctx, args, resolved, ref) => {
+                if (resolved.length !== 1) {
+                    throwCompilationError("ascii() expects one argument", ref);
+                }
+
+                // Load slice data
+                const str = evalConstantExpression(
+                    resolved[0]!,
+                    ctx.ctx,
+                ) as string;
+
+                if (str.length > 32) {
+                    throwCompilationError(
+                        `ascii() expects string argument with length <= 32`,
+                        ref,
+                    );
+                }
+
+                return `"${str}"u`;
+            },
+        },
+    ],
+    [
+        "crc32",
+        {
+            name: "crc32",
+            resolve: (ctx, args, ref) => {
+                if (args.length !== 1) {
+                    throwCompilationError("crc32() expects one argument", ref);
+                }
+                const arg0 = args[0]!;
+                if (arg0.kind !== "ref") {
+                    throwCompilationError(
+                        "crc32() expects string argument",
+                        ref,
+                    );
+                }
+                if (arg0.name !== "String") {
+                    throwCompilationError(
+                        "crc32() expects string argument",
+                        ref,
+                    );
+                }
+                return { kind: "ref", name: "Int", optional: false };
+            },
+            generate: (ctx, args, resolved, ref) => {
+                if (resolved.length !== 1) {
+                    throwCompilationError("crc32() expects one argument", ref);
+                }
+
+                // Load slice data
+                const str = evalConstantExpression(
+                    resolved[0]!,
+                    ctx.ctx,
+                ) as string;
+
+                return `"${str}"c`;
             },
         },
     ],

--- a/src/generator/writers/writeConstant.ts
+++ b/src/generator/writers/writeConstant.ts
@@ -1,4 +1,4 @@
-import { Address, beginCell, Cell } from "@ton/core";
+import { Address, beginCell, Cell, Slice } from "@ton/core";
 import { WriterContext } from "../Writer";
 
 export function writeString(str: string, ctx: WriterContext) {
@@ -24,6 +24,16 @@ export function writeCell(cell: Cell, ctx: WriterContext) {
     return writeRawCell(
         "cell",
         "Cell " + cell.hash().toString("base64"),
+        cell,
+        ctx,
+    );
+}
+
+export function writeSlice(slice: Slice, ctx: WriterContext) {
+    const cell = slice.asCell();
+    return writeRawSlice(
+        "slice",
+        "Slice " + cell.hash().toString("base64"),
         cell,
         ctx,
     );

--- a/src/generator/writers/writeExpression.ts
+++ b/src/generator/writers/writeExpression.ts
@@ -31,11 +31,12 @@ import { GlobalFunctions } from "../../abi/global";
 import { funcIdOf } from "./id";
 import { StructFunctions } from "../../abi/struct";
 import { resolveFuncType } from "./resolveFuncType";
-import { Address, Cell } from "@ton/core";
+import { Address, Cell, Slice } from "@ton/core";
 import {
     writeAddress,
     writeCell,
     writeComment,
+    writeSlice,
     writeString,
 } from "./writeConstant";
 import { ops } from "./ops";
@@ -116,6 +117,11 @@ export function writeValue(val: Value, wCtx: WriterContext): string {
     }
     if (val instanceof Cell) {
         const res = writeCell(val, wCtx);
+        wCtx.used(res);
+        return `${res}()`;
+    }
+    if (val instanceof Slice) {
+        const res = writeSlice(val, wCtx);
         wCtx.used(res);
         return `${res}()`;
     }

--- a/src/interpreter.ts
+++ b/src/interpreter.ts
@@ -1,4 +1,5 @@
-import { Address, Cell, toNano } from "@ton/core";
+import { Address, beginCell, Cell, toNano } from "@ton/core";
+import * as crc32 from "crc-32";
 import { evalConstantExpression } from "./constEval";
 import { CompilerContext } from "./context";
 import {
@@ -1068,6 +1069,71 @@ export class Interpreter {
                             ast.loc,
                         );
                     }
+                }
+                break;
+            case "slice":
+                {
+                    ensureFunArity(1, ast.args, ast.loc);
+                    const str = ensureString(
+                        this.interpretExpression(ast.args[0]!),
+                        ast.args[0]!.loc,
+                    );
+                    try {
+                        return Cell.fromBase64(str).asSlice();
+                    } catch (_) {
+                        throwErrorConstEval(
+                            `invalid base64 encoding for a cell: ${str}`,
+                            ast.loc,
+                        );
+                    }
+                }
+                break;
+            case "rawSlice":
+                {
+                    ensureFunArity(1, ast.args, ast.loc);
+                    const str = ensureString(
+                        this.interpretExpression(ast.args[0]!),
+                        ast.args[0]!.loc,
+                    );
+                    try {
+                        return beginCell()
+                            .storeBuffer(Buffer.from(str))
+                            .endCell()
+                            .asSlice();
+                    } catch (_) {
+                        throwErrorConstEval(
+                            `invalid slice data: ${str}`,
+                            ast.loc,
+                        );
+                    }
+                }
+                break;
+            case "ascii":
+                {
+                    ensureFunArity(1, ast.args, ast.loc);
+                    const str = ensureString(
+                        this.interpretExpression(ast.args[0]!),
+                        ast.args[0]!.loc,
+                    );
+                    if (str.length > 32) {
+                        throwErrorConstEval(
+                            `ascii string is too long, expected up to 32 characters, got ${str.length}`,
+                            ast.loc,
+                        );
+                    }
+                    return BigInt(
+                        "0x" + Buffer.from(str, "ascii").toString("hex"),
+                    );
+                }
+                break;
+            case "crc32":
+                {
+                    ensureFunArity(1, ast.args, ast.loc);
+                    const str = ensureString(
+                        this.interpretExpression(ast.args[0]!),
+                        ast.args[0]!.loc,
+                    );
+                    return BigInt(crc32.str(str));
                 }
                 break;
             case "address":

--- a/src/interpreter.ts
+++ b/src/interpreter.ts
@@ -1135,6 +1135,12 @@ export class Interpreter {
                             ast.loc,
                         );
                     }
+                    if (str.length == 0) {
+                        throwErrorConstEval(
+                            `ascii string cannot be empty`,
+                            ast.loc,
+                        );
+                    }
                     return BigInt(
                         "0x" + Buffer.from(str, "ascii").toString("hex"),
                     );

--- a/src/interpreter.ts
+++ b/src/interpreter.ts
@@ -1095,9 +1095,23 @@ export class Interpreter {
                         this.interpretExpression(ast.args[0]!),
                         ast.args[0]!.loc,
                     );
+
+                    if (str.length > 255) {
+                        throwErrorConstEval(
+                            `hex string is too long, expected up to 255 characters, got ${str.length}`,
+                            ast.loc,
+                        );
+                    }
+                    if (!/^[0-9a-fA-F]*$/.test(str)) {
+                        throwErrorConstEval(
+                            `invalid hex string: ${str}`,
+                            ast.loc,
+                        );
+                    }
+
                     try {
                         return beginCell()
-                            .storeBuffer(Buffer.from(str))
+                            .storeBuffer(Buffer.from(str, "hex"))
                             .endCell()
                             .asSlice();
                     } catch (_) {

--- a/src/interpreter.ts
+++ b/src/interpreter.ts
@@ -1133,7 +1133,8 @@ export class Interpreter {
                         this.interpretExpression(ast.args[0]!),
                         ast.args[0]!.loc,
                     );
-                    return BigInt(crc32.str(str));
+                    const c = BigInt(crc32.str(str));
+                    return c < 0 ? c + 4294967296n : c;
                 }
                 break;
             case "address":

--- a/src/interpreter.ts
+++ b/src/interpreter.ts
@@ -1129,21 +1129,20 @@ export class Interpreter {
                         this.interpretExpression(ast.args[0]!),
                         ast.args[0]!.loc,
                     );
-                    if (str.length > 32) {
+                    const hex = Buffer.from(str).toString("hex");
+                    if (hex.length > 32) {
                         throwErrorConstEval(
-                            `ascii string is too long, expected up to 32 characters, got ${str.length}`,
+                            `ascii string is too long, expected up to 32 bytes, got ${Math.floor(hex.length / 2)}`,
                             ast.loc,
                         );
                     }
-                    if (str.length == 0) {
+                    if (hex.length == 0) {
                         throwErrorConstEval(
                             `ascii string cannot be empty`,
                             ast.loc,
                         );
                     }
-                    return BigInt(
-                        "0x" + Buffer.from(str, "ascii").toString("hex"),
-                    );
+                    return BigInt("0x" + hex);
                 }
                 break;
             case "crc32":

--- a/src/interpreter.ts
+++ b/src/interpreter.ts
@@ -1152,8 +1152,7 @@ export class Interpreter {
                         this.interpretExpression(ast.args[0]!),
                         ast.args[0]!.loc,
                     );
-                    const c = BigInt(crc32.str(str));
-                    return c < 0 ? c + 4294967296n : c;
+                    return BigInt(crc32.str(str) >>> 0); // >>> 0 converts to unsigned
                 }
                 break;
             case "address":

--- a/src/interpreter.ts
+++ b/src/interpreter.ts
@@ -1130,7 +1130,7 @@ export class Interpreter {
                         ast.args[0]!.loc,
                     );
                     const hex = Buffer.from(str).toString("hex");
-                    if (hex.length > 32) {
+                    if (hex.length > 64) {
                         throwErrorConstEval(
                             `ascii string is too long, expected up to 32 bytes, got ${Math.floor(hex.length / 2)}`,
                             ast.loc,

--- a/src/test/compilation-failed/const-eval-failed.spec.ts
+++ b/src/test/compilation-failed/const-eval-failed.spec.ts
@@ -168,4 +168,9 @@ describe("fail-const-eval", () => {
         errorMessage:
             "Cannot evaluate expression to a constant: ascii string is too long, expected up to 32 characters, got 33",
     });
+    itShouldNotCompile({
+        testName: "const-eval-rawslice-not-hex",
+        errorMessage:
+            "Cannot evaluate expression to a constant: invalid hex string: hello world",
+    });
 });

--- a/src/test/compilation-failed/const-eval-failed.spec.ts
+++ b/src/test/compilation-failed/const-eval-failed.spec.ts
@@ -173,4 +173,9 @@ describe("fail-const-eval", () => {
         errorMessage:
             "Cannot evaluate expression to a constant: invalid hex string: hello world",
     });
+    itShouldNotCompile({
+        testName: "const-eval-ascii-empty",
+        errorMessage:
+            "Cannot evaluate expression to a constant: ascii string cannot be empty",
+    });
 });

--- a/src/test/compilation-failed/const-eval-failed.spec.ts
+++ b/src/test/compilation-failed/const-eval-failed.spec.ts
@@ -179,6 +179,11 @@ describe("fail-const-eval", () => {
             "Cannot evaluate expression to a constant: invalid hex string: hello world",
     });
     itShouldNotCompile({
+        testName: "const-eval-rawslice-overflow",
+        errorMessage:
+            "Cannot evaluate expression to a constant: hex string is too long, expected up to 255 characters, got 256",
+    });
+    itShouldNotCompile({
         testName: "const-eval-ascii-empty",
         errorMessage:
             "Cannot evaluate expression to a constant: ascii string cannot be empty",

--- a/src/test/compilation-failed/const-eval-failed.spec.ts
+++ b/src/test/compilation-failed/const-eval-failed.spec.ts
@@ -163,4 +163,9 @@ describe("fail-const-eval", () => {
         errorMessage:
             "Cannot evaluate expression to a constant: repeat argument must be a number between -2^256 (inclusive) and 2^31 - 1 (inclusive)",
     });
+    itShouldNotCompile({
+        testName: "const-eval-ascii-overflow",
+        errorMessage:
+            "Cannot evaluate expression to a constant: ascii string is too long, expected up to 32 characters, got 33",
+    });
 });

--- a/src/test/compilation-failed/const-eval-failed.spec.ts
+++ b/src/test/compilation-failed/const-eval-failed.spec.ts
@@ -166,7 +166,12 @@ describe("fail-const-eval", () => {
     itShouldNotCompile({
         testName: "const-eval-ascii-overflow",
         errorMessage:
-            "Cannot evaluate expression to a constant: ascii string is too long, expected up to 32 characters, got 33",
+            "Cannot evaluate expression to a constant: ascii string is too long, expected up to 32 bytes, got 33",
+    });
+    itShouldNotCompile({
+        testName: "const-eval-ascii-overflow-2",
+        errorMessage:
+            "Cannot evaluate expression to a constant: ascii string is too long, expected up to 32 bytes, got 33",
     });
     itShouldNotCompile({
         testName: "const-eval-rawslice-not-hex",

--- a/src/test/compilation-failed/contracts/const-eval-ascii-empty.tact
+++ b/src/test/compilation-failed/contracts/const-eval-ascii-empty.tact
@@ -1,0 +1,5 @@
+contract AsciiOverflow {
+    get fun getAscii_fail(): Int {
+        return ascii("");
+    }
+}

--- a/src/test/compilation-failed/contracts/const-eval-ascii-overflow-2.tact
+++ b/src/test/compilation-failed/contracts/const-eval-ascii-overflow-2.tact
@@ -1,0 +1,5 @@
+contract AsciiOverflow {
+    get fun getAscii_fail(): Int {
+        return ascii("⚡⚡⚡⚡⚡⚡⚡⚡⚡⚡⚡");
+    }
+}

--- a/src/test/compilation-failed/contracts/const-eval-ascii-overflow.tact
+++ b/src/test/compilation-failed/contracts/const-eval-ascii-overflow.tact
@@ -1,0 +1,5 @@
+contract AsciiOverflow {
+    get fun getAscii_fail(): Int {
+        return ascii("000000000000000000000000000000000");
+    }
+}

--- a/src/test/compilation-failed/contracts/const-eval-rawslice-not-hex.tact
+++ b/src/test/compilation-failed/contracts/const-eval-rawslice-not-hex.tact
@@ -1,0 +1,5 @@
+contract AsciiOverflow {
+    get fun getRawSlice_fail(): Slice {
+        return rawSlice("hello world");
+    }
+}

--- a/src/test/compilation-failed/contracts/const-eval-rawslice-overflow.tact
+++ b/src/test/compilation-failed/contracts/const-eval-rawslice-overflow.tact
@@ -1,0 +1,5 @@
+contract AsciiOverflow {
+    get fun getRawSlice_fail(): Slice {
+        return rawSlice("abcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcd");
+    }
+}

--- a/src/test/compilation-failed/tact.config.json
+++ b/src/test/compilation-failed/tact.config.json
@@ -198,6 +198,11 @@
       "output": "./contracts/output"
     },
     {
+      "name": "const-eval-ascii-empty",
+      "path": "./contracts/const-eval-ascii-empty.tact",
+      "output": "./contracts/output"
+    },  
+    {
       "name": "scope-const-shadows-stdlib-ident",
       "path": "./contracts/scope-const-shadows-stdlib-ident.tact",
       "output": "./contracts/output"

--- a/src/test/compilation-failed/tact.config.json
+++ b/src/test/compilation-failed/tact.config.json
@@ -206,7 +206,7 @@
       "name": "const-eval-rawslice-overflow",
       "path": "./contracts/const-eval-rawslice-overflow.tact",
       "output": "./contracts/output"
-},
+    },
     {
       "name": "const-eval-ascii-empty",
       "path": "./contracts/const-eval-ascii-empty.tact",

--- a/src/test/compilation-failed/tact.config.json
+++ b/src/test/compilation-failed/tact.config.json
@@ -193,6 +193,11 @@
       "output": "./contracts/output"
     },
     {
+      "name": "const-eval-rawslice-not-hex",
+      "path": "./contracts/const-eval-rawslice-not-hex.tact",
+      "output": "./contracts/output"
+    },  
+    {
       "name": "scope-const-shadows-stdlib-ident",
       "path": "./contracts/scope-const-shadows-stdlib-ident.tact",
       "output": "./contracts/output"

--- a/src/test/compilation-failed/tact.config.json
+++ b/src/test/compilation-failed/tact.config.json
@@ -196,7 +196,7 @@
       "name": "const-eval-rawslice-not-hex",
       "path": "./contracts/const-eval-rawslice-not-hex.tact",
       "output": "./contracts/output"
-    },  
+    },
     {
       "name": "scope-const-shadows-stdlib-ident",
       "path": "./contracts/scope-const-shadows-stdlib-ident.tact",

--- a/src/test/compilation-failed/tact.config.json
+++ b/src/test/compilation-failed/tact.config.json
@@ -203,6 +203,11 @@
       "output": "./contracts/output"
     },
     {
+      "name": "const-eval-rawslice-overflow",
+      "path": "./contracts/const-eval-rawslice-overflow.tact",
+      "output": "./contracts/output"
+},
+    {
       "name": "const-eval-ascii-empty",
       "path": "./contracts/const-eval-ascii-empty.tact",
       "output": "./contracts/output"

--- a/src/test/compilation-failed/tact.config.json
+++ b/src/test/compilation-failed/tact.config.json
@@ -188,6 +188,11 @@
       "output": "./contracts/output"
     },
     {
+      "name": "const-eval-ascii-overflow",
+      "path": "./contracts/const-eval-ascii-overflow.tact",
+      "output": "./contracts/output"
+    },
+    {
       "name": "scope-const-shadows-stdlib-ident",
       "path": "./contracts/scope-const-shadows-stdlib-ident.tact",
       "output": "./contracts/output"

--- a/src/test/compilation-failed/tact.config.json
+++ b/src/test/compilation-failed/tact.config.json
@@ -193,6 +193,11 @@
       "output": "./contracts/output"
     },
     {
+      "name": "const-eval-ascii-overflow-2",
+      "path": "./contracts/const-eval-ascii-overflow-2.tact",
+      "output": "./contracts/output"
+    },
+    {
       "name": "const-eval-rawslice-not-hex",
       "path": "./contracts/const-eval-rawslice-not-hex.tact",
       "output": "./contracts/output"

--- a/src/test/compilation-failed/tact.config.json
+++ b/src/test/compilation-failed/tact.config.json
@@ -206,7 +206,7 @@
       "name": "const-eval-ascii-empty",
       "path": "./contracts/const-eval-ascii-empty.tact",
       "output": "./contracts/output"
-    },  
+    },
     {
       "name": "scope-const-shadows-stdlib-ident",
       "path": "./contracts/scope-const-shadows-stdlib-ident.tact",

--- a/src/test/e2e-emulated/contracts/intrinsics.tact
+++ b/src/test/e2e-emulated/contracts/intrinsics.tact
@@ -12,6 +12,7 @@ contract IntrinsicsTester {
     j: Int = crc32("transfer(slice, int)");
     k: Int = crc32("");
     l: Int = ascii("⚡⚡⚡⚡⚡⚡⚡⚡⚡⚡");
+    m: Slice = rawSlice("");
     
     init() {
 
@@ -99,6 +100,14 @@ contract IntrinsicsTester {
 
     get fun getRawSlice2(): Slice {
         return self.h;
+    }
+
+    get fun getRawSlice3(): Slice {
+        return rawSlice("");
+    }
+
+    get fun getRawSlice4(): Slice {
+        return self.m;
     }
 
     get fun getAscii(): Int {

--- a/src/test/e2e-emulated/contracts/intrinsics.tact
+++ b/src/test/e2e-emulated/contracts/intrinsics.tact
@@ -10,6 +10,8 @@ contract IntrinsicsTester {
     h: Slice = rawSlice("abcdef");
     i: Int = ascii("hello world");
     j: Int = crc32("transfer(slice, int)");
+    k: Int = crc32("");
+    l: Int = ascii("⚡⚡⚡⚡⚡⚡⚡⚡⚡⚡");
     
     init() {
 
@@ -107,11 +109,27 @@ contract IntrinsicsTester {
         return self.i;
     }
 
+    get fun getAscii3(): Int {
+        return ascii("⚡⚡⚡⚡⚡⚡⚡⚡⚡⚡");
+    }
+
+    get fun getAscii4(): Int {
+        return self.l;
+    }
+
     get fun getCrc32(): Int {
         return crc32("transfer(slice, int)");
     }
 
     get fun getCrc32_2(): Int {
         return self.j;
+    }
+
+    get fun getCrc32_3(): Int {
+        return self.k;
+    }
+
+    get fun getCrc32_4(): Int {
+        return crc32("");
     }
 }

--- a/src/test/e2e-emulated/contracts/intrinsics.tact
+++ b/src/test/e2e-emulated/contracts/intrinsics.tact
@@ -6,6 +6,10 @@ contract IntrinsicsTester {
     d: Cell = cell("te6cckEBAQEADgAAGEhlbGxvIHdvcmxkIXgtxbw=");
     e: Int = pow(2, 9);
     f: Int = sha256("hello world");
+    g: Slice = slice("te6cckEBAQEADgAAGEhlbGxvIHdvcmxkIXgtxbw=");
+    h: Slice = rawSlice("hello world");
+    i: Int = ascii("hello world");
+    j: Int = crc32("hello world");
     
     init() {
 
@@ -77,5 +81,37 @@ contract IntrinsicsTester {
 
     receive("emit_1") {
         emit("Hello world".asComment());
+    }
+
+    get fun getSlice(): Slice {
+        return slice("te6cckEBAQEADgAAGEhlbGxvIHdvcmxkIXgtxbw=");
+    }
+
+    get fun getSlice2(): Slice {
+        return self.g;
+    }
+
+    get fun getRawSlice(): Slice {
+        return rawSlice("hello world");
+    }
+
+    get fun getRawSlice2(): Slice {
+        return self.h;
+    }
+
+    get fun getAscii(): Int {
+        return ascii("hello world");
+    }
+
+    get fun getAscii2(): Int {
+        return self.i;
+    }
+
+    get fun getCrc32(): Int {
+        return crc32("hello world");
+    }
+
+    get fun getCrc32_2(): Int {
+        return self.j;
     }
 }

--- a/src/test/e2e-emulated/contracts/intrinsics.tact
+++ b/src/test/e2e-emulated/contracts/intrinsics.tact
@@ -9,7 +9,7 @@ contract IntrinsicsTester {
     g: Slice = slice("te6cckEBAQEADgAAGEhlbGxvIHdvcmxkIXgtxbw=");
     h: Slice = rawSlice("hello world");
     i: Int = ascii("hello world");
-    j: Int = crc32("hello world");
+    j: Int = crc32("transfer(slice, int)");
     
     init() {
 
@@ -108,7 +108,7 @@ contract IntrinsicsTester {
     }
 
     get fun getCrc32(): Int {
-        return crc32("hello world");
+        return crc32("transfer(slice, int)");
     }
 
     get fun getCrc32_2(): Int {

--- a/src/test/e2e-emulated/contracts/intrinsics.tact
+++ b/src/test/e2e-emulated/contracts/intrinsics.tact
@@ -7,7 +7,7 @@ contract IntrinsicsTester {
     e: Int = pow(2, 9);
     f: Int = sha256("hello world");
     g: Slice = slice("te6cckEBAQEADgAAGEhlbGxvIHdvcmxkIXgtxbw=");
-    h: Slice = rawSlice("hello world");
+    h: Slice = rawSlice("abcdef");
     i: Int = ascii("hello world");
     j: Int = crc32("transfer(slice, int)");
     
@@ -92,7 +92,7 @@ contract IntrinsicsTester {
     }
 
     get fun getRawSlice(): Slice {
-        return rawSlice("hello world");
+        return rawSlice("abcdef");
     }
 
     get fun getRawSlice2(): Slice {

--- a/src/test/e2e-emulated/intrinsics.spec.ts
+++ b/src/test/e2e-emulated/intrinsics.spec.ts
@@ -125,12 +125,20 @@ describe("intrinsics", () => {
         expect(
             (await contract.getGetRawSlice())
                 .asCell()
-                .equals(beginCell().storeStringTail("hello world").endCell()),
+                .equals(
+                    beginCell()
+                        .storeBuffer(Buffer.from("abcdef", "hex"))
+                        .endCell(),
+                ),
         ).toBe(true);
         expect(
             (await contract.getGetRawSlice2())
                 .asCell()
-                .equals(beginCell().storeStringTail("hello world").endCell()),
+                .equals(
+                    beginCell()
+                        .storeBuffer(Buffer.from("abcdef", "hex"))
+                        .endCell(),
+                ),
         ).toBe(true);
 
         // Check `ascii`

--- a/src/test/e2e-emulated/intrinsics.spec.ts
+++ b/src/test/e2e-emulated/intrinsics.spec.ts
@@ -142,7 +142,7 @@ describe("intrinsics", () => {
         );
 
         // Check `crc32`
-        expect(await contract.getGetCrc32()).toBe(BigInt(0xd4a1185));
-        expect(await contract.getGetCrc32_2()).toBe(BigInt(0xd4a1185));
+        expect(await contract.getGetCrc32()).toBe(BigInt(2235694568));
+        expect(await contract.getGetCrc32_2()).toBe(BigInt(2235694568));
     });
 });

--- a/src/test/e2e-emulated/intrinsics.spec.ts
+++ b/src/test/e2e-emulated/intrinsics.spec.ts
@@ -148,9 +148,21 @@ describe("intrinsics", () => {
         expect(await contract.getGetAscii2()).toBe(
             BigInt("0x68656c6c6f20776f726c64"),
         );
+        expect(await contract.getGetAscii3()).toBe(
+            BigInt(
+                "1563963554659859369353828835329962428465513941646011501275668087180532385",
+            ),
+        );
+        expect(await contract.getGetAscii4()).toBe(
+            BigInt(
+                "1563963554659859369353828835329962428465513941646011501275668087180532385",
+            ),
+        );
 
         // Check `crc32`
         expect(await contract.getGetCrc32()).toBe(BigInt(2235694568));
         expect(await contract.getGetCrc32_2()).toBe(BigInt(2235694568));
+        expect(await contract.getGetCrc32_3()).toBe(0n);
+        expect(await contract.getGetCrc32_4()).toBe(0n);
     });
 });

--- a/src/test/e2e-emulated/intrinsics.spec.ts
+++ b/src/test/e2e-emulated/intrinsics.spec.ts
@@ -104,5 +104,45 @@ describe("intrinsics", () => {
             ),
         ).toBe(sha256("sometest"));
         expect(await contract.getGetHash4("wallet")).toBe(sha256("wallet"));
+
+        // Check `slice`
+        expect(
+            (await contract.getGetSlice())
+                .asCell()
+                .equals(
+                    Cell.fromBase64("te6cckEBAQEADgAAGEhlbGxvIHdvcmxkIXgtxbw="),
+                ),
+        ).toBe(true);
+        expect(
+            (await contract.getGetSlice2())
+                .asCell()
+                .equals(
+                    Cell.fromBase64("te6cckEBAQEADgAAGEhlbGxvIHdvcmxkIXgtxbw="),
+                ),
+        ).toBe(true);
+
+        // Check `rawSlice`
+        expect(
+            (await contract.getGetRawSlice())
+                .asCell()
+                .equals(beginCell().storeStringTail("hello world").endCell()),
+        ).toBe(true);
+        expect(
+            (await contract.getGetRawSlice2())
+                .asCell()
+                .equals(beginCell().storeStringTail("hello world").endCell()),
+        ).toBe(true);
+
+        // Check `ascii`
+        expect(await contract.getGetAscii()).toBe(
+            BigInt("0x68656c6c6f20776f726c64"),
+        );
+        expect(await contract.getGetAscii2()).toBe(
+            BigInt("0x68656c6c6f20776f726c64"),
+        );
+
+        // Check `crc32`
+        expect(await contract.getGetCrc32()).toBe(BigInt(0xd4a1185));
+        expect(await contract.getGetCrc32_2()).toBe(BigInt(0xd4a1185));
     });
 });

--- a/src/test/e2e-emulated/intrinsics.spec.ts
+++ b/src/test/e2e-emulated/intrinsics.spec.ts
@@ -140,6 +140,12 @@ describe("intrinsics", () => {
                         .endCell(),
                 ),
         ).toBe(true);
+        expect(
+            (await contract.getGetRawSlice3()).asCell().equals(Cell.EMPTY),
+        ).toBe(true);
+        expect(
+            (await contract.getGetRawSlice4()).asCell().equals(Cell.EMPTY),
+        ).toBe(true);
 
         // Check `ascii`
         expect(await contract.getGetAscii()).toBe(

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -1,4 +1,4 @@
-import { ABIField, Address, Cell } from "@ton/core";
+import { ABIField, Address, Cell, Slice } from "@ton/core";
 import { throwInternalCompilerError } from "../errors";
 import {
     AstConstantDef,
@@ -78,6 +78,7 @@ export type Value =
     | string
     | Address
     | Cell
+    | Slice
     | null
     | CommentValue
     | StructValue;
@@ -91,7 +92,7 @@ export function showValue(val: Value): string {
         return val ? "true" : "false";
     } else if (Address.isAddress(val)) {
         return val.toRawString();
-    } else if (val instanceof Cell) {
+    } else if (val instanceof Cell || val instanceof Slice) {
         return val.toString();
     } else if (val === null) {
         return "null";

--- a/yarn.lock
+++ b/yarn.lock
@@ -2243,6 +2243,11 @@ cosmiconfig@9.0.0:
     js-yaml "^4.1.0"
     parse-json "^5.2.0"
 
+crc-32@1.2.2:
+  version "1.2.2"
+  resolved "https://registry.npmjs.org/crc-32/-/crc-32-1.2.2.tgz#3cad35a934b8bf71f25ca524b6da51fb7eace2ff"
+  integrity sha512-ROmzCKrTnOwybPcJApAA6WBWij23HVfGVNKqqrZpuyZOHqK2CwHSvpGuyt/UNNvaIjEd8X5IFGp4Mh+Ie1IHJQ==
+
 create-jest@^29.7.0:
   version "29.7.0"
   resolved "https://registry.npmjs.org/create-jest/-/create-jest-29.7.0.tgz"


### PR DESCRIPTION
<!--
IMPORTANT:
If your PR doesn't close a particular issue, please, create the issue first and describe the whole context: what you're adding/changing and why you're doing so. And only then open the Pull Request, which would close that issue!
-->

## Issue

Closes #444.

* `slice()` isn't actually an equivalent of any string literals, but just a more efficient way to define slice constants from BOC, similarly to `cell()`
* `rawSlice("abcd")` is an equivalent of `"abcd"s` in FunC
* `ascii("hello world")` is an equivalent of `"hello world"u` in FunC
* `crc32("hello world")` is an equivalent of `"hello world"c` in FunC

## Checklist

- [x] I have updated CHANGELOG.md
- [ ] I have documented my contribution in Tact Docs: https://github.com/tact-lang/tact-docs/pull/PR-NUMBER
- [x] I have added tests to demonstrate the contribution is correctly implemented: this usually includes both positive and negative tests, showing the happy path(s) and featuring intentionally broken cases
- [x] I have run all the tests locally and no test failure was reported
- [x] I have run the linter, formatter and spellchecker
- [x] I did not do unrelated and/or undiscussed refactorings
