### PR TITLE
feat: allow optional types for `self` argument in `extends mutates` functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Optional types for `self` argument in `extends mutates` functions are now allowed: PR [#854](https://github.com/tact-lang/tact/pull/854)
+
 ### Fixed
 
 - Collisions in getter method ids are now handled and reported properly: PR [#875](https://github.com/tact-lang/tact/pull/875)

--- a/cspell.json
+++ b/cspell.json
@@ -35,6 +35,7 @@
     "decompiling",
     "dentry",
     "Descr",
+    "DICTUSET",
     "disasm",
     "divmod",
     "dnsresolve",

--- a/cspell.json
+++ b/cspell.json
@@ -35,7 +35,6 @@
     "decompiling",
     "dentry",
     "Descr",
-    "DICTUSET",
     "disasm",
     "divmod",
     "dnsresolve",

--- a/src/generator/writers/writeExpression.ts
+++ b/src/generator/writers/writeExpression.ts
@@ -558,13 +558,6 @@ export function writeExpression(f: AstExpression, wCtx: WriterContext): string {
 
         // Reference type
         if (selfTyRef.kind === "ref") {
-            if (selfTyRef.optional) {
-                throwCompilationError(
-                    `Cannot call function of non - direct type: "${printTypeRef(selfTyRef)}"`,
-                    f.loc,
-                );
-            }
-
             // Render function call
             const selfTy = getType(wCtx.ctx, selfTyRef.name);
 

--- a/src/generator/writers/writeFunction.ts
+++ b/src/generator/writers/writeFunction.ts
@@ -503,7 +503,7 @@ function writeCondition(
 
 export function writeFunction(f: FunctionDescription, ctx: WriterContext) {
     // Resolve self
-    const self = f.self ? getType(ctx.ctx, f.self) : null;
+    const self = f.self?.kind === "ref" ? getType(ctx.ctx, f.self.name) : null;
 
     // Write function header
     let returns: string = resolveFuncType(f.returns, ctx);
@@ -683,7 +683,7 @@ function writeNonMutatingFunction(
 
 export function writeGetter(f: FunctionDescription, ctx: WriterContext) {
     // Render tensors
-    const self = f.self !== null ? getType(ctx.ctx, f.self) : null;
+    const self = f.self?.kind === "ref" ? getType(ctx.ctx, f.self.name) : null;
     if (!self) {
         throw new Error(`No self type for getter ${idTextErr(f.name)}`); // Impossible
     }

--- a/src/storage/__snapshots__/resolveAllocation.spec.ts.snap
+++ b/src/storage/__snapshots__/resolveAllocation.spec.ts.snap
@@ -2293,7 +2293,11 @@ exports[`resolveAllocation should write program 1`] = `
           "returns": {
             "kind": "void",
           },
-          "self": "Sample",
+          "self": {
+            "kind": "ref",
+            "name": "Sample",
+            "optional": false,
+          },
         },
       },
       "header": null,

--- a/src/test/e2e-emulated/contracts/mutating-methods.tact
+++ b/src/test/e2e-emulated/contracts/mutating-methods.tact
@@ -5,6 +5,13 @@ extends mutates fun multiply(self: Int, x: Int): Int {
     return self;
 }
 
+extends fun multiplyExtends(self: Int?, x: Int): Int? {
+    if (self == null) {
+        return null;
+    }
+    return self!! * x;
+}
+
 struct Foo {
     s: Slice;
 }
@@ -70,5 +77,11 @@ contract Tester {
     get fun test10(dict: Cell?): Cell? {
         dict.nativeUdictStoreUint(8, 123, rawSlice("456"));
         return dict;
+    }
+
+    get fun test11(x: Int?): Int? {
+        x.multiplyExtends(2);
+        x.multiplyExtends(2).multiplyExtends(3);
+        return x.multiplyExtends(2).multiplyExtends(3);
     }
 }

--- a/src/test/e2e-emulated/contracts/mutating-methods.tact
+++ b/src/test/e2e-emulated/contracts/mutating-methods.tact
@@ -1,3 +1,5 @@
+asm(value key self keySize) extends mutates fun nativeUdictStoreUint(self: Cell?, keySize: Int, key: Int, value: Slice) { DICTUSET }
+
 extends mutates fun multiply(self: Int, x: Int): Int {
     self *= x;
     return self;
@@ -63,5 +65,10 @@ contract Tester {
     get fun test9(): Int {
         self.s.loadUint(1);
         return self.s.loadUint(3);
+    }
+
+    get fun test10(dict: Cell?): Cell? {
+        dict.nativeUdictStoreUint(8, 123, rawSlice("456"));
+        return dict;
     }
 }

--- a/src/test/e2e-emulated/mutating-methods.spec.ts
+++ b/src/test/e2e-emulated/mutating-methods.spec.ts
@@ -85,5 +85,8 @@ describe("bugs", () => {
             expect(d?.size).toBe(1);
             expect(d?.get(123)?.toString()).toBe("456");
         }
+
+        expect(await contract.getTest11(1n)).toBe(6n);
+        expect(await contract.getTest11(2n)).toBe(12n);
     });
 });

--- a/src/test/e2e-emulated/mutating-methods.spec.ts
+++ b/src/test/e2e-emulated/mutating-methods.spec.ts
@@ -1,6 +1,6 @@
-import { toNano } from "@ton/core";
+import { beginCell, BitString, Dictionary, toNano } from "@ton/core";
 import { Blockchain, SandboxContract, TreasuryContract } from "@ton/sandbox";
-import { Tester } from "./contracts/output/mutating-method-chaining_Tester";
+import { Tester } from "./contracts/output/mutating-methods_Tester";
 import "@ton/test-utils";
 
 describe("bugs", () => {
@@ -52,5 +52,38 @@ describe("bugs", () => {
         expect(await contract.getTest7()).toBe(42n);
         expect(await contract.getTest8()).toBe(5n);
         expect(await contract.getTest9()).toBe(5n);
+
+        // Test `extends mutates` function with optional self param
+        {
+            // Non-empty dictionary
+            const d = Dictionary.empty(
+                Dictionary.Keys.Uint(8),
+                Dictionary.Values.BitString(12),
+            );
+            d.set(1, new BitString(Buffer.from("1234", "hex"), 0, 12));
+            const c = beginCell().storeDictDirect(d).endCell();
+            const c2 = await contract.getTest10(c);
+            const d2 = c2
+                ?.beginParse()
+                .loadDictDirect(
+                    Dictionary.Keys.Uint(8),
+                    Dictionary.Values.BitString(12),
+                );
+            expect(d2?.size).toBe(2);
+            expect(d2?.get(1)?.toString()).toBe("123");
+            expect(d2?.get(123)?.toString()).toBe("456");
+        }
+        {
+            // Empty dictionary
+            const c = await contract.getTest10(null);
+            const d = c
+                ?.beginParse()
+                .loadDictDirect(
+                    Dictionary.Keys.Uint(8),
+                    Dictionary.Values.BitString(12),
+                );
+            expect(d?.size).toBe(1);
+            expect(d?.get(123)?.toString()).toBe("456");
+        }
     });
 });

--- a/src/types/__snapshots__/resolveDescriptors.spec.ts.snap
+++ b/src/types/__snapshots__/resolveDescriptors.spec.ts.snap
@@ -769,7 +769,11 @@ exports[`resolveDescriptors should resolve descriptors for asm-extends-fun 1`] =
           "name": "Cell",
           "optional": false,
         },
-        "self": "Slice",
+        "self": {
+          "kind": "ref",
+          "name": "Slice",
+          "optional": false,
+        },
       },
     },
     "header": null,
@@ -4505,7 +4509,11 @@ exports[`resolveDescriptors should resolve descriptors for contract-getter-overr
           "name": "Int",
           "optional": false,
         },
-        "self": "T",
+        "self": {
+          "kind": "ref",
+          "name": "T",
+          "optional": false,
+        },
       },
     },
     "header": null,
@@ -4682,7 +4690,11 @@ exports[`resolveDescriptors should resolve descriptors for contract-getter-overr
           "name": "Int",
           "optional": false,
         },
-        "self": "TestContract",
+        "self": {
+          "kind": "ref",
+          "name": "TestContract",
+          "optional": false,
+        },
       },
     },
     "header": null,
@@ -4832,7 +4844,11 @@ exports[`resolveDescriptors should resolve descriptors for contract-getter-overr
               "name": "Int",
               "optional": false,
             },
-            "self": "T",
+            "self": {
+              "kind": "ref",
+              "name": "T",
+              "optional": false,
+            },
           },
         },
         "header": null,
@@ -5073,7 +5089,11 @@ exports[`resolveDescriptors should resolve descriptors for contract-getter-overr
           "name": "Int",
           "optional": false,
         },
-        "self": "T",
+        "self": {
+          "kind": "ref",
+          "name": "T",
+          "optional": false,
+        },
       },
     },
     "header": null,
@@ -5250,7 +5270,11 @@ exports[`resolveDescriptors should resolve descriptors for contract-getter-overr
           "name": "Int",
           "optional": false,
         },
-        "self": "TestContract",
+        "self": {
+          "kind": "ref",
+          "name": "TestContract",
+          "optional": false,
+        },
       },
     },
     "header": null,
@@ -5428,7 +5452,11 @@ exports[`resolveDescriptors should resolve descriptors for contract-getter-overr
               "name": "Int",
               "optional": false,
             },
-            "self": "T",
+            "self": {
+              "kind": "ref",
+              "name": "T",
+              "optional": false,
+            },
           },
         },
         "header": null,
@@ -5484,6 +5512,1132 @@ exports[`resolveDescriptors should resolve descriptors for contract-getter-overr
 `;
 
 exports[`resolveDescriptors should resolve descriptors for contract-getter-override-virtual 2`] = `[]`;
+
+exports[`resolveDescriptors should resolve descriptors for fun-extends-opt-self 1`] = `
+[
+  {
+    "ast": {
+      "id": 2,
+      "kind": "primitive_type_decl",
+      "loc": primitive Int;,
+      "name": {
+        "id": 1,
+        "kind": "type_id",
+        "loc": Int,
+        "text": "Int",
+      },
+    },
+    "constants": [],
+    "dependsOn": [],
+    "fields": [],
+    "functions": Map {
+      "test_extends" => {
+        "ast": {
+          "attributes": [
+            {
+              "loc": extends,
+              "type": "extends",
+            },
+          ],
+          "id": 44,
+          "kind": "function_def",
+          "loc": extends fun test_extends(self: Int, y: Int?): Int {
+    if (y == null) {
+        return self;
+    }
+    return self + y!!;
+},
+          "name": {
+            "id": 24,
+            "kind": "id",
+            "loc": test_extends,
+            "text": "test_extends",
+          },
+          "params": [
+            {
+              "id": 28,
+              "kind": "typed_parameter",
+              "loc": self: Int,
+              "name": {
+                "id": 26,
+                "kind": "id",
+                "loc": self,
+                "text": "self",
+              },
+              "type": {
+                "id": 27,
+                "kind": "type_id",
+                "loc": Int,
+                "text": "Int",
+              },
+            },
+            {
+              "id": 32,
+              "kind": "typed_parameter",
+              "loc": y: Int?,
+              "name": {
+                "id": 29,
+                "kind": "id",
+                "loc": y,
+                "text": "y",
+              },
+              "type": {
+                "id": 31,
+                "kind": "optional_type",
+                "loc": Int?,
+                "typeArg": {
+                  "id": 30,
+                  "kind": "type_id",
+                  "loc": Int,
+                  "text": "Int",
+                },
+              },
+            },
+          ],
+          "return": {
+            "id": 25,
+            "kind": "type_id",
+            "loc": Int,
+            "text": "Int",
+          },
+          "statements": [
+            {
+              "condition": {
+                "id": 35,
+                "kind": "op_binary",
+                "left": {
+                  "id": 33,
+                  "kind": "id",
+                  "loc": y,
+                  "text": "y",
+                },
+                "loc": y == null,
+                "op": "==",
+                "right": {
+                  "id": 34,
+                  "kind": "null",
+                  "loc": null,
+                },
+              },
+              "elseif": null,
+              "falseStatements": null,
+              "id": 38,
+              "kind": "statement_condition",
+              "loc": if (y == null) {
+        return self;
+    },
+              "trueStatements": [
+                {
+                  "expression": {
+                    "id": 36,
+                    "kind": "id",
+                    "loc": self,
+                    "text": "self",
+                  },
+                  "id": 37,
+                  "kind": "statement_return",
+                  "loc": return self;,
+                },
+              ],
+            },
+            {
+              "expression": {
+                "id": 42,
+                "kind": "op_binary",
+                "left": {
+                  "id": 39,
+                  "kind": "id",
+                  "loc": self,
+                  "text": "self",
+                },
+                "loc": self + y!!,
+                "op": "+",
+                "right": {
+                  "id": 41,
+                  "kind": "op_unary",
+                  "loc": y!!,
+                  "op": "!!",
+                  "operand": {
+                    "id": 40,
+                    "kind": "id",
+                    "loc": y,
+                    "text": "y",
+                  },
+                },
+              },
+              "id": 43,
+              "kind": "statement_return",
+              "loc": return self + y!!;,
+            },
+          ],
+        },
+        "isAbstract": false,
+        "isGetter": false,
+        "isInline": false,
+        "isMutating": false,
+        "isOverride": false,
+        "isVirtual": false,
+        "name": "test_extends",
+        "origin": "user",
+        "params": [
+          {
+            "loc": y: Int?,
+            "name": {
+              "id": 29,
+              "kind": "id",
+              "loc": y,
+              "text": "y",
+            },
+            "type": {
+              "kind": "ref",
+              "name": "Int",
+              "optional": true,
+            },
+          },
+        ],
+        "returns": {
+          "kind": "ref",
+          "name": "Int",
+          "optional": false,
+        },
+        "self": {
+          "kind": "ref",
+          "name": "Int",
+          "optional": false,
+        },
+      },
+      "test_extends_self" => {
+        "ast": {
+          "attributes": [
+            {
+              "loc": extends,
+              "type": "extends",
+            },
+          ],
+          "id": 65,
+          "kind": "function_def",
+          "loc": extends fun test_extends_self(self: Int?, y: Int): Int {
+    if (self == null) {
+        return y;
+    }
+    return self!! + y;
+},
+          "name": {
+            "id": 45,
+            "kind": "id",
+            "loc": test_extends_self,
+            "text": "test_extends_self",
+          },
+          "params": [
+            {
+              "id": 50,
+              "kind": "typed_parameter",
+              "loc": self: Int?,
+              "name": {
+                "id": 47,
+                "kind": "id",
+                "loc": self,
+                "text": "self",
+              },
+              "type": {
+                "id": 49,
+                "kind": "optional_type",
+                "loc": Int?,
+                "typeArg": {
+                  "id": 48,
+                  "kind": "type_id",
+                  "loc": Int,
+                  "text": "Int",
+                },
+              },
+            },
+            {
+              "id": 53,
+              "kind": "typed_parameter",
+              "loc": y: Int,
+              "name": {
+                "id": 51,
+                "kind": "id",
+                "loc": y,
+                "text": "y",
+              },
+              "type": {
+                "id": 52,
+                "kind": "type_id",
+                "loc": Int,
+                "text": "Int",
+              },
+            },
+          ],
+          "return": {
+            "id": 46,
+            "kind": "type_id",
+            "loc": Int,
+            "text": "Int",
+          },
+          "statements": [
+            {
+              "condition": {
+                "id": 56,
+                "kind": "op_binary",
+                "left": {
+                  "id": 54,
+                  "kind": "id",
+                  "loc": self,
+                  "text": "self",
+                },
+                "loc": self == null,
+                "op": "==",
+                "right": {
+                  "id": 55,
+                  "kind": "null",
+                  "loc": null,
+                },
+              },
+              "elseif": null,
+              "falseStatements": null,
+              "id": 59,
+              "kind": "statement_condition",
+              "loc": if (self == null) {
+        return y;
+    },
+              "trueStatements": [
+                {
+                  "expression": {
+                    "id": 57,
+                    "kind": "id",
+                    "loc": y,
+                    "text": "y",
+                  },
+                  "id": 58,
+                  "kind": "statement_return",
+                  "loc": return y;,
+                },
+              ],
+            },
+            {
+              "expression": {
+                "id": 63,
+                "kind": "op_binary",
+                "left": {
+                  "id": 61,
+                  "kind": "op_unary",
+                  "loc": self!!,
+                  "op": "!!",
+                  "operand": {
+                    "id": 60,
+                    "kind": "id",
+                    "loc": self,
+                    "text": "self",
+                  },
+                },
+                "loc": self!! + y,
+                "op": "+",
+                "right": {
+                  "id": 62,
+                  "kind": "id",
+                  "loc": y,
+                  "text": "y",
+                },
+              },
+              "id": 64,
+              "kind": "statement_return",
+              "loc": return self!! + y;,
+            },
+          ],
+        },
+        "isAbstract": false,
+        "isGetter": false,
+        "isInline": false,
+        "isMutating": false,
+        "isOverride": false,
+        "isVirtual": false,
+        "name": "test_extends_self",
+        "origin": "user",
+        "params": [
+          {
+            "loc": y: Int,
+            "name": {
+              "id": 51,
+              "kind": "id",
+              "loc": y,
+              "text": "y",
+            },
+            "type": {
+              "kind": "ref",
+              "name": "Int",
+              "optional": false,
+            },
+          },
+        ],
+        "returns": {
+          "kind": "ref",
+          "name": "Int",
+          "optional": false,
+        },
+        "self": {
+          "kind": "ref",
+          "name": "Int",
+          "optional": true,
+        },
+      },
+      "test_mutates" => {
+        "ast": {
+          "attributes": [
+            {
+              "loc": extends,
+              "type": "extends",
+            },
+            {
+              "loc": mutates,
+              "type": "mutates",
+            },
+          ],
+          "id": 86,
+          "kind": "function_def",
+          "loc": extends mutates fun test_mutates(self: Int, y: Int?): Int {
+    if (y == null) {
+        return self;
+    }
+    self += y;
+    return self;
+},
+          "name": {
+            "id": 66,
+            "kind": "id",
+            "loc": test_mutates,
+            "text": "test_mutates",
+          },
+          "params": [
+            {
+              "id": 70,
+              "kind": "typed_parameter",
+              "loc": self: Int,
+              "name": {
+                "id": 68,
+                "kind": "id",
+                "loc": self,
+                "text": "self",
+              },
+              "type": {
+                "id": 69,
+                "kind": "type_id",
+                "loc": Int,
+                "text": "Int",
+              },
+            },
+            {
+              "id": 74,
+              "kind": "typed_parameter",
+              "loc": y: Int?,
+              "name": {
+                "id": 71,
+                "kind": "id",
+                "loc": y,
+                "text": "y",
+              },
+              "type": {
+                "id": 73,
+                "kind": "optional_type",
+                "loc": Int?,
+                "typeArg": {
+                  "id": 72,
+                  "kind": "type_id",
+                  "loc": Int,
+                  "text": "Int",
+                },
+              },
+            },
+          ],
+          "return": {
+            "id": 67,
+            "kind": "type_id",
+            "loc": Int,
+            "text": "Int",
+          },
+          "statements": [
+            {
+              "condition": {
+                "id": 77,
+                "kind": "op_binary",
+                "left": {
+                  "id": 75,
+                  "kind": "id",
+                  "loc": y,
+                  "text": "y",
+                },
+                "loc": y == null,
+                "op": "==",
+                "right": {
+                  "id": 76,
+                  "kind": "null",
+                  "loc": null,
+                },
+              },
+              "elseif": null,
+              "falseStatements": null,
+              "id": 80,
+              "kind": "statement_condition",
+              "loc": if (y == null) {
+        return self;
+    },
+              "trueStatements": [
+                {
+                  "expression": {
+                    "id": 78,
+                    "kind": "id",
+                    "loc": self,
+                    "text": "self",
+                  },
+                  "id": 79,
+                  "kind": "statement_return",
+                  "loc": return self;,
+                },
+              ],
+            },
+            {
+              "expression": {
+                "id": 82,
+                "kind": "id",
+                "loc": y,
+                "text": "y",
+              },
+              "id": 83,
+              "kind": "statement_augmentedassign",
+              "loc": self += y;,
+              "op": "+",
+              "path": {
+                "id": 81,
+                "kind": "id",
+                "loc": self,
+                "text": "self",
+              },
+            },
+            {
+              "expression": {
+                "id": 84,
+                "kind": "id",
+                "loc": self,
+                "text": "self",
+              },
+              "id": 85,
+              "kind": "statement_return",
+              "loc": return self;,
+            },
+          ],
+        },
+        "isAbstract": false,
+        "isGetter": false,
+        "isInline": false,
+        "isMutating": true,
+        "isOverride": false,
+        "isVirtual": false,
+        "name": "test_mutates",
+        "origin": "user",
+        "params": [
+          {
+            "loc": y: Int?,
+            "name": {
+              "id": 71,
+              "kind": "id",
+              "loc": y,
+              "text": "y",
+            },
+            "type": {
+              "kind": "ref",
+              "name": "Int",
+              "optional": true,
+            },
+          },
+        ],
+        "returns": {
+          "kind": "ref",
+          "name": "Int",
+          "optional": false,
+        },
+        "self": {
+          "kind": "ref",
+          "name": "Int",
+          "optional": false,
+        },
+      },
+      "test_mutates_self" => {
+        "ast": {
+          "attributes": [
+            {
+              "loc": extends,
+              "type": "extends",
+            },
+            {
+              "loc": mutates,
+              "type": "mutates",
+            },
+          ],
+          "id": 108,
+          "kind": "function_def",
+          "loc": extends mutates fun test_mutates_self(self: Int?, y: Int): Int {
+    if (self == null) {
+        return y;
+    }
+    self!! += y;
+    return self;
+},
+          "name": {
+            "id": 87,
+            "kind": "id",
+            "loc": test_mutates_self,
+            "text": "test_mutates_self",
+          },
+          "params": [
+            {
+              "id": 92,
+              "kind": "typed_parameter",
+              "loc": self: Int?,
+              "name": {
+                "id": 89,
+                "kind": "id",
+                "loc": self,
+                "text": "self",
+              },
+              "type": {
+                "id": 91,
+                "kind": "optional_type",
+                "loc": Int?,
+                "typeArg": {
+                  "id": 90,
+                  "kind": "type_id",
+                  "loc": Int,
+                  "text": "Int",
+                },
+              },
+            },
+            {
+              "id": 95,
+              "kind": "typed_parameter",
+              "loc": y: Int,
+              "name": {
+                "id": 93,
+                "kind": "id",
+                "loc": y,
+                "text": "y",
+              },
+              "type": {
+                "id": 94,
+                "kind": "type_id",
+                "loc": Int,
+                "text": "Int",
+              },
+            },
+          ],
+          "return": {
+            "id": 88,
+            "kind": "type_id",
+            "loc": Int,
+            "text": "Int",
+          },
+          "statements": [
+            {
+              "condition": {
+                "id": 98,
+                "kind": "op_binary",
+                "left": {
+                  "id": 96,
+                  "kind": "id",
+                  "loc": self,
+                  "text": "self",
+                },
+                "loc": self == null,
+                "op": "==",
+                "right": {
+                  "id": 97,
+                  "kind": "null",
+                  "loc": null,
+                },
+              },
+              "elseif": null,
+              "falseStatements": null,
+              "id": 101,
+              "kind": "statement_condition",
+              "loc": if (self == null) {
+        return y;
+    },
+              "trueStatements": [
+                {
+                  "expression": {
+                    "id": 99,
+                    "kind": "id",
+                    "loc": y,
+                    "text": "y",
+                  },
+                  "id": 100,
+                  "kind": "statement_return",
+                  "loc": return y;,
+                },
+              ],
+            },
+            {
+              "expression": {
+                "id": 104,
+                "kind": "id",
+                "loc": y,
+                "text": "y",
+              },
+              "id": 105,
+              "kind": "statement_augmentedassign",
+              "loc": self!! += y;,
+              "op": "+",
+              "path": {
+                "id": 103,
+                "kind": "op_unary",
+                "loc": self!!,
+                "op": "!!",
+                "operand": {
+                  "id": 102,
+                  "kind": "id",
+                  "loc": self,
+                  "text": "self",
+                },
+              },
+            },
+            {
+              "expression": {
+                "id": 106,
+                "kind": "id",
+                "loc": self,
+                "text": "self",
+              },
+              "id": 107,
+              "kind": "statement_return",
+              "loc": return self;,
+            },
+          ],
+        },
+        "isAbstract": false,
+        "isGetter": false,
+        "isInline": false,
+        "isMutating": true,
+        "isOverride": false,
+        "isVirtual": false,
+        "name": "test_mutates_self",
+        "origin": "user",
+        "params": [
+          {
+            "loc": y: Int,
+            "name": {
+              "id": 93,
+              "kind": "id",
+              "loc": y,
+              "text": "y",
+            },
+            "type": {
+              "kind": "ref",
+              "name": "Int",
+              "optional": false,
+            },
+          },
+        ],
+        "returns": {
+          "kind": "ref",
+          "name": "Int",
+          "optional": false,
+        },
+        "self": {
+          "kind": "ref",
+          "name": "Int",
+          "optional": true,
+        },
+      },
+      "test_mutates_self_opt" => {
+        "ast": {
+          "attributes": [
+            {
+              "loc": extends,
+              "type": "extends",
+            },
+            {
+              "loc": mutates,
+              "type": "mutates",
+            },
+          ],
+          "id": 131,
+          "kind": "function_def",
+          "loc": extends mutates fun test_mutates_self_opt(self: Int?, y: Int): Int? {
+    if (self == null) {
+        return null;
+    }
+    self!! += y;
+    return self;
+},
+          "name": {
+            "id": 109,
+            "kind": "id",
+            "loc": test_mutates_self_opt,
+            "text": "test_mutates_self_opt",
+          },
+          "params": [
+            {
+              "id": 115,
+              "kind": "typed_parameter",
+              "loc": self: Int?,
+              "name": {
+                "id": 112,
+                "kind": "id",
+                "loc": self,
+                "text": "self",
+              },
+              "type": {
+                "id": 114,
+                "kind": "optional_type",
+                "loc": Int?,
+                "typeArg": {
+                  "id": 113,
+                  "kind": "type_id",
+                  "loc": Int,
+                  "text": "Int",
+                },
+              },
+            },
+            {
+              "id": 118,
+              "kind": "typed_parameter",
+              "loc": y: Int,
+              "name": {
+                "id": 116,
+                "kind": "id",
+                "loc": y,
+                "text": "y",
+              },
+              "type": {
+                "id": 117,
+                "kind": "type_id",
+                "loc": Int,
+                "text": "Int",
+              },
+            },
+          ],
+          "return": {
+            "id": 111,
+            "kind": "optional_type",
+            "loc": Int?,
+            "typeArg": {
+              "id": 110,
+              "kind": "type_id",
+              "loc": Int,
+              "text": "Int",
+            },
+          },
+          "statements": [
+            {
+              "condition": {
+                "id": 121,
+                "kind": "op_binary",
+                "left": {
+                  "id": 119,
+                  "kind": "id",
+                  "loc": self,
+                  "text": "self",
+                },
+                "loc": self == null,
+                "op": "==",
+                "right": {
+                  "id": 120,
+                  "kind": "null",
+                  "loc": null,
+                },
+              },
+              "elseif": null,
+              "falseStatements": null,
+              "id": 124,
+              "kind": "statement_condition",
+              "loc": if (self == null) {
+        return null;
+    },
+              "trueStatements": [
+                {
+                  "expression": {
+                    "id": 122,
+                    "kind": "null",
+                    "loc": null,
+                  },
+                  "id": 123,
+                  "kind": "statement_return",
+                  "loc": return null;,
+                },
+              ],
+            },
+            {
+              "expression": {
+                "id": 127,
+                "kind": "id",
+                "loc": y,
+                "text": "y",
+              },
+              "id": 128,
+              "kind": "statement_augmentedassign",
+              "loc": self!! += y;,
+              "op": "+",
+              "path": {
+                "id": 126,
+                "kind": "op_unary",
+                "loc": self!!,
+                "op": "!!",
+                "operand": {
+                  "id": 125,
+                  "kind": "id",
+                  "loc": self,
+                  "text": "self",
+                },
+              },
+            },
+            {
+              "expression": {
+                "id": 129,
+                "kind": "id",
+                "loc": self,
+                "text": "self",
+              },
+              "id": 130,
+              "kind": "statement_return",
+              "loc": return self;,
+            },
+          ],
+        },
+        "isAbstract": false,
+        "isGetter": false,
+        "isInline": false,
+        "isMutating": true,
+        "isOverride": false,
+        "isVirtual": false,
+        "name": "test_mutates_self_opt",
+        "origin": "user",
+        "params": [
+          {
+            "loc": y: Int,
+            "name": {
+              "id": 116,
+              "kind": "id",
+              "loc": y,
+              "text": "y",
+            },
+            "type": {
+              "kind": "ref",
+              "name": "Int",
+              "optional": false,
+            },
+          },
+        ],
+        "returns": {
+          "kind": "ref",
+          "name": "Int",
+          "optional": true,
+        },
+        "self": {
+          "kind": "ref",
+          "name": "Int",
+          "optional": true,
+        },
+      },
+    },
+    "header": null,
+    "init": null,
+    "interfaces": [],
+    "kind": "primitive_type_decl",
+    "name": "Int",
+    "origin": "user",
+    "partialFieldCount": 0,
+    "receivers": [],
+    "signature": null,
+    "tlb": null,
+    "traits": [],
+    "uid": 38154,
+  },
+]
+`;
+
+exports[`resolveDescriptors should resolve descriptors for fun-extends-opt-self 2`] = `
+[
+  {
+    "ast": {
+      "attributes": [],
+      "id": 23,
+      "kind": "function_def",
+      "loc": fun test(x: Int, y: Int?): Int {
+    if (y == null) {
+        return x;
+    }
+    return x + y!!;
+},
+      "name": {
+        "id": 3,
+        "kind": "id",
+        "loc": test,
+        "text": "test",
+      },
+      "params": [
+        {
+          "id": 7,
+          "kind": "typed_parameter",
+          "loc": x: Int,
+          "name": {
+            "id": 5,
+            "kind": "id",
+            "loc": x,
+            "text": "x",
+          },
+          "type": {
+            "id": 6,
+            "kind": "type_id",
+            "loc": Int,
+            "text": "Int",
+          },
+        },
+        {
+          "id": 11,
+          "kind": "typed_parameter",
+          "loc": y: Int?,
+          "name": {
+            "id": 8,
+            "kind": "id",
+            "loc": y,
+            "text": "y",
+          },
+          "type": {
+            "id": 10,
+            "kind": "optional_type",
+            "loc": Int?,
+            "typeArg": {
+              "id": 9,
+              "kind": "type_id",
+              "loc": Int,
+              "text": "Int",
+            },
+          },
+        },
+      ],
+      "return": {
+        "id": 4,
+        "kind": "type_id",
+        "loc": Int,
+        "text": "Int",
+      },
+      "statements": [
+        {
+          "condition": {
+            "id": 14,
+            "kind": "op_binary",
+            "left": {
+              "id": 12,
+              "kind": "id",
+              "loc": y,
+              "text": "y",
+            },
+            "loc": y == null,
+            "op": "==",
+            "right": {
+              "id": 13,
+              "kind": "null",
+              "loc": null,
+            },
+          },
+          "elseif": null,
+          "falseStatements": null,
+          "id": 17,
+          "kind": "statement_condition",
+          "loc": if (y == null) {
+        return x;
+    },
+          "trueStatements": [
+            {
+              "expression": {
+                "id": 15,
+                "kind": "id",
+                "loc": x,
+                "text": "x",
+              },
+              "id": 16,
+              "kind": "statement_return",
+              "loc": return x;,
+            },
+          ],
+        },
+        {
+          "expression": {
+            "id": 21,
+            "kind": "op_binary",
+            "left": {
+              "id": 18,
+              "kind": "id",
+              "loc": x,
+              "text": "x",
+            },
+            "loc": x + y!!,
+            "op": "+",
+            "right": {
+              "id": 20,
+              "kind": "op_unary",
+              "loc": y!!,
+              "op": "!!",
+              "operand": {
+                "id": 19,
+                "kind": "id",
+                "loc": y,
+                "text": "y",
+              },
+            },
+          },
+          "id": 22,
+          "kind": "statement_return",
+          "loc": return x + y!!;,
+        },
+      ],
+    },
+    "isAbstract": false,
+    "isGetter": false,
+    "isInline": false,
+    "isMutating": false,
+    "isOverride": false,
+    "isVirtual": false,
+    "name": "test",
+    "origin": "user",
+    "params": [
+      {
+        "loc": x: Int,
+        "name": {
+          "id": 5,
+          "kind": "id",
+          "loc": x,
+          "text": "x",
+        },
+        "type": {
+          "kind": "ref",
+          "name": "Int",
+          "optional": false,
+        },
+      },
+      {
+        "loc": y: Int?,
+        "name": {
+          "id": 8,
+          "kind": "id",
+          "loc": y,
+          "text": "y",
+        },
+        "type": {
+          "kind": "ref",
+          "name": "Int",
+          "optional": true,
+        },
+      },
+    ],
+    "returns": {
+      "kind": "ref",
+      "name": "Int",
+      "optional": false,
+    },
+    "self": null,
+  },
+]
+`;
 
 exports[`resolveDescriptors should resolve descriptors for init-vars-analysis-uninit-storage-vars 1`] = `
 [
@@ -5805,7 +6959,11 @@ exports[`resolveDescriptors should resolve descriptors for init-vars-analysis-un
         "returns": {
           "kind": "void",
         },
-        "self": "HelloWorld",
+        "self": {
+          "kind": "ref",
+          "name": "HelloWorld",
+          "optional": false,
+        },
       },
       "hello2" => {
         "ast": {
@@ -5837,7 +6995,11 @@ exports[`resolveDescriptors should resolve descriptors for init-vars-analysis-un
         "returns": {
           "kind": "void",
         },
-        "self": "HelloWorld",
+        "self": {
+          "kind": "ref",
+          "name": "HelloWorld",
+          "optional": false,
+        },
       },
     },
     "header": null,
@@ -6682,7 +7844,11 @@ exports[`resolveDescriptors should resolve descriptors for item-funs-with-errors
           "name": "Int",
           "optional": false,
         },
-        "self": "Main",
+        "self": {
+          "kind": "ref",
+          "name": "Main",
+          "optional": false,
+        },
       },
       "hello2" => {
         "ast": {
@@ -6739,7 +7905,11 @@ exports[`resolveDescriptors should resolve descriptors for item-funs-with-errors
           "name": "Point",
           "optional": false,
         },
-        "self": "Main",
+        "self": {
+          "kind": "ref",
+          "name": "Main",
+          "optional": false,
+        },
       },
     },
     "header": null,
@@ -6972,7 +8142,11 @@ exports[`resolveDescriptors should resolve descriptors for item-method 1`] = `
           "name": "Int",
           "optional": false,
         },
-        "self": "Int",
+        "self": {
+          "kind": "ref",
+          "name": "Int",
+          "optional": false,
+        },
       },
     },
     "header": null,
@@ -7320,7 +8494,11 @@ mutates extends native inc(self: Int): Int;,
           "name": "Int",
           "optional": false,
         },
-        "self": "Int",
+        "self": {
+          "kind": "ref",
+          "name": "Int",
+          "optional": false,
+        },
       },
     },
     "header": null,
@@ -8090,7 +9268,11 @@ exports[`resolveDescriptors should resolve descriptors for map-value-as-coins 1`
           "name": "Int",
           "optional": false,
         },
-        "self": "Main",
+        "self": {
+          "kind": "ref",
+          "name": "Main",
+          "optional": false,
+        },
       },
     },
     "header": null,

--- a/src/types/__snapshots__/resolveDescriptors.spec.ts.snap
+++ b/src/types/__snapshots__/resolveDescriptors.spec.ts.snap
@@ -5539,54 +5539,51 @@ exports[`resolveDescriptors should resolve descriptors for fun-extends-opt-self 
               "type": "extends",
             },
           ],
-          "id": 44,
+          "id": 26,
           "kind": "function_def",
           "loc": extends fun test_extends(self: Int, y: Int?): Int {
-    if (y == null) {
-        return self;
-    }
-    return self + y!!;
+    return 123;
 },
           "name": {
-            "id": 24,
+            "id": 15,
             "kind": "id",
             "loc": test_extends,
             "text": "test_extends",
           },
           "params": [
             {
-              "id": 28,
+              "id": 19,
               "kind": "typed_parameter",
               "loc": self: Int,
               "name": {
-                "id": 26,
+                "id": 17,
                 "kind": "id",
                 "loc": self,
                 "text": "self",
               },
               "type": {
-                "id": 27,
+                "id": 18,
                 "kind": "type_id",
                 "loc": Int,
                 "text": "Int",
               },
             },
             {
-              "id": 32,
+              "id": 23,
               "kind": "typed_parameter",
               "loc": y: Int?,
               "name": {
-                "id": 29,
+                "id": 20,
                 "kind": "id",
                 "loc": y,
                 "text": "y",
               },
               "type": {
-                "id": 31,
+                "id": 22,
                 "kind": "optional_type",
                 "loc": Int?,
                 "typeArg": {
-                  "id": 30,
+                  "id": 21,
                   "kind": "type_id",
                   "loc": Int,
                   "text": "Int",
@@ -5595,79 +5592,23 @@ exports[`resolveDescriptors should resolve descriptors for fun-extends-opt-self 
             },
           ],
           "return": {
-            "id": 25,
+            "id": 16,
             "kind": "type_id",
             "loc": Int,
             "text": "Int",
           },
           "statements": [
             {
-              "condition": {
-                "id": 35,
-                "kind": "op_binary",
-                "left": {
-                  "id": 33,
-                  "kind": "id",
-                  "loc": y,
-                  "text": "y",
-                },
-                "loc": y == null,
-                "op": "==",
-                "right": {
-                  "id": 34,
-                  "kind": "null",
-                  "loc": null,
-                },
-              },
-              "elseif": null,
-              "falseStatements": null,
-              "id": 38,
-              "kind": "statement_condition",
-              "loc": if (y == null) {
-        return self;
-    },
-              "trueStatements": [
-                {
-                  "expression": {
-                    "id": 36,
-                    "kind": "id",
-                    "loc": self,
-                    "text": "self",
-                  },
-                  "id": 37,
-                  "kind": "statement_return",
-                  "loc": return self;,
-                },
-              ],
-            },
-            {
               "expression": {
-                "id": 42,
-                "kind": "op_binary",
-                "left": {
-                  "id": 39,
-                  "kind": "id",
-                  "loc": self,
-                  "text": "self",
-                },
-                "loc": self + y!!,
-                "op": "+",
-                "right": {
-                  "id": 41,
-                  "kind": "op_unary",
-                  "loc": y!!,
-                  "op": "!!",
-                  "operand": {
-                    "id": 40,
-                    "kind": "id",
-                    "loc": y,
-                    "text": "y",
-                  },
-                },
+                "base": 10,
+                "id": 24,
+                "kind": "number",
+                "loc": 123,
+                "value": 123n,
               },
-              "id": 43,
+              "id": 25,
               "kind": "statement_return",
-              "loc": return self + y!!;,
+              "loc": return 123;,
             },
           ],
         },
@@ -5683,7 +5624,7 @@ exports[`resolveDescriptors should resolve descriptors for fun-extends-opt-self 
           {
             "loc": y: Int?,
             "name": {
-              "id": 29,
+              "id": 20,
               "kind": "id",
               "loc": y,
               "text": "y",
@@ -5714,37 +5655,34 @@ exports[`resolveDescriptors should resolve descriptors for fun-extends-opt-self 
               "type": "extends",
             },
           ],
-          "id": 65,
+          "id": 38,
           "kind": "function_def",
           "loc": extends fun test_extends_self(self: Int?, y: Int): Int {
-    if (self == null) {
-        return y;
-    }
-    return self!! + y;
+    return 123;
 },
           "name": {
-            "id": 45,
+            "id": 27,
             "kind": "id",
             "loc": test_extends_self,
             "text": "test_extends_self",
           },
           "params": [
             {
-              "id": 50,
+              "id": 32,
               "kind": "typed_parameter",
               "loc": self: Int?,
               "name": {
-                "id": 47,
+                "id": 29,
                 "kind": "id",
                 "loc": self,
                 "text": "self",
               },
               "type": {
-                "id": 49,
+                "id": 31,
                 "kind": "optional_type",
                 "loc": Int?,
                 "typeArg": {
-                  "id": 48,
+                  "id": 30,
                   "kind": "type_id",
                   "loc": Int,
                   "text": "Int",
@@ -5752,17 +5690,17 @@ exports[`resolveDescriptors should resolve descriptors for fun-extends-opt-self 
               },
             },
             {
-              "id": 53,
+              "id": 35,
               "kind": "typed_parameter",
               "loc": y: Int,
               "name": {
-                "id": 51,
+                "id": 33,
                 "kind": "id",
                 "loc": y,
                 "text": "y",
               },
               "type": {
-                "id": 52,
+                "id": 34,
                 "kind": "type_id",
                 "loc": Int,
                 "text": "Int",
@@ -5770,79 +5708,23 @@ exports[`resolveDescriptors should resolve descriptors for fun-extends-opt-self 
             },
           ],
           "return": {
-            "id": 46,
+            "id": 28,
             "kind": "type_id",
             "loc": Int,
             "text": "Int",
           },
           "statements": [
             {
-              "condition": {
-                "id": 56,
-                "kind": "op_binary",
-                "left": {
-                  "id": 54,
-                  "kind": "id",
-                  "loc": self,
-                  "text": "self",
-                },
-                "loc": self == null,
-                "op": "==",
-                "right": {
-                  "id": 55,
-                  "kind": "null",
-                  "loc": null,
-                },
-              },
-              "elseif": null,
-              "falseStatements": null,
-              "id": 59,
-              "kind": "statement_condition",
-              "loc": if (self == null) {
-        return y;
-    },
-              "trueStatements": [
-                {
-                  "expression": {
-                    "id": 57,
-                    "kind": "id",
-                    "loc": y,
-                    "text": "y",
-                  },
-                  "id": 58,
-                  "kind": "statement_return",
-                  "loc": return y;,
-                },
-              ],
-            },
-            {
               "expression": {
-                "id": 63,
-                "kind": "op_binary",
-                "left": {
-                  "id": 61,
-                  "kind": "op_unary",
-                  "loc": self!!,
-                  "op": "!!",
-                  "operand": {
-                    "id": 60,
-                    "kind": "id",
-                    "loc": self,
-                    "text": "self",
-                  },
-                },
-                "loc": self!! + y,
-                "op": "+",
-                "right": {
-                  "id": 62,
-                  "kind": "id",
-                  "loc": y,
-                  "text": "y",
-                },
+                "base": 10,
+                "id": 36,
+                "kind": "number",
+                "loc": 123,
+                "value": 123n,
               },
-              "id": 64,
+              "id": 37,
               "kind": "statement_return",
-              "loc": return self!! + y;,
+              "loc": return 123;,
             },
           ],
         },
@@ -5858,7 +5740,7 @@ exports[`resolveDescriptors should resolve descriptors for fun-extends-opt-self 
           {
             "loc": y: Int,
             "name": {
-              "id": 51,
+              "id": 33,
               "kind": "id",
               "loc": y,
               "text": "y",
@@ -5893,55 +5775,51 @@ exports[`resolveDescriptors should resolve descriptors for fun-extends-opt-self 
               "type": "mutates",
             },
           ],
-          "id": 86,
+          "id": 50,
           "kind": "function_def",
           "loc": extends mutates fun test_mutates(self: Int, y: Int?): Int {
-    if (y == null) {
-        return self;
-    }
-    self += y;
-    return self;
+    return 123;
 },
           "name": {
-            "id": 66,
+            "id": 39,
             "kind": "id",
             "loc": test_mutates,
             "text": "test_mutates",
           },
           "params": [
             {
-              "id": 70,
+              "id": 43,
               "kind": "typed_parameter",
               "loc": self: Int,
               "name": {
-                "id": 68,
+                "id": 41,
                 "kind": "id",
                 "loc": self,
                 "text": "self",
               },
               "type": {
-                "id": 69,
+                "id": 42,
                 "kind": "type_id",
                 "loc": Int,
                 "text": "Int",
               },
             },
             {
-              "id": 74,
+              "id": 47,
               "kind": "typed_parameter",
               "loc": y: Int?,
               "name": {
-                "id": 71,
+                "id": 44,
                 "kind": "id",
                 "loc": y,
                 "text": "y",
               },
               "type": {
-                "id": 73,
+                "id": 46,
                 "kind": "optional_type",
                 "loc": Int?,
                 "typeArg": {
-                  "id": 72,
+                  "id": 45,
                   "kind": "type_id",
                   "loc": Int,
                   "text": "Int",
@@ -5950,79 +5828,23 @@ exports[`resolveDescriptors should resolve descriptors for fun-extends-opt-self 
             },
           ],
           "return": {
-            "id": 67,
+            "id": 40,
             "kind": "type_id",
             "loc": Int,
             "text": "Int",
           },
           "statements": [
             {
-              "condition": {
-                "id": 77,
-                "kind": "op_binary",
-                "left": {
-                  "id": 75,
-                  "kind": "id",
-                  "loc": y,
-                  "text": "y",
-                },
-                "loc": y == null,
-                "op": "==",
-                "right": {
-                  "id": 76,
-                  "kind": "null",
-                  "loc": null,
-                },
-              },
-              "elseif": null,
-              "falseStatements": null,
-              "id": 80,
-              "kind": "statement_condition",
-              "loc": if (y == null) {
-        return self;
-    },
-              "trueStatements": [
-                {
-                  "expression": {
-                    "id": 78,
-                    "kind": "id",
-                    "loc": self,
-                    "text": "self",
-                  },
-                  "id": 79,
-                  "kind": "statement_return",
-                  "loc": return self;,
-                },
-              ],
-            },
-            {
               "expression": {
-                "id": 82,
-                "kind": "id",
-                "loc": y,
-                "text": "y",
+                "base": 10,
+                "id": 48,
+                "kind": "number",
+                "loc": 123,
+                "value": 123n,
               },
-              "id": 83,
-              "kind": "statement_augmentedassign",
-              "loc": self += y;,
-              "op": "+",
-              "path": {
-                "id": 81,
-                "kind": "id",
-                "loc": self,
-                "text": "self",
-              },
-            },
-            {
-              "expression": {
-                "id": 84,
-                "kind": "id",
-                "loc": self,
-                "text": "self",
-              },
-              "id": 85,
+              "id": 49,
               "kind": "statement_return",
-              "loc": return self;,
+              "loc": return 123;,
             },
           ],
         },
@@ -6038,7 +5860,7 @@ exports[`resolveDescriptors should resolve descriptors for fun-extends-opt-self 
           {
             "loc": y: Int?,
             "name": {
-              "id": 71,
+              "id": 44,
               "kind": "id",
               "loc": y,
               "text": "y",
@@ -6073,38 +5895,34 @@ exports[`resolveDescriptors should resolve descriptors for fun-extends-opt-self 
               "type": "mutates",
             },
           ],
-          "id": 108,
+          "id": 62,
           "kind": "function_def",
           "loc": extends mutates fun test_mutates_self(self: Int?, y: Int): Int {
-    if (self == null) {
-        return y;
-    }
-    self!! += y;
-    return self;
+    return 123;
 },
           "name": {
-            "id": 87,
+            "id": 51,
             "kind": "id",
             "loc": test_mutates_self,
             "text": "test_mutates_self",
           },
           "params": [
             {
-              "id": 92,
+              "id": 56,
               "kind": "typed_parameter",
               "loc": self: Int?,
               "name": {
-                "id": 89,
+                "id": 53,
                 "kind": "id",
                 "loc": self,
                 "text": "self",
               },
               "type": {
-                "id": 91,
+                "id": 55,
                 "kind": "optional_type",
                 "loc": Int?,
                 "typeArg": {
-                  "id": 90,
+                  "id": 54,
                   "kind": "type_id",
                   "loc": Int,
                   "text": "Int",
@@ -6112,17 +5930,17 @@ exports[`resolveDescriptors should resolve descriptors for fun-extends-opt-self 
               },
             },
             {
-              "id": 95,
+              "id": 59,
               "kind": "typed_parameter",
               "loc": y: Int,
               "name": {
-                "id": 93,
+                "id": 57,
                 "kind": "id",
                 "loc": y,
                 "text": "y",
               },
               "type": {
-                "id": 94,
+                "id": 58,
                 "kind": "type_id",
                 "loc": Int,
                 "text": "Int",
@@ -6130,85 +5948,23 @@ exports[`resolveDescriptors should resolve descriptors for fun-extends-opt-self 
             },
           ],
           "return": {
-            "id": 88,
+            "id": 52,
             "kind": "type_id",
             "loc": Int,
             "text": "Int",
           },
           "statements": [
             {
-              "condition": {
-                "id": 98,
-                "kind": "op_binary",
-                "left": {
-                  "id": 96,
-                  "kind": "id",
-                  "loc": self,
-                  "text": "self",
-                },
-                "loc": self == null,
-                "op": "==",
-                "right": {
-                  "id": 97,
-                  "kind": "null",
-                  "loc": null,
-                },
-              },
-              "elseif": null,
-              "falseStatements": null,
-              "id": 101,
-              "kind": "statement_condition",
-              "loc": if (self == null) {
-        return y;
-    },
-              "trueStatements": [
-                {
-                  "expression": {
-                    "id": 99,
-                    "kind": "id",
-                    "loc": y,
-                    "text": "y",
-                  },
-                  "id": 100,
-                  "kind": "statement_return",
-                  "loc": return y;,
-                },
-              ],
-            },
-            {
               "expression": {
-                "id": 104,
-                "kind": "id",
-                "loc": y,
-                "text": "y",
+                "base": 10,
+                "id": 60,
+                "kind": "number",
+                "loc": 123,
+                "value": 123n,
               },
-              "id": 105,
-              "kind": "statement_augmentedassign",
-              "loc": self!! += y;,
-              "op": "+",
-              "path": {
-                "id": 103,
-                "kind": "op_unary",
-                "loc": self!!,
-                "op": "!!",
-                "operand": {
-                  "id": 102,
-                  "kind": "id",
-                  "loc": self,
-                  "text": "self",
-                },
-              },
-            },
-            {
-              "expression": {
-                "id": 106,
-                "kind": "id",
-                "loc": self,
-                "text": "self",
-              },
-              "id": 107,
+              "id": 61,
               "kind": "statement_return",
-              "loc": return self;,
+              "loc": return 123;,
             },
           ],
         },
@@ -6224,7 +5980,7 @@ exports[`resolveDescriptors should resolve descriptors for fun-extends-opt-self 
           {
             "loc": y: Int,
             "name": {
-              "id": 93,
+              "id": 57,
               "kind": "id",
               "loc": y,
               "text": "y",
@@ -6259,38 +6015,34 @@ exports[`resolveDescriptors should resolve descriptors for fun-extends-opt-self 
               "type": "mutates",
             },
           ],
-          "id": 131,
+          "id": 75,
           "kind": "function_def",
           "loc": extends mutates fun test_mutates_self_opt(self: Int?, y: Int): Int? {
-    if (self == null) {
-        return null;
-    }
-    self!! += y;
-    return self;
+    return null;
 },
           "name": {
-            "id": 109,
+            "id": 63,
             "kind": "id",
             "loc": test_mutates_self_opt,
             "text": "test_mutates_self_opt",
           },
           "params": [
             {
-              "id": 115,
+              "id": 69,
               "kind": "typed_parameter",
               "loc": self: Int?,
               "name": {
-                "id": 112,
+                "id": 66,
                 "kind": "id",
                 "loc": self,
                 "text": "self",
               },
               "type": {
-                "id": 114,
+                "id": 68,
                 "kind": "optional_type",
                 "loc": Int?,
                 "typeArg": {
-                  "id": 113,
+                  "id": 67,
                   "kind": "type_id",
                   "loc": Int,
                   "text": "Int",
@@ -6298,17 +6050,17 @@ exports[`resolveDescriptors should resolve descriptors for fun-extends-opt-self 
               },
             },
             {
-              "id": 118,
+              "id": 72,
               "kind": "typed_parameter",
               "loc": y: Int,
               "name": {
-                "id": 116,
+                "id": 70,
                 "kind": "id",
                 "loc": y,
                 "text": "y",
               },
               "type": {
-                "id": 117,
+                "id": 71,
                 "kind": "type_id",
                 "loc": Int,
                 "text": "Int",
@@ -6316,11 +6068,11 @@ exports[`resolveDescriptors should resolve descriptors for fun-extends-opt-self 
             },
           ],
           "return": {
-            "id": 111,
+            "id": 65,
             "kind": "optional_type",
             "loc": Int?,
             "typeArg": {
-              "id": 110,
+              "id": 64,
               "kind": "type_id",
               "loc": Int,
               "text": "Int",
@@ -6328,77 +6080,14 @@ exports[`resolveDescriptors should resolve descriptors for fun-extends-opt-self 
           },
           "statements": [
             {
-              "condition": {
-                "id": 121,
-                "kind": "op_binary",
-                "left": {
-                  "id": 119,
-                  "kind": "id",
-                  "loc": self,
-                  "text": "self",
-                },
-                "loc": self == null,
-                "op": "==",
-                "right": {
-                  "id": 120,
-                  "kind": "null",
-                  "loc": null,
-                },
-              },
-              "elseif": null,
-              "falseStatements": null,
-              "id": 124,
-              "kind": "statement_condition",
-              "loc": if (self == null) {
-        return null;
-    },
-              "trueStatements": [
-                {
-                  "expression": {
-                    "id": 122,
-                    "kind": "null",
-                    "loc": null,
-                  },
-                  "id": 123,
-                  "kind": "statement_return",
-                  "loc": return null;,
-                },
-              ],
-            },
-            {
               "expression": {
-                "id": 127,
-                "kind": "id",
-                "loc": y,
-                "text": "y",
+                "id": 73,
+                "kind": "null",
+                "loc": null,
               },
-              "id": 128,
-              "kind": "statement_augmentedassign",
-              "loc": self!! += y;,
-              "op": "+",
-              "path": {
-                "id": 126,
-                "kind": "op_unary",
-                "loc": self!!,
-                "op": "!!",
-                "operand": {
-                  "id": 125,
-                  "kind": "id",
-                  "loc": self,
-                  "text": "self",
-                },
-              },
-            },
-            {
-              "expression": {
-                "id": 129,
-                "kind": "id",
-                "loc": self,
-                "text": "self",
-              },
-              "id": 130,
+              "id": 74,
               "kind": "statement_return",
-              "loc": return self;,
+              "loc": return null;,
             },
           ],
         },
@@ -6414,7 +6103,7 @@ exports[`resolveDescriptors should resolve descriptors for fun-extends-opt-self 
           {
             "loc": y: Int,
             "name": {
-              "id": 116,
+              "id": 70,
               "kind": "id",
               "loc": y,
               "text": "y",
@@ -6459,13 +6148,10 @@ exports[`resolveDescriptors should resolve descriptors for fun-extends-opt-self 
   {
     "ast": {
       "attributes": [],
-      "id": 23,
+      "id": 14,
       "kind": "function_def",
       "loc": fun test(x: Int, y: Int?): Int {
-    if (y == null) {
-        return x;
-    }
-    return x + y!!;
+    return 123;
 },
       "name": {
         "id": 3,
@@ -6522,72 +6208,16 @@ exports[`resolveDescriptors should resolve descriptors for fun-extends-opt-self 
       },
       "statements": [
         {
-          "condition": {
-            "id": 14,
-            "kind": "op_binary",
-            "left": {
-              "id": 12,
-              "kind": "id",
-              "loc": y,
-              "text": "y",
-            },
-            "loc": y == null,
-            "op": "==",
-            "right": {
-              "id": 13,
-              "kind": "null",
-              "loc": null,
-            },
-          },
-          "elseif": null,
-          "falseStatements": null,
-          "id": 17,
-          "kind": "statement_condition",
-          "loc": if (y == null) {
-        return x;
-    },
-          "trueStatements": [
-            {
-              "expression": {
-                "id": 15,
-                "kind": "id",
-                "loc": x,
-                "text": "x",
-              },
-              "id": 16,
-              "kind": "statement_return",
-              "loc": return x;,
-            },
-          ],
-        },
-        {
           "expression": {
-            "id": 21,
-            "kind": "op_binary",
-            "left": {
-              "id": 18,
-              "kind": "id",
-              "loc": x,
-              "text": "x",
-            },
-            "loc": x + y!!,
-            "op": "+",
-            "right": {
-              "id": 20,
-              "kind": "op_unary",
-              "loc": y!!,
-              "op": "!!",
-              "operand": {
-                "id": 19,
-                "kind": "id",
-                "loc": y,
-                "text": "y",
-              },
-            },
+            "base": 10,
+            "id": 12,
+            "kind": "number",
+            "loc": 123,
+            "value": 123n,
           },
-          "id": 22,
+          "id": 13,
           "kind": "statement_return",
-          "loc": return x + y!!;,
+          "loc": return 123;,
         },
       ],
     },

--- a/src/types/__snapshots__/resolveStatements.spec.ts.snap
+++ b/src/types/__snapshots__/resolveStatements.spec.ts.snap
@@ -2268,6 +2268,223 @@ exports[`resolveStatements should resolve statements for expr-struct-constructio
 ]
 `;
 
+exports[`resolveStatements should resolve statements for fun-extends-optional 1`] = `
+[
+  [
+    "y",
+    "Int?",
+  ],
+  [
+    "null",
+    "<null>",
+  ],
+  [
+    "y == null",
+    "Bool",
+  ],
+  [
+    "x",
+    "Int",
+  ],
+  [
+    "x",
+    "Int",
+  ],
+  [
+    "y",
+    "Int?",
+  ],
+  [
+    "y!!",
+    "Int",
+  ],
+  [
+    "x + y!!",
+    "Int",
+  ],
+  [
+    "y",
+    "Int?",
+  ],
+  [
+    "null",
+    "<null>",
+  ],
+  [
+    "y == null",
+    "Bool",
+  ],
+  [
+    "self",
+    "Int",
+  ],
+  [
+    "self",
+    "Int",
+  ],
+  [
+    "y",
+    "Int?",
+  ],
+  [
+    "y!!",
+    "Int",
+  ],
+  [
+    "self + y!!",
+    "Int",
+  ],
+  [
+    "self",
+    "Int?",
+  ],
+  [
+    "null",
+    "<null>",
+  ],
+  [
+    "self == null",
+    "Bool",
+  ],
+  [
+    "y",
+    "Int",
+  ],
+  [
+    "self",
+    "Int?",
+  ],
+  [
+    "self!!",
+    "Int",
+  ],
+  [
+    "y",
+    "Int",
+  ],
+  [
+    "self!! + y",
+    "Int",
+  ],
+  [
+    "y",
+    "Int?",
+  ],
+  [
+    "null",
+    "<null>",
+  ],
+  [
+    "y == null",
+    "Bool",
+  ],
+  [
+    "self",
+    "Int",
+  ],
+  [
+    "self",
+    "Int",
+  ],
+  [
+    "y",
+    "Int?",
+  ],
+  [
+    "y!!",
+    "Int",
+  ],
+  [
+    "self",
+    "Int",
+  ],
+  [
+    "self",
+    "Int?",
+  ],
+  [
+    "null",
+    "<null>",
+  ],
+  [
+    "self == null",
+    "Bool",
+  ],
+  [
+    "y",
+    "Int",
+  ],
+  [
+    "self",
+    "Int?",
+  ],
+  [
+    "self",
+    "Int?",
+  ],
+  [
+    "self!!",
+    "Int",
+  ],
+  [
+    "y",
+    "Int",
+  ],
+  [
+    "self!! + y",
+    "Int",
+  ],
+  [
+    "self",
+    "Int?",
+  ],
+  [
+    "self!!",
+    "Int",
+  ],
+  [
+    "self",
+    "Int?",
+  ],
+  [
+    "null",
+    "<null>",
+  ],
+  [
+    "self == null",
+    "Bool",
+  ],
+  [
+    "null",
+    "<null>",
+  ],
+  [
+    "self",
+    "Int?",
+  ],
+  [
+    "self",
+    "Int?",
+  ],
+  [
+    "self!!",
+    "Int",
+  ],
+  [
+    "y",
+    "Int",
+  ],
+  [
+    "self!! + y",
+    "Int",
+  ],
+  [
+    "self",
+    "Int?",
+  ],
+]
+`;
+
 exports[`resolveStatements should resolve statements for init-vars-analysis-with-if 1`] = `
 [
   [

--- a/src/types/resolveDescriptors.ts
+++ b/src/types/resolveDescriptors.ts
@@ -747,7 +747,7 @@ export function resolveDescriptors(ctx: CompilerContext) {
         // Check virtual
         if (isVirtual) {
             if (self?.kind !== "ref") {
-                throwCompilationError(
+                throwInternalCompilerError(
                     "Virtual functions must have a self parameter",
                     isVirtual.loc,
                 );
@@ -764,7 +764,7 @@ export function resolveDescriptors(ctx: CompilerContext) {
         // Check abstract
         if (isAbstract) {
             if (self?.kind !== "ref") {
-                throwCompilationError(
+                throwInternalCompilerError(
                     "Abstract functions must have a self parameter",
                     isAbstract.loc,
                 );
@@ -780,7 +780,7 @@ export function resolveDescriptors(ctx: CompilerContext) {
 
         if (isOverride) {
             if (self?.kind !== "ref") {
-                throwCompilationError(
+                throwInternalCompilerError(
                     "Override functions must have a self parameter",
                     isOverride.loc,
                 );

--- a/src/types/resolveDescriptors.ts
+++ b/src/types/resolveDescriptors.ts
@@ -818,12 +818,6 @@ export function resolveDescriptors(ctx: CompilerContext) {
                     firstParam.loc,
                 );
             }
-            if (firstParam.type.optional) {
-                throwCompilationError(
-                    "Extend functions must have a non-optional type as the first parameter",
-                    firstParam.loc,
-                );
-            }
             if (!types.has(firstParam.type.name)) {
                 throwCompilationError(
                     "Type " + firstParam.type.name + " not found",

--- a/src/types/resolveExpression.ts
+++ b/src/types/resolveExpression.ts
@@ -562,13 +562,6 @@ function resolveCall(
 
     // Handle ref
     if (src.kind === "ref") {
-        if (src.optional) {
-            throwCompilationError(
-                `Invalid type "${printTypeRef(src)}" for function call`,
-                exp.loc,
-            );
-        }
-
         // Register return type
         const srcT = getType(ctx, src.name);
 

--- a/src/types/resolveStatements.ts
+++ b/src/types/resolveStatements.ts
@@ -864,12 +864,12 @@ export function resolveStatements(ctx: CompilerContext) {
             ) {
                 // Build statement context
                 let sctx = emptyContext(f.ast.loc, f.name, f.returns);
-                sctx = addVariable(
-                    selfId,
-                    { kind: "ref", name: t.name, optional: false },
-                    ctx,
-                    sctx,
-                );
+                if (f.self === null) {
+                    throwInternalCompilerError(
+                        "Self is null where it should not be",
+                    );
+                }
+                sctx = addVariable(selfId, f.self, ctx, sctx);
                 for (const a of f.params) {
                     sctx = addVariable(a.name, a.type, ctx, sctx);
                 }

--- a/src/types/stmts/fun-extends-optional.tact
+++ b/src/types/stmts/fun-extends-optional.tact
@@ -1,0 +1,46 @@
+primitive Int;
+
+fun test(x: Int, y: Int?): Int {
+    if (y == null) {
+        return x;
+    }
+    return x + y!!;
+}
+
+extends fun test_extends(self: Int, y: Int?): Int {
+    if (y == null) {
+        return self;
+    }
+    return self + y!!;
+}
+
+extends fun test_extends_self(self: Int?, y: Int): Int {
+    if (self == null) {
+        return y;
+    }
+    return self!! + y;
+}
+
+extends mutates fun test_mutates(self: Int, y: Int?): Int {
+    if (y == null) {
+        return self;
+    }
+    self += y!!;
+    return self;
+}
+
+extends mutates fun test_mutates_self(self: Int?, y: Int): Int {
+    if (self == null) {
+        return y;
+    }
+    self = self!! + y;
+    return self!!;
+}
+
+extends mutates fun test_mutates_self_opt(self: Int?, y: Int): Int? {
+    if (self == null) {
+        return null;
+    }
+    self = self!! + y;
+    return self;
+}

--- a/src/types/test/fun-extends-opt-self.tact
+++ b/src/types/test/fun-extends-opt-self.tact
@@ -1,46 +1,25 @@
 primitive Int;
 
 fun test(x: Int, y: Int?): Int {
-    if (y == null) {
-        return x;
-    }
-    return x + y!!;
+    return 123;
 }
 
 extends fun test_extends(self: Int, y: Int?): Int {
-    if (y == null) {
-        return self;
-    }
-    return self + y!!;
+    return 123;
 }
 
 extends fun test_extends_self(self: Int?, y: Int): Int {
-    if (self == null) {
-        return y;
-    }
-    return self!! + y;
+    return 123;
 }
 
 extends mutates fun test_mutates(self: Int, y: Int?): Int {
-    if (y == null) {
-        return self;
-    }
-    self += y;
-    return self;
+    return 123;
 }
 
 extends mutates fun test_mutates_self(self: Int?, y: Int): Int {
-    if (self == null) {
-        return y;
-    }
-    self!! += y;
-    return self;
+    return 123;
 }
 
 extends mutates fun test_mutates_self_opt(self: Int?, y: Int): Int? {
-    if (self == null) {
-        return null;
-    }
-    self!! += y;
-    return self;
+    return null;
 }

--- a/src/types/test/fun-extends-opt-self.tact
+++ b/src/types/test/fun-extends-opt-self.tact
@@ -1,0 +1,46 @@
+primitive Int;
+
+fun test(x: Int, y: Int?): Int {
+    if (y == null) {
+        return x;
+    }
+    return x + y!!;
+}
+
+extends fun test_extends(self: Int, y: Int?): Int {
+    if (y == null) {
+        return self;
+    }
+    return self + y!!;
+}
+
+extends fun test_extends_self(self: Int?, y: Int): Int {
+    if (self == null) {
+        return y;
+    }
+    return self!! + y;
+}
+
+extends mutates fun test_mutates(self: Int, y: Int?): Int {
+    if (y == null) {
+        return self;
+    }
+    self += y;
+    return self;
+}
+
+extends mutates fun test_mutates_self(self: Int?, y: Int): Int {
+    if (self == null) {
+        return y;
+    }
+    self!! += y;
+    return self;
+}
+
+extends mutates fun test_mutates_self_opt(self: Int?, y: Int): Int? {
+    if (self == null) {
+        return null;
+    }
+    self!! += y;
+    return self;
+}

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -149,7 +149,7 @@ export type FunctionDescription = {
     isVirtual: boolean;
     isAbstract: boolean;
     isInline: boolean;
-    self: string | null;
+    self: TypeRef | null;
     returns: TypeRef;
     params: FunctionParameter[];
     ast:

--- a/tact.config.json
+++ b/tact.config.json
@@ -95,8 +95,8 @@
       "output": "./src/test/e2e-emulated/contracts/output"
     },
     {
-      "name": "mutating-method-chaining",
-      "path": "./src/test/e2e-emulated/contracts/mutating-method-chaining.tact",
+      "name": "mutating-methods",
+      "path": "./src/test/e2e-emulated/contracts/mutating-methods.tact",
       "output": "./src/test/e2e-emulated/contracts/output"
     },
     {


### PR DESCRIPTION
<!--
IMPORTANT:
If your PR doesn't close a particular issue, please, create the issue first and describe the whole context: what you're adding/changing and why you're doing so. And only then open the Pull Request, which would close that issue!
-->

## Issue

Closes #70.

## Checklist

- [x] I have updated CHANGELOG.md
- [ ] I have documented my contribution in Tact Docs: https://github.com/tact-lang/tact-docs/pull/PR-NUMBER
- [x] I have added tests to demonstrate the contribution is correctly implemented: this usually includes both positive and negative tests, showing the happy path(s) and featuring intentionally broken cases
- [x] I have run all the tests locally and no test failure was reported
- [x] I have run the linter, formatter and spellchecker
- [x] I did not do unrelated and/or undiscussed refactorings
