### PR TITLE
fix(docs): a small list of housekeeping updates and visual improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `&&=`, `||=`, `>>=` and `<<=` augmented assignment operators: PR [#853](https://github.com/tact-lang/tact/pull/853)
 - New CSpell dictionaries: TVM instructions and adjusted list of Fift words: PR [#881](https://github.com/tact-lang/tact/pull/881)
+- Docs: the `description` property to the frontmatter of the each page for better SEO: PR [#916](https://github.com/tact-lang/tact/pull/916)
 
 ### Changed
 
@@ -19,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Collisions in getter method ids are now handled and reported properly: PR [#875](https://github.com/tact-lang/tact/pull/875)
+- Docs: layout of tables, syntax highlighting, Chinese translations of sidebar separators: PR [#916](https://github.com/tact-lang/tact/pull/916)
 
 ### Release contributors
 

--- a/cspell.json
+++ b/cspell.json
@@ -45,6 +45,7 @@
     "funcfiftlib",
     "funcid",
     "funs",
+    "frontmatter",
     "Georgiy",
     "gettest",
     "Héctor",

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,5 +1,5 @@
 
-<img src="public/banner.jpeg">
+<img src="public/banner.jpg">
 
 # Welcome to ⚡ Tact Documentation
 

--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -45,9 +45,9 @@ export default defineConfig({
 		starlight({
 			title: {
 				en: '⚡ Tact Documentation',
-				'zh-CN': '⚡ Tact Documentation',
+				'zh-CN': '⚡ Tact 语言文档',
 			},
-			titleDelimiter: '-',
+			titleDelimiter: undefined,
 			favicon: '/favicon.png',
 			logo: {
 				dark: '/public/logo-dark.svg',
@@ -55,7 +55,7 @@ export default defineConfig({
 				alt: '⚡ Tact Documentation',
 				replacesTitle: true,
 			},
-			// 'head' is auto-populated with SEO-friendly contents
+			// 'head' is auto-populated with SEO-friendly contents based on the page frontmatters
 			social: {
 				github: 'https://github.com/tact-lang/tact',
 				telegram: 'https://t.me/tactlang',
@@ -113,7 +113,7 @@ export default defineConfig({
 						'zh-CN': '图书',
 					},
 					items: [
-						'book',
+						{ slug: 'book' },
 						{
 							label: 'Cheatsheets',
 							translations: {
@@ -123,52 +123,52 @@ export default defineConfig({
 							autogenerate: { directory: 'book/cs' },
 						},
 						{
-						  label: 'Fundamentals of Tact',
-						  translations: { 'zn-CN': 'Tact 语言基础' },
-						  link: '#', attrs: { class: 'sidebar-separator' }
+							label: 'Fundamentals of Tact',
+							translations: { 'zh-CN': 'Tact 语言基础' },
+							link: '#', attrs: { class: 'sidebar-separator' }
 						},
-						'book/types',
-						'book/integers',
-						'book/cells',
-						'book/maps',
-						'book/structs-and-messages',
-						'book/optionals',
-						'book/contracts',
-						'book/exit-codes',
+						{ slug: 'book/types' },
+						{ slug: 'book/integers' },
+						{ slug: 'book/cells' },
+						{ slug: 'book/maps' },
+						{ slug: 'book/structs-and-messages' },
+						{ slug: 'book/optionals' },
+						{ slug: 'book/contracts' },
+						{ slug: 'book/exit-codes' },
 						{
-						  label: 'Expressiveness',
-						  translations: { 'zn-CN': '表现力' },
-						  link: '#', attrs: { class: 'sidebar-separator' }
+							label: 'Expressiveness',
+							translations: { 'zh-CN': '表现力' },
+							link: '#', attrs: { class: 'sidebar-separator' }
 						},
-						'book/operators',
-						'book/expressions',
-						'book/statements',
-						'book/constants',
-						'book/functions',
+						{ slug: 'book/operators' },
+						{ slug: 'book/expressions' },
+						{ slug: 'book/statements' },
+						{ slug: 'book/constants' },
+						{ slug: 'book/functions' },
 						{
-						  label: 'Communication',
-						  translations: { 'zn-CN': '交流' },
-						  link: '#', attrs: { class: 'sidebar-separator' }
+							label: 'Communication',
+							translations: { 'zh-CN': '交流' },
+							link: '#', attrs: { class: 'sidebar-separator' }
 						},
-						'book/receive',
-						'book/bounced',
-						'book/external',
-						'book/lifecycle',
-						'book/send',
-						'book/message-mode',
+						{ slug: 'book/receive' },
+						{ slug: 'book/bounced' },
+						{ slug: 'book/external' },
+						{ slug: 'book/lifecycle' },
+						{ slug: 'book/send' },
+						{ slug: 'book/message-mode' },
 						{
-						  label: 'Going places',
-						  translations: { 'zn-CN': '前往各地' },
-						  link: '#', attrs: { class: 'sidebar-separator' }
+							label: 'Going places',
+							translations: { 'zh-CN': '前往各地' },
+							link: '#', attrs: { class: 'sidebar-separator' }
 						},
-						'book/deploy',
-						'book/debug',
-						'book/upgrades',
-						'book/import',
-						'book/config',
-						'book/masterchain',
-						'book/func',
-						'book/programmatic',
+						{ slug: 'book/deploy' },
+						{ slug: 'book/debug' },
+						{ slug: 'book/upgrades' },
+						{ slug: 'book/import' },
+						{ slug: 'book/config' },
+						{ slug: 'book/masterchain' },
+						{ slug: 'book/func' },
+						{ slug: 'book/programmatic' },
 					],
 				},
 				{
@@ -177,28 +177,28 @@ export default defineConfig({
 						'zh-CN': '食谱',
 					},
 					items: [
-						'cookbook',
+						{ slug: 'cookbook' },
 						{
-						  label: 'Single contract',
-						  translations: { 'zn-CN': '单一合同' },
-						  link: '#', attrs: { class: 'sidebar-separator' }
+							label: 'Single contract',
+							translations: { 'zh-CN': '单一合同' },
+							link: '#', attrs: { class: 'sidebar-separator' }
 						},
-						'cookbook/single-communication',
-						'cookbook/type-conversion',
-						'cookbook/data-structures',
-						'cookbook/algo',
-						'cookbook/time',
-						'cookbook/access',
-						'cookbook/random',
-						'cookbook/misc',
+						{ slug: 'cookbook/single-communication' },
+						{ slug: 'cookbook/type-conversion' },
+						{ slug: 'cookbook/data-structures' },
+						{ slug: 'cookbook/algo' },
+						{ slug: 'cookbook/time' },
+						{ slug: 'cookbook/access' },
+						{ slug: 'cookbook/random' },
+						{ slug: 'cookbook/misc' },
 						{
-						  label: 'Multiple contracts',
-						  translations: { 'zn-CN': '多重合同' },
-						  link: '#', attrs: { class: 'sidebar-separator' }
+							label: 'Multiple contracts',
+							translations: { 'zh-CN': '多重合同' },
+							link: '#', attrs: { class: 'sidebar-separator' }
 						},
-						'cookbook/multi-communication',
-						'cookbook/jettons',
-						'cookbook/nfts',
+						{ slug: 'cookbook/multi-communication' },
+						{ slug: 'cookbook/jettons' },
+						{ slug: 'cookbook/nfts' },
 						{
 							label: 'Decentralized EXchanges (DEXes)',
 							translations: {
@@ -215,8 +215,8 @@ export default defineConfig({
 						'zh-CN': '参考',
 					},
 					items: [
-						'ref',
-						'ref/spec',
+						{ slug: 'ref' },
+						{ slug: 'ref/spec' },
 						{
 							'label': 'Evolution',
 							translations: {
@@ -226,31 +226,31 @@ export default defineConfig({
 							autogenerate: { directory: 'ref/evolution' }
 						},
 						{
-						  label: 'Core library',
-						  translations: { 'zn-CN': '核心图书馆' },
-						  link: '#', attrs: { class: 'sidebar-separator' }
+							label: 'Core library',
+							translations: { 'zh-CN': '核心图书馆' },
+							link: '#', attrs: { class: 'sidebar-separator' }
 						},
-						'ref/core-base',
-						'ref/core-common',
-						'ref/core-comptime',
-						'ref/core-debug',
-						'ref/core-random',
-						'ref/core-math',
-						'ref/core-strings',
-						'ref/core-cells',
-						'ref/core-advanced',
+						{ slug: 'ref/core-base' },
+						{ slug: 'ref/core-common' },
+						{ slug: 'ref/core-comptime' },
+						{ slug: 'ref/core-debug' },
+						{ slug: 'ref/core-random' },
+						{ slug: 'ref/core-math' },
+						{ slug: 'ref/core-strings' },
+						{ slug: 'ref/core-cells' },
+						{ slug: 'ref/core-advanced' },
 						{
-						  label: 'Standard libraries',
-						  translations: { 'zn-CN': '标准图书馆' },
-						  link: '#', attrs: { class: 'sidebar-separator' }
+							label: 'Standard libraries',
+							translations: { 'zh-CN': '标准图书馆' },
+							link: '#', attrs: { class: 'sidebar-separator' }
 						},
-						'ref/standard-libraries',
-						'ref/stdlib-config',
-						'ref/stdlib-content',
-						'ref/stdlib-deploy',
-						'ref/stdlib-dns',
-						'ref/stdlib-ownable',
-						'ref/stdlib-stoppable',
+						{ slug: 'ref/standard-libraries' },
+						{ slug: 'ref/stdlib-config' },
+						{ slug: 'ref/stdlib-content' },
+						{ slug: 'ref/stdlib-deploy' },
+						{ slug: 'ref/stdlib-dns' },
+						{ slug: 'ref/stdlib-ownable' },
+						{ slug: 'ref/stdlib-stoppable' },
 					],
 				},
 				{
@@ -259,16 +259,16 @@ export default defineConfig({
 						'zh-CN': '生态系统',
 					},
 					items: [
-						'ecosystem',
+						{ slug: 'ecosystem' },
 						{
-						  label: 'Tools',
-						  translations: { 'zn-CN': '工具' },
-						  link: '#', attrs: { class: 'sidebar-separator' }
+							label: 'Tools',
+							translations: { 'zh-CN': '工具' },
+							link: '#', attrs: { class: 'sidebar-separator' }
 						},
-						'ecosystem/typescript',
-						'ecosystem/vscode',
-						'ecosystem/jetbrains',
-						'ecosystem/misti',
+						{ slug: 'ecosystem/typescript' },
+						{ slug: 'ecosystem/vscode' },
+						{ slug: 'ecosystem/jetbrains' },
+						{ slug: 'ecosystem/misti' },
 					],
 				},
 				{

--- a/docs/grammars/grammar-tact.json
+++ b/docs/grammars/grammar-tact.json
@@ -158,7 +158,13 @@
               "name": "keyword.operator.mapsto.tact"
             },
             {
-              "match": "\\b([0-9]*)\\b",
+              "comment": "Decimal integer WITH leading zero",
+              "match": "\\b(0[0-9]*)\\b",
+              "name": "constant.numeric.decimal.tact"
+            },
+            {
+              "comment": "Decimal integer WITHOUT leading zero",
+              "match": "\\b([1-9](?:_?[0-9])*)\\b",
               "name": "constant.numeric.decimal.tact"
             }
           ],

--- a/docs/inline-code-highlighting.js
+++ b/docs/inline-code-highlighting.js
@@ -9,8 +9,8 @@ import { toString } from 'hast-util-to-string';
 import {
   bundledLanguages,
   createHighlighter,
+  createWasmOnigEngine,
 } from 'shiki';
-import { createOnigurumaEngine } from 'shiki/engine/oniguruma';
 import fs from 'node:fs';
 
 // Import custom grammars
@@ -71,7 +71,7 @@ export default function rehypeInlineCodeHighlighting() {
       ],
       // TODO: Made the 'name' lowercase in the TextMate grammars
       langAlias: { fc: 'func' },
-      engine: await createOnigurumaEngine(import('shiki/wasm')),
+      engine: await createWasmOnigEngine(import('shiki/wasm')),
     });
 
     // Apply highlighting to each target node

--- a/docs/inline-code-highlighting.js
+++ b/docs/inline-code-highlighting.js
@@ -9,8 +9,8 @@ import { toString } from 'hast-util-to-string';
 import {
   bundledLanguages,
   createHighlighter,
-  createWasmOnigEngine,
 } from 'shiki';
+import { createOnigurumaEngine } from 'shiki/engine/oniguruma';
 import fs from 'node:fs';
 
 // Import custom grammars
@@ -71,7 +71,7 @@ export default function rehypeInlineCodeHighlighting() {
       ],
       // TODO: Made the 'name' lowercase in the TextMate grammars
       langAlias: { fc: 'func' },
-      engine: await createWasmOnigEngine(import('shiki/wasm')),
+      engine: await createOnigurumaEngine(import('shiki/wasm')),
     });
 
     // Apply highlighting to each target node

--- a/docs/src/content/docs/book/bounced.mdx
+++ b/docs/src/content/docs/book/bounced.mdx
@@ -1,5 +1,6 @@
 ---
 title: Bounced messages
+description: "When a contract sends a message with a flag bounce set to true, then if the message wasn't processed properly, it would bounce back to the sender"
 ---
 
 When a contract sends a message with a flag `bounce` set to `true{:tact}`, then if the message wasn't processed properly, it would bounce back to the sender. This is useful when you want to make sure that the message was processed properly and if not — revert the changes.

--- a/docs/src/content/docs/book/cells.mdx
+++ b/docs/src/content/docs/book/cells.mdx
@@ -1,5 +1,6 @@
 ---
 title: Cells, Builders and Slices
+description: "Cells, Builders and Slices are low-level primitives of TON Blockchain"
 ---
 
 [Cells](#cells), [Builders](#builders) and [Slices](#slices) are low-level [primitives][p] of TON Blockchain. The virtual machine of TON Blockchain, [TVM][tvm], uses cells to represent all data structures in persistent storage, and most in memory.

--- a/docs/src/content/docs/book/config.mdx
+++ b/docs/src/content/docs/book/config.mdx
@@ -1,10 +1,11 @@
 ---
 title: Configuration
+description: "The behavior of Tact compiler can be customized using its configuration file"
 ---
 
 The behavior of Tact compiler can be customized using its configuration file, `tact.config.json` — a JSON file that contains the list of settings according to the specific [schema](#schema).
 
-This page lists all of the configuration options as they're structured in the [schema](#schema). Look for table of contents on the right to easily navigate them.
+This page lists all the configuration options as they're structured in the [schema](#schema). Look for table of contents on the right to easily navigate them.
 
 :::note
 

--- a/docs/src/content/docs/book/constants.mdx
+++ b/docs/src/content/docs/book/constants.mdx
@@ -1,8 +1,9 @@
 ---
 title: Constants
+description: "Immutable values that cannot be changed through reassignment"
 ---
 
-Constants in Tact could be a little bit more advanced than in popular languages: they could be virtual and abstract. Smart contracts often need to implement multiple traits and sometimes you need to configure some of them in compile time. Constructors in traits are prohibited due to their unpredicted behavior. So, we have to use constants and fields instead to pass values to them. It is the job of a main contract to implement values and constants for all traits.
+Constants in Tact could be a little bit more advanced than in popular languages: they could be virtual and abstract. Smart contracts often need to implement multiple traits and sometimes you need to configure some of them in compile time. Constructors in traits are prohibited due to their unpredictable behavior. So, we have to use constants and fields instead to pass values to them. It is the job of a main contract to implement values and constants for all traits.
 
 ## Simple constant
 

--- a/docs/src/content/docs/book/contracts.mdx
+++ b/docs/src/content/docs/book/contracts.mdx
@@ -1,5 +1,6 @@
 ---
 title: Contracts
+description: "Contracts in Tact are similar to classes in popular object-oriented languages, except that their instances are deployed on the blockchain and they can't be passed around like Structs and Messages"
 ---
 
 Contracts in Tact are similar to classes in popular object-oriented languages, except that their instances are deployed on the blockchain and they can't be passed around like [Structs and Messages](/book/structs-and-messages).

--- a/docs/src/content/docs/book/cs/from-func.mdx
+++ b/docs/src/content/docs/book/cs/from-func.mdx
@@ -1,5 +1,6 @@
 ---
 title: Coming from FunC
+description: "A cheat sheet to quickly transition from FunC to Tact"
 sidebar:
   order: 1
 ---

--- a/docs/src/content/docs/book/cs/from-solidity.mdx
+++ b/docs/src/content/docs/book/cs/from-solidity.mdx
@@ -1,5 +1,6 @@
 ---
 title: Coming from Solidity
+description: "A cheat sheet to quickly transition from Solidity to Tact and from Ethereum to TON Blockchain"
 sidebar:
   order: 2
 ---

--- a/docs/src/content/docs/book/debug.mdx
+++ b/docs/src/content/docs/book/debug.mdx
@@ -1,5 +1,6 @@
 ---
 title: Debugging Tact contracts
+description: "Various ways to reveal problems or bugs in Tact code"
 ---
 
 import { LinkCard, CardGrid, Steps, Tabs, TabItem } from '@astrojs/starlight/components';

--- a/docs/src/content/docs/book/deploy.mdx
+++ b/docs/src/content/docs/book/deploy.mdx
@@ -1,5 +1,6 @@
 ---
 title: Deployment
+description: "Common ways to deploy Tact contracts to testnet or mainnet of TON Blockchain"
 ---
 
 Tact Deployer is a small library that integrates with [TON Verifier](https://verifier.ton.org) that allows you to deploy your contracts safely using your favorite wallet without needing to manage keys or deploy contracts manually. Tact Deployer also automatically verifies your contract's source code and you can be sure that your compiler is not compromised.

--- a/docs/src/content/docs/book/exit-codes.mdx
+++ b/docs/src/content/docs/book/exit-codes.mdx
@@ -1,5 +1,6 @@
 ---
-title: Exit Codes
+title: Exit codes
+description: "An exit code is a 32-bit signed integer, which indicates whether the compute or action phase of the transaction was successful, and if not — signals the code of the exception occurred"
 ---
 
 :::caution

--- a/docs/src/content/docs/book/expressions.mdx
+++ b/docs/src/content/docs/book/expressions.mdx
@@ -1,5 +1,6 @@
 ---
 title: Expressions
+description: "This page lists all the expressions in Tact"
 ---
 
 Every operator in Tact forms an expression, but there's much more to uncover as Tact offers a wide range of expressive options to choose from.

--- a/docs/src/content/docs/book/external.mdx
+++ b/docs/src/content/docs/book/external.mdx
@@ -1,6 +1,11 @@
 ---
 title: External Messages
+description: "External messages don't have a sender and can be sent by anyone from the offchain"
 ---
+
+:::caution
+  This page is under re-construction as per [#384](https://github.com/tact-lang/tact-docs/issues/384). All anchor links (`#`) may change in the future!
+:::
 
 :::caution
   External message support must be enabled explicitly in the project configuration.
@@ -26,13 +31,15 @@ External messages are not accepted automatically. You need to accept them manual
 10k gas is a very small limit, and Tact itself can consume a sizable amount of gas before it even reaches your code. You should always test the gas usage of your contracts and verify that everything is working as intended.
 
 :::tip[Hey there!]
+
   The 10k gas limit for external messages is based on the parameter we set by the
   validator for the whole blockchain of the `gas_limit` field. You can take
   the reference here:
-    - https://docs.ton.org/develop/smart-contracts/guidelines/accept#external-messages
-    - https://docs.ton.org/develop/howto/blockchain-configs#param-20-and-21
 
-  :::
+  - https://docs.ton.org/develop/smart-contracts/guidelines/accept#external-messages
+  - https://docs.ton.org/develop/howto/blockchain-configs#param-20-and-21
+
+:::
 
 ### Unbounded Gas Usage After Message Acceptance
 

--- a/docs/src/content/docs/book/func.mdx
+++ b/docs/src/content/docs/book/func.mdx
@@ -1,5 +1,6 @@
 ---
 title: Compatibility with FunC
+description: "Tact compiles to FunC and maps all its entities directly to various FunC and TL-B types."
 ---
 
 Tact itself compiles to FunC and maps all its entities directly to various FunC and TL-B types.

--- a/docs/src/content/docs/book/functions.mdx
+++ b/docs/src/content/docs/book/functions.mdx
@@ -1,5 +1,6 @@
 ---
-title: Functions and their types
+title: Functions
+description: "Global, asm, native functions, as well as receivers, getters and storage functions, plus the many attributes that allow for great flexibility and expressivity of Tact language"
 ---
 
 Functions in Tact could be defined in different ways:

--- a/docs/src/content/docs/book/import.mdx
+++ b/docs/src/content/docs/book/import.mdx
@@ -1,5 +1,6 @@
 ---
 title: Importing code
+description: "Tact allows you to import Tact and FunC code, and has a versatile set of standard libraries"
 ---
 
 Tact allows you to import Tact and [FunC](https://docs.ton.org/develop/func/overview) code — any given `.tact` or `.fc`/`.func` file can be imported into your project using the `import{:tact}` keyword.

--- a/docs/src/content/docs/book/index.mdx
+++ b/docs/src/content/docs/book/index.mdx
@@ -1,5 +1,6 @@
 ---
 title: Book overview
+description: "Book section — an introductory book about the Tact language"
 ---
 
 import { LinkCard, CardGrid, Steps } from '@astrojs/starlight/components';

--- a/docs/src/content/docs/book/integers.mdx
+++ b/docs/src/content/docs/book/integers.mdx
@@ -1,5 +1,6 @@
 ---
 title: Integers
+description: "Arithmetic in smart contracts on TON is always done with integers and never with floats"
 ---
 
 Arithmetic in smart contracts on TON is always done with integers and never with floating-point numbers since the floats are [unpredictable](https://learn.microsoft.com/en-us/cpp/build/why-floating-point-numbers-may-lose-precision). Therefore, the big accent goes on integers and their handling.

--- a/docs/src/content/docs/book/lifecycle.mdx
+++ b/docs/src/content/docs/book/lifecycle.mdx
@@ -1,5 +1,6 @@
 ---
 title: Message Lifecycle
+description: "Every transaction on TON Blockchain has multiple stages, where compute and action ones are the most important for message lifecycle"
 ---
 
 There are several stages of message processing by a contract, there are more of them, but we would focus on the most important ones:

--- a/docs/src/content/docs/book/maps.mdx
+++ b/docs/src/content/docs/book/maps.mdx
@@ -1,5 +1,6 @@
 ---
 title: Maps
+description: "The composite type map is used as a way to associate keys with corresponding values of various types"
 ---
 
 The [composite type](/book/types#composite-types) `map<K, V>{:tact}` is used as a way to associate keys of type `K{:tact}` with corresponding values of type `V{:tact}`.

--- a/docs/src/content/docs/book/masterchain.mdx
+++ b/docs/src/content/docs/book/masterchain.mdx
@@ -1,5 +1,6 @@
 ---
 title: Masterchain
+description: "In TON Blockchain, a special chain called masterchain is used to synchronize message routing and transaction execution, so that nodes in the network can fix a particular point in a multi-chain state and reach a consensus about that state"
 ---
 
 :::caution

--- a/docs/src/content/docs/book/message-mode.mdx
+++ b/docs/src/content/docs/book/message-mode.mdx
@@ -1,5 +1,6 @@
 ---
 title: Message mode
+description: "Messages are sent with the mode param of a struct SendParameters. It's an Int value, which is combined from base modes and optional flags, which are also Int values"
 ---
 
 As it was previously mentioned, messages are sent with the `mode` param of a struct `SendParameters{:tact}`. It's an [`Int{:tact}`][int] value, which is combined from base modes and optional flags, which are also [`Int{:tact}`][int] values.

--- a/docs/src/content/docs/book/operators.mdx
+++ b/docs/src/content/docs/book/operators.mdx
@@ -1,5 +1,6 @@
 ---
 title: Operators
+description: "This page lists all the operators in Tact in decreasing order of their precedence, with examples of usage"
 ---
 
 Almost every contract operates on data: transforms some values into another. Scope may vary, but operators lay in core of such modifications.

--- a/docs/src/content/docs/book/programmatic.mdx
+++ b/docs/src/content/docs/book/programmatic.mdx
@@ -1,5 +1,6 @@
 ---
 title: Programmatic API
+description: "Ways to use the Tact compiler as a library in Node.js and browser projects"
 ---
 
 You can invoke the Tact compiler from your code in node and browser environments.

--- a/docs/src/content/docs/book/receive.mdx
+++ b/docs/src/content/docs/book/receive.mdx
@@ -1,8 +1,9 @@
 ---
 title: Receive messages
+description: "The most common type of messages is the internal message - a message sent from one contract to another"
 ---
 
-TON is a distributed blockchain which means that communication between contracts is done by sending and receiving messages. The most common type of message is the internal message - a message sent from one contract (or a wallet) to another.
+TON is a distributed blockchain which means that communication between contracts is done by sending and receiving messages. The most common type of messages is the internal message - a message sent from one contract (or a wallet) to another.
 
 ## Receive internal messages
 

--- a/docs/src/content/docs/book/send.mdx
+++ b/docs/src/content/docs/book/send.mdx
@@ -1,5 +1,6 @@
 ---
 title: Sending messages
+description: "TON Blockchain is message-based — to communicate with other contracts and to deploy new ones you need to send messages."
 ---
 
 TON blockchain is message-based — to communicate with other contracts and to deploy new ones you need to send messages.

--- a/docs/src/content/docs/book/statements.mdx
+++ b/docs/src/content/docs/book/statements.mdx
@@ -1,5 +1,6 @@
 ---
 title: Statements
+description: "This page lists all the statements in Tact, which can appear anywhere in the function bodies"
 ---
 
 The following statements can appear anywhere in the [function](/book/functions) body.

--- a/docs/src/content/docs/book/structs-and-messages.mdx
+++ b/docs/src/content/docs/book/structs-and-messages.mdx
@@ -1,5 +1,6 @@
 ---
 title: Structs and Messages
+description: "Structs can define complex data types that contain multiple fields of different types, while Messages also have a 32-bit header and are convenient to receive and sent message bodies on TON Blockchain"
 ---
 
 Tact supports a number of [primitive data types](/book/types#primitive-types) that are tailored for smart contract use. However, using individual means of storage often becomes cumbersome, so there are [Structs](#structs) and [Messages](#messages) which allow combining types together.

--- a/docs/src/content/docs/book/types.mdx
+++ b/docs/src/content/docs/book/types.mdx
@@ -1,5 +1,6 @@
 ---
 title: Type system overview
+description: "Every variable, item, and value in Tact programs has a type"
 ---
 
 Every variable, item, and value in Tact programs has a type. They can be:

--- a/docs/src/content/docs/book/upgrades.mdx
+++ b/docs/src/content/docs/book/upgrades.mdx
@@ -1,5 +1,6 @@
 ---
 title: Contracts upgrades
+description: "Tact currently does not allow contract upgrades, as Tact contracts are more complicated than those in FunC"
 ---
 
-Tact currently doesn't allow contract upgrades since Tact contracts have a more convoluted nature than the ones in FunC. It is theoretically possible, but the required tools are not here.
+Tact currently does not allow contract upgrades, as Tact contracts are more complicated than those in FunC. It is theoretically possible, but the required tools are not here.

--- a/docs/src/content/docs/cookbook/access.mdx
+++ b/docs/src/content/docs/cookbook/access.mdx
@@ -1,5 +1,6 @@
 ---
 title: Access control
+description: "This page lists common examples of working with privileges, ownership and access control"
 ---
 
 This page lists common examples of working with privileges, ownership and access control.

--- a/docs/src/content/docs/cookbook/algo.mdx
+++ b/docs/src/content/docs/cookbook/algo.mdx
@@ -1,5 +1,6 @@
 ---
 title: Algorithms
+description: "Common algorithm implementations on Tact, generally geared towards contract development"
 ---
 
 Algorithm is a finite sequence of rigorous instructions, typically used to solve a class of specific problems or to perform a computation.

--- a/docs/src/content/docs/cookbook/data-structures.mdx
+++ b/docs/src/content/docs/cookbook/data-structures.mdx
@@ -1,5 +1,6 @@
 ---
 title: Data structures
+description: "This page lists a handy collection of data structures implemented in Tact for your day-to-day needs and beyond"
 ---
 
 Data structures are data organization, management, and storage formats that are usually chosen for efficient access to data. More precisely, a data structure is a collection of data values, the relationships among them, and the functions or operations that can be applied to the data.

--- a/docs/src/content/docs/cookbook/dexes/dedust.mdx
+++ b/docs/src/content/docs/cookbook/dexes/dedust.mdx
@@ -1,5 +1,6 @@
 ---
 title: DeDust.io
+description: "This page list examples of working with DeDust, a decentralized exchange and automated market maker built natively on TON Blockchain and DeDust Protocol"
 sidebar:
   order: 1
 ---

--- a/docs/src/content/docs/cookbook/dexes/stonfi.mdx
+++ b/docs/src/content/docs/cookbook/dexes/stonfi.mdx
@@ -1,5 +1,6 @@
 ---
 title: STON.fi
+description: "This page list examples of working with STON.fi, a decentralized automated market maker built on TON Blockchain"
 sidebar:
   order: 2
 ---

--- a/docs/src/content/docs/cookbook/index.mdx
+++ b/docs/src/content/docs/cookbook/index.mdx
@@ -1,5 +1,6 @@
 ---
 title: Cookbook overview
+description: "Cookbook section is focused on everyday tasks that every Tact developer resolves during the development of smart contracts"
 ---
 
 import { LinkCard, Card, CardGrid, Steps } from '@astrojs/starlight/components';

--- a/docs/src/content/docs/cookbook/jettons.mdx
+++ b/docs/src/content/docs/cookbook/jettons.mdx
@@ -1,5 +1,6 @@
 ---
 title: Fungible Tokens (Jettons)
+description: "Common examples of working with Fungible Tokens (Jettons) in Tact"
 ---
 
 This page lists common examples of working with [jettons](https://docs.ton.org/develop/dapps/asset-processing/jettons).

--- a/docs/src/content/docs/cookbook/misc.mdx
+++ b/docs/src/content/docs/cookbook/misc.mdx
@@ -1,5 +1,6 @@
 ---
 title: Miscellaneous
+description: "Various niche examples which don't yet have a dedicated page, but are useful and interesting nonetheless"
 ---
 
 Various niche examples which don't yet have a dedicated page, but are useful and interesting nonetheless.

--- a/docs/src/content/docs/cookbook/multi-communication.mdx
+++ b/docs/src/content/docs/cookbook/multi-communication.mdx
@@ -1,5 +1,6 @@
 ---
 title: Multi-contract communication
+description: "Common examples of communication between many deployed contracts on blockchain"
 ---
 
 :::danger[Not implemented]

--- a/docs/src/content/docs/cookbook/nfts.mdx
+++ b/docs/src/content/docs/cookbook/nfts.mdx
@@ -1,5 +1,6 @@
 ---
 title: Non-Fungible Tokens (NFTs)
+description: "Common examples of working with Non-Fungible Tokens (NFTs) in Tact"
 ---
 
 :::danger[Not implemented]

--- a/docs/src/content/docs/cookbook/random.mdx
+++ b/docs/src/content/docs/cookbook/random.mdx
@@ -1,5 +1,6 @@
 ---
 title: Randomness
+description: "Common examples of working with random numbers, uncertainty and randomness in general"
 ---
 
 This page lists examples of working with random numbers, uncertainty and randomness in general.

--- a/docs/src/content/docs/cookbook/single-communication.mdx
+++ b/docs/src/content/docs/cookbook/single-communication.mdx
@@ -1,5 +1,6 @@
 ---
 title: Single-contract Communication
+description: "Common examples of communication of a single deployed contract with other contracts on blockchain"
 ---
 
 This page lists examples of communication of a single deployed contract with other contracts on blockchain.

--- a/docs/src/content/docs/cookbook/time.mdx
+++ b/docs/src/content/docs/cookbook/time.mdx
@@ -1,5 +1,6 @@
 ---
 title: Time and date
+description: "Common examples of working with time and date in Tact"
 ---
 
 ## How to get the current time

--- a/docs/src/content/docs/cookbook/type-conversion.mdx
+++ b/docs/src/content/docs/cookbook/type-conversion.mdx
@@ -1,5 +1,6 @@
 ---
 title: Type conversion
+description: "Common examples of converting between primitive types and obtaining them from composite types"
 ---
 
 This page shows examples of converting between [primitive types][p] and obtaining them from [composite types](/book/types#composite-types).

--- a/docs/src/content/docs/ecosystem/index.mdx
+++ b/docs/src/content/docs/ecosystem/index.mdx
@@ -1,10 +1,11 @@
 ---
 title: Ecosystem overview
+description: "Ecosystem section — a bird-eye overview of Tact ecosystem, tools and ways you can start contributing"
 ---
 
 import { CardGrid, LinkCard, Steps } from '@astrojs/starlight/components';
 
-Welcome to the **Ecosystem** section — a bird-eye overview of Tact ecosystem, tools and ways you can start contributing to those!
+Welcome to the **Ecosystem** section — a bird-eye overview of Tact ecosystem, tools and ways you can start contributing to those and beyond!
 
 Here are its main contents:
 

--- a/docs/src/content/docs/ecosystem/jetbrains.mdx
+++ b/docs/src/content/docs/ecosystem/jetbrains.mdx
@@ -1,5 +1,6 @@
 ---
 title: TON development plugin for JetBrains IDEs
+description: "Supports highlighting Tact's syntax in JetBrains IDEs versioned **2023.** and later, and also provides rich support of FunC and Fift languages of TON Blockchain, as well as TL-B schemas"
 ---
 
 Supports highlighting Tact's syntax in JetBrains IDEs versioned **2023.** and later. Note, that besides support for Tact, it also includes a rich support of FunC and Fift languages of TON Blockchain, as well as TL-B schemas.

--- a/docs/src/content/docs/ecosystem/misti.mdx
+++ b/docs/src/content/docs/ecosystem/misti.mdx
@@ -1,5 +1,6 @@
 ---
 title: Misti static analyzer
+description: "Static analysis of Tact contracts, custom detectors and CI/CD integration"
 ---
 
 [Misti](https://nowarp.github.io/tools/misti/) is a static program analysis tool that supports Tact.

--- a/docs/src/content/docs/ecosystem/typescript.mdx
+++ b/docs/src/content/docs/ecosystem/typescript.mdx
@@ -1,5 +1,6 @@
 ---
 title: TypeScript libraries
+description: "The compiler of Tact automatically generates wrapper code for use with @ton/ton and @ton/core libraries"
 ---
 
 The Tact language has built-in support for the [@ton/ton](https://github.com/ton-org/ton) and [@ton/core](https://github.com/ton-org/ton-core) TypeScript libraries. The compiler automatically generates code for these libraries, so you can use [@tact-lang/emulator](https://github.com/tact-lang/tact-emulator) or [@ton/sandbox](https://github.com/ton-org/sandbox), that work on top of them.

--- a/docs/src/content/docs/ecosystem/vscode.mdx
+++ b/docs/src/content/docs/ecosystem/vscode.mdx
@@ -1,5 +1,6 @@
 ---
 title: VS Code extension
+description: "Extensive support for Tact language in the Visual Studio Code: syntax highlighting, error diagnostics, snippets, hover info and more"
 ---
 
 Provides extensive support for Tact language in the Visual Studio Code:

--- a/docs/src/content/docs/index.mdx
+++ b/docs/src/content/docs/index.mdx
@@ -32,8 +32,6 @@ hero:
 
 import { LinkCard, CardGrid, Tabs, TabItem, Steps } from '@astrojs/starlight/components';
 
-      {/* icon: right-arrow */}
-
 ## 🚀 Let's start! {#start}
 
 <p>ㅤ</p>

--- a/docs/src/content/docs/ref/core-advanced.mdx
+++ b/docs/src/content/docs/ref/core-advanced.mdx
@@ -1,5 +1,6 @@
 ---
 title: Advanced
+description: "Advanced, niche or dangerous functions from the Core library of Tact"
 ---
 
 Various niche, dangerous or unstable features which can produce unexpected results and are meant to be used by the more experienced users.

--- a/docs/src/content/docs/ref/core-base.mdx
+++ b/docs/src/content/docs/ref/core-base.mdx
@@ -1,5 +1,6 @@
 ---
 title: Base trait
+description: "Every contract and trait in Tact implicitly inherits the BaseTrait trait"
 ---
 
 Every [contract](/book/contracts) and [trait](/book/types#traits) in Tact implicitly [inherits](/book/contracts#traits) the `BaseTrait{:tact}` trait, which contains a number of the most useful [internal functions](/book/contracts#internal-functions) for any kind of contract, and a constant `self.storageReserve{:tact}` aimed at advanced users of Tact.

--- a/docs/src/content/docs/ref/core-cells.mdx
+++ b/docs/src/content/docs/ref/core-cells.mdx
@@ -1,5 +1,6 @@
 ---
 title: Cells, Builders and Slices
+description: "Various Cell, Builder and Slice functions from the Core library of Tact"
 ---
 
 [`Cell{:tact}`][cell] is a low-level [primitive][p] that represents data in TON Blockchain. Cells consist of $1023$ bits of data with up to $4$ references to another cells. They are read-only and immutable, and cannot have cyclic references.

--- a/docs/src/content/docs/ref/core-common.mdx
+++ b/docs/src/content/docs/ref/core-common.mdx
@@ -1,5 +1,6 @@
 ---
 title: Common
+description: "Commonly used global static functions from the Core library of Tact"
 ---
 
 List of the most commonly used built-in [global static functions](/book/functions#global-static-functions).

--- a/docs/src/content/docs/ref/core-comptime.mdx
+++ b/docs/src/content/docs/ref/core-comptime.mdx
@@ -1,5 +1,6 @@
 ---
 title: Compile-time
+description: "Various compile-time global functions from the Core library of Tact"
 ---
 
 This page lists all the built-in [global static functions](/book/functions#global-static-functions), which are evaluated at the time of building the Tact project and cannot work with non-constant, run-time data. These functions are commonly referred to as "compile-time functions".

--- a/docs/src/content/docs/ref/core-debug.mdx
+++ b/docs/src/content/docs/ref/core-debug.mdx
@@ -1,5 +1,6 @@
 ---
 title: Debug
+description: "Various debugging functions from the Core library of Tact"
 ---
 
 List of functions commonly used for debugging smart contracts in Tact.

--- a/docs/src/content/docs/ref/core-math.mdx
+++ b/docs/src/content/docs/ref/core-math.mdx
@@ -1,5 +1,6 @@
 ---
 title: Math
+description: "Various math helper functions from the Core library of Tact"
 ---
 
 Various math helper functions.

--- a/docs/src/content/docs/ref/core-random.mdx
+++ b/docs/src/content/docs/ref/core-random.mdx
@@ -1,5 +1,6 @@
 ---
 title: Random number generation
+description: "Various random number generation functions from the Core library of Tact"
 ---
 
 Random number generation for Tact smart contracts.

--- a/docs/src/content/docs/ref/core-strings.mdx
+++ b/docs/src/content/docs/ref/core-strings.mdx
@@ -1,5 +1,6 @@
 ---
 title: Strings and StringBuilders
+description: "Various String and StringBuilder functions from the Core library of Tact"
 ---
 
 Strings are immutable sequences of characters, which means that once a [`String{:tact}`][p] is created, it cannot be changed. Strings are useful to store text, and so they can be converted to [`Cell{:tact}`][cell] type to be used as message bodies.

--- a/docs/src/content/docs/ref/evolution/otp-001.mdx
+++ b/docs/src/content/docs/ref/evolution/otp-001.mdx
@@ -1,5 +1,6 @@
 ---
 title: "OTP-001: Supported Interfaces"
+description: "This proposal recommends a way to introspect smart contracts and find out what interfaces they support"
 sidebar:
   order: 1
 ---

--- a/docs/src/content/docs/ref/evolution/otp-002.mdx
+++ b/docs/src/content/docs/ref/evolution/otp-002.mdx
@@ -1,5 +1,6 @@
 ---
 title: "OTP-002: Contract ABI"
+description: "This proposal defines an ABI to communicate with deployed smart contracts"
 sidebar:
   order: 2
 ---

--- a/docs/src/content/docs/ref/evolution/otp-003.mdx
+++ b/docs/src/content/docs/ref/evolution/otp-003.mdx
@@ -1,5 +1,6 @@
 ---
 title: "OTP-003: Self-ABI reporting"
+description: "This proposal defines how to report the contract's ABI using the IPFS link"
 sidebar:
   order: 3
 ---

--- a/docs/src/content/docs/ref/evolution/otp-004.mdx
+++ b/docs/src/content/docs/ref/evolution/otp-004.mdx
@@ -1,5 +1,6 @@
 ---
 title: "OTP-004: Auto Encoder"
+description: "This proposal defines a way to automatically build a serialization layout for a given structure"
 sidebar:
   order: 4
 ---

--- a/docs/src/content/docs/ref/evolution/otp-005.mdx
+++ b/docs/src/content/docs/ref/evolution/otp-005.mdx
@@ -1,5 +1,6 @@
 ---
 title: "OTP-005: Argument-addressable contracts"
+description: "This proposal defines a way to address contracts by their arguments instead of their initial data"
 sidebar:
   order: 5
 ---

--- a/docs/src/content/docs/ref/evolution/otp-006.mdx
+++ b/docs/src/content/docs/ref/evolution/otp-006.mdx
@@ -1,5 +1,6 @@
 ---
 title: "OTP-006: Contract Package"
+description: "This proposal defines a way to package compile contracts, their dependencies, and all related metadata into a single file"
 sidebar:
   order: 6
 ---

--- a/docs/src/content/docs/ref/evolution/overview.mdx
+++ b/docs/src/content/docs/ref/evolution/overview.mdx
@@ -1,5 +1,6 @@
 ---
 title: Evolution overview
+description: "Evolution sub-section contains all standards that are defined by the Tact Foundation and are used in the evolution process of the Tact and TON ecosystem"
 sidebar:
   label: Overview
   order: 0

--- a/docs/src/content/docs/ref/index.mdx
+++ b/docs/src/content/docs/ref/index.mdx
@@ -1,5 +1,6 @@
 ---
 title: Reference overview
+description: "Reference section — a place for discovering the Tact's standard library, grammar specification and evolution process"
 ---
 
 import { LinkCard, CardGrid, Steps } from '@astrojs/starlight/components';

--- a/docs/src/content/docs/ref/spec.mdx
+++ b/docs/src/content/docs/ref/spec.mdx
@@ -1,5 +1,6 @@
 ---
 title: Tact Specification
+description: "Tact grammar used in its compiler is written in an Ohm language, which is based on parsing expression grammars (PEGs), which are a formal way of describing syntax, similar to regular expressions and context-free grammars."
 pagefind: false  # hide the page from the search index
 ---
 

--- a/docs/src/content/docs/ref/standard-libraries.mdx
+++ b/docs/src/content/docs/ref/standard-libraries.mdx
@@ -1,5 +1,6 @@
 ---
 title: Standard libraries overview
+description: "Some libraries come bundled with Tact compiler, but aren't automatically included to your project until explicitly made to"
 ---
 
 Some libraries (also referred to as standard libraries or stdlibs) come bundled with Tact compiler, but aren't automatically included to your project until explicitly made to.

--- a/docs/src/content/docs/ref/stdlib-config.mdx
+++ b/docs/src/content/docs/ref/stdlib-config.mdx
@@ -1,5 +1,6 @@
 ---
 title: "@stdlib/config"
+description: "Provides functions for config and elector Address retrieval"
 ---
 
 Provides functions for config and elector Address retrieval.

--- a/docs/src/content/docs/ref/stdlib-content.mdx
+++ b/docs/src/content/docs/ref/stdlib-content.mdx
@@ -1,5 +1,6 @@
 ---
 title: "@stdlib/content"
+description: "Provides a function for encoding an off-chain link from a String to a Cell"
 ---
 
 Provides a function for encoding an off-chain link from a [`String{:tact}`][p] to a [`Cell{:tact}`][cell].

--- a/docs/src/content/docs/ref/stdlib-deploy.mdx
+++ b/docs/src/content/docs/ref/stdlib-deploy.mdx
@@ -1,5 +1,6 @@
 ---
 title: "@stdlib/deploy"
+description: "Provides unified mechanisms for deployments"
 ---
 
 Provides unified mechanisms for deployments.

--- a/docs/src/content/docs/ref/stdlib-dns.mdx
+++ b/docs/src/content/docs/ref/stdlib-dns.mdx
@@ -1,5 +1,6 @@
 ---
 title: "@stdlib/dns"
+description: "Provides means for resolution of DNS names on TON"
 ---
 
 Provides means for resolution of [DNS](https://docs.ton.org/participate/web3/dns) names.

--- a/docs/src/content/docs/ref/stdlib-ownable.mdx
+++ b/docs/src/content/docs/ref/stdlib-ownable.mdx
@@ -1,8 +1,9 @@
 ---
 title: "@stdlib/ownable"
+description: "Provides traits for ownable contracts, which are commonly required by other traits"
 ---
 
-Provides [traits](/book/types#composite-types) for ownable contracts. This is most commonly used trait that is required by most other traits.
+Provides [traits](/book/types#composite-types) for ownable contracts. These traits are commonly required by other traits.
 
 To use this library, import `@stdlib/ownable`:
 

--- a/docs/src/content/docs/ref/stdlib-stoppable.mdx
+++ b/docs/src/content/docs/ref/stdlib-stoppable.mdx
@@ -1,5 +1,6 @@
 ---
 title: "@stdlib/stoppable"
+description: "Provides traits that allow to stop a contract, which are useful for emergency or maintenance modes"
 ---
 
 Provides [traits](/book/types#composite-types) that allow to stop a [contract](/book/contracts). Useful for emergency or maintenance modes. Requires an [`Ownable{:tact}`](/ref/stdlib-ownable#ownable) trait from [`@stdlib/ownable`](/ref/stdlib-ownable). This trait just manages a single flag `stopped` in the contract and handling stopped state have to be done in the contract itself.

--- a/docs/src/starlight.custom.css
+++ b/docs/src/starlight.custom.css
@@ -79,7 +79,7 @@ h4:hover .autolink-header {
 /* # */
 
 /* Disable bold fonts on nested group labels */
-ul ul div.group-label > span.large {
+ul ul div.group-label>span.large {
 	font-size: var(--sl-text-sm);
 	font-weight: inherit;
 	color: inherit;
@@ -87,11 +87,13 @@ ul ul div.group-label > span.large {
 
 /* Add a sidebar separator */
 .sidebar-separator {
-  margin-top: 1rem;
-  font-weight: 600;
-  pointer-events: none;
+	margin-top: 1rem;
+	font-weight: 600;
+	pointer-events: none;
 }
 
-/* CSS classes to modify / target: */
-/* .sidebar-content .group-label */
-/* */
+/* Prevent work breaks in inline code items in tables */
+td>code,
+td>a>code {
+	white-space: nowrap;
+}


### PR DESCRIPTION
1. Fix layout of tables, preventing the word breaks in inline `<code>` elements
2. Apply the small patch from tact-sublime, fixing a minor issue with the highlighting
3. Fix Chinese translations in sidebar separator items (`zn-CN` -> `zh-CN`)
4. Add `description` property to the frontmatter of the each page for better SEO

<!--
IMPORTANT:
If your PR doesn't close a particular issue, please, create the issue first and describe the whole context: what you're adding/changing and why you're doing so. And only then open the Pull Request, which would close that issue!
-->

## Issue

Closes #895.

## Checklist

- [x] I have updated CHANGELOG.md
- [x] I have run the linter, formatter and spellchecker
- [x] I did not do unrelated and/or undiscussed refactorings
