### PR TITLE
fix(wrappers): non-null optional struct fields after null ones

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Collisions in getter method ids are now handled and reported properly: PR [#875](https://github.com/tact-lang/tact/pull/875)
 - Docs: layout of tables, syntax highlighting, Chinese translations of sidebar separators: PR [#916](https://github.com/tact-lang/tact/pull/916)
+- Non-null struct fields after null ones are treated correctly in Sandbox tests after updating `@ton/core` to 0.59.0: PR [#933](https://github.com/tact-lang/tact/pull/933)
 
 ### Release contributors
 

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
   },
   "dependencies": {
     "@tact-lang/opcode": "^0.0.16",
-    "@ton/core": "0.58.1",
+    "@ton/core": "0.59.0",
     "@ton/crypto": "^3.2.0",
     "blockstore-core": "1.0.5",
     "change-case": "^4.1.2",

--- a/src/test/e2e-emulated/contracts/structs.tact
+++ b/src/test/e2e-emulated/contracts/structs.tact
@@ -240,6 +240,11 @@ struct Dict {
     m: map<Int as uint8, Int as coins>;
 }
 
+struct OptionalFields {
+    nickname: String?;
+    avatar: String?;
+}
+
 contract StructsTester {
     s1: S = S {a: false, b: 21 + 21};
     s2: S;
@@ -920,5 +925,12 @@ contract StructsTester {
 
     get fun uintFieldsFromCell(src: Cell): UintFields {
         return UintFields.fromCell(src);
+    }
+
+    get fun optionalFields(): OptionalFields {
+        return OptionalFields {
+            nickname: null,
+            avatar: "non-null string",
+        }
     }
 }

--- a/src/test/e2e-emulated/structs.spec.ts
+++ b/src/test/e2e-emulated/structs.spec.ts
@@ -6,6 +6,7 @@ import {
     MyStruct1,
     MyStruct2,
     MyStruct3,
+    OptionalFields,
     StructsTester,
     UintFields,
     loadMyMessage1,
@@ -402,5 +403,14 @@ describe("structs", () => {
             to: treasure.address,
             body: beginCell().storeDict(m).endCell(),
         });
+
+        const optionalFields: OptionalFields = {
+            $$type: "OptionalFields",
+            nickname: null,
+            avatar: "non-null string",
+        };
+        expect(
+            await contract.getOptionalFields(),
+        ).toMatchObject<OptionalFields>(optionalFields);
     });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -1291,10 +1291,10 @@
   resolved "https://registry.npmjs.org/@tact-lang/ton-jest/-/ton-jest-0.0.4.tgz"
   integrity sha512-FWjfiNvhMlE44ZLLL7tgmHbrszMTPMttmYiaTekf1vwFXV3uAOawM8xM9NldYaCVs9eh8840PjgISdMMUTCSCw==
 
-"@ton/core@0.58.1":
-  version "0.58.1"
-  resolved "https://registry.npmjs.org/@ton/core/-/core-0.58.1.tgz#f6f2ecef6a7149bcd23825bfbb454f116d54363f"
-  integrity sha512-zydh42iT6E3U3Ky/DhTFqJMN/ycKKzbsHASY257Qr2sZn97G/MOcHFizPfMnbJJgx0H9iHX6mdyMvp1IKBVAFA==
+"@ton/core@0.59.0":
+  version "0.59.0"
+  resolved "https://registry.npmjs.org/@ton/core/-/core-0.59.0.tgz#58da9fcaa58e5a0c705b63baf1e86cab6e196689"
+  integrity sha512-LSIkGst7BoY7fMWshejzcH0UJnoW21JGlRrW0ch+6A7Xb/7EuekxgdKym7fHxcry6OIf6FoeFg97lJ960N/Ghg==
   dependencies:
     symbol.inspect "1.0.1"
 


### PR DESCRIPTION
## Issue

Closes #918.

This was fixed in the `@ton-core` dependency, so updating it here and adding a test.

## Checklist

- [x] I have updated CHANGELOG.md
- [x] I have added tests to demonstrate the contribution is correctly implemented: this usually includes both positive and negative tests, showing the happy path(s) and featuring intentionally broken cases
- [x] I have run all the tests locally and no test failure was reported
- [x] I have run the linter, formatter and spellchecker
- [x] I did not do unrelated and/or undiscussed refactorings
