### PR TITLE
fix: return AST import nodes from `parseImports` instead of strings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Destructuring of structs and messages: PR [#856](https://github.com/tact-lang/tact/pull/856)
 
 ### Changed
-
+- Adapted resolveImports to handle AstImport objects from parseImports: PR [#966](https://github.com/tact-lang/tact/pull/966)
 - Optional types for `self` argument in `extends mutates` functions are now allowed: PR [#854](https://github.com/tact-lang/tact/pull/854)
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Destructuring of structs and messages: PR [#856](https://github.com/tact-lang/tact/pull/856)
 
 ### Changed
+
 - Adapted resolveImports to handle AstImport objects from parseImports: PR [#966](https://github.com/tact-lang/tact/pull/966)
 - Optional types for `self` argument in `extends mutates` functions are now allowed: PR [#854](https://github.com/tact-lang/tact/pull/854)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Adapted resolveImports to handle AstImport objects from parseImports: PR [#966](https://github.com/tact-lang/tact/pull/966)
+- The `parseImports` function now returns AST import nodes instead of raw strings: PR [#966](https://github.com/tact-lang/tact/pull/966)
 - Optional types for `self` argument in `extends mutates` functions are now allowed: PR [#854](https://github.com/tact-lang/tact/pull/854)
 
 ### Fixed

--- a/src/grammar/grammar.ts
+++ b/src/grammar/grammar.ts
@@ -1509,7 +1509,7 @@ export function parseImports(
     src: string,
     path: string,
     origin: ItemOrigin,
-): string[] {
+): AstImport[] {
     return inFile(path, () => {
         const matchResult = tactGrammar.match(src, "JustImports");
         if (matchResult.failed()) {
@@ -1517,9 +1517,7 @@ export function parseImports(
         }
         ctx = { origin };
         try {
-            const imports: AstImport[] =
-                semantics(matchResult).astOfJustImports();
-            return imports.map((imp) => imp.path.value);
+            return semantics(matchResult).astOfJustImports();
         } finally {
             ctx = null;
         }

--- a/src/imports/resolveImports.ts
+++ b/src/imports/resolveImports.ts
@@ -52,7 +52,7 @@ export function resolveImports(args: {
             });
             if (!resolved.ok) {
                 throwCompilationError(
-                    `Could not resolve import "${i}" in ${path}`,
+                    `Could not resolve import "${importPath}" in ${path}`,
                 );
             }
 

--- a/src/imports/resolveImports.ts
+++ b/src/imports/resolveImports.ts
@@ -42,10 +42,11 @@ export function resolveImports(args: {
     function processImports(source: string, path: string, origin: ItemOrigin) {
         const imp = parseImports(source, path, origin);
         for (const i of imp) {
+            const importPath = i.path.value;
             // Resolve library
             const resolved = resolveLibrary({
                 path: path,
-                name: i,
+                name: importPath,
                 project: args.project,
                 stdlib: args.stdlib,
             });


### PR DESCRIPTION
<!--
IMPORTANT:
If your PR doesn't close a particular issue, please, create the issue first and describe the whole context: what you're adding/changing and why you're doing so. And only then open the Pull Request, which would close that issue!
-->

## Issue

Closes #965 .

## Checklist

- [x] I have updated CHANGELOG.md
- [x] I have added tests to demonstrate the contribution is correctly implemented: this usually includes both positive and negative tests, showing the happy path(s) and featuring intentionally broken cases
- [x] I have run all the tests locally and no test failure was reported
- [x] I have run the linter, formatter and spellchecker
- [x] I did not do unrelated and/or undiscussed refactorings
