### PR TITLE
fix(docs): prevent inline code snippets from changing background color

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Collisions in getter method ids are now handled and reported properly: PR [#875](https://github.com/tact-lang/tact/pull/875)
 - Docs: layout of tables, syntax highlighting, Chinese translations of sidebar separators: PR [#916](https://github.com/tact-lang/tact/pull/916)
 - Non-null struct fields after null ones are treated correctly in Sandbox tests after updating `@ton/core` to 0.59.0: PR [#933](https://github.com/tact-lang/tact/pull/933)
-- Prevent inline code snippets from changing their background color: PR [#932](https://github.com/tact-lang/tact/pull/932)
+- Prevent inline code snippets from changing their background color: PR [#935](https://github.com/tact-lang/tact/pull/935)
 
 ### Release contributors
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Collisions in getter method ids are now handled and reported properly: PR [#875](https://github.com/tact-lang/tact/pull/875)
 - Docs: layout of tables, syntax highlighting, Chinese translations of sidebar separators: PR [#916](https://github.com/tact-lang/tact/pull/916)
 - Non-null struct fields after null ones are treated correctly in Sandbox tests after updating `@ton/core` to 0.59.0: PR [#933](https://github.com/tact-lang/tact/pull/933)
+- Prevent inline code snippets from changing their background color: PR [#932](https://github.com/tact-lang/tact/pull/932)
 
 ### Release contributors
 

--- a/docs/src/starlight.custom.css
+++ b/docs/src/starlight.custom.css
@@ -97,3 +97,8 @@ td>code,
 td>a>code {
 	white-space: nowrap;
 }
+
+/* Prevent inline code snippets from changing background color */
+code:not(pre *) {
+	background-color: var(--sl-color-bg-inline-code) !important;
+}


### PR DESCRIPTION
Especially helpful for visibility inside colorful asides (`:::note`, etc.) in the light theme

<!--
IMPORTANT:
If your PR doesn't close a particular issue, please, create the issue first and describe the whole context: what you're adding/changing and why you're doing so. And only then open the Pull Request, which would close that issue!
-->

## Issue

Closes tact-lang/tact-docs#406.

## Checklist

- [x] I have updated CHANGELOG.md
- [x] I have run the linter, formatter and spellchecker
- [x] I did not do unrelated and/or undiscussed refactorings
