### PR TITLE
chore: backport Node.js compatibility layer for versions ≥18 and <22

### DIFF
--- a/.github/workflows/tact.yml
+++ b/.github/workflows/tact.yml
@@ -24,6 +24,29 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v3
 
+      - name: Setup Node.js 18 for backwards compat tests
+        uses: actions/setup-node@v3
+        with:
+          node-version: 18
+          # without caching
+
+      - name: Backwards compat tests
+        run: |
+          # Temporarily ignore engines
+          yarn config set ignore-engines true
+          # Install dependencies, gen and build the compiler
+          yarn install
+          yarn clean
+          yarn gen
+          yarn build
+          # Test some specific things for backwards compatibility.
+          # It's important to restrain from using too much of Node.js 22+ features
+          # until it goes into maintenance LTS state and majority of users catches up
+          yarn jest -t 'isSubsetOf'
+          # Clean-up
+          yarn cleanall
+          yarn config delete ignore-engines
+
       - name: Setup Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v3
         with:

--- a/scripts/copy-files.ts
+++ b/scripts/copy-files.ts
@@ -1,0 +1,22 @@
+import * as fs from "node:fs/promises";
+import * as path from "node:path";
+import * as glob from "glob";
+
+const cp = async (fromGlob: string, toPath: string) => {
+    const files = glob.sync(fromGlob);
+    for (const file of files) {
+        await fs.copyFile(file, path.join(toPath, path.basename(file)));
+    }
+};
+
+const main = async () => {
+    try {
+        await cp("./src/grammar/grammar.ohm*", "./dist/grammar/");
+        await cp("./src/func/funcfiftlib.*", "./dist/func/");
+    } catch (e) {
+        console.error(e);
+        process.exit(1);
+    }
+};
+
+void main();

--- a/src/types/resolveDescriptors.ts
+++ b/src/types/resolveDescriptors.ts
@@ -43,6 +43,7 @@ import {
 import { getRawAST } from "../grammar/store";
 import { cloneNode } from "../grammar/clone";
 import { crc16 } from "../utils/crc16";
+import { isSubsetOf } from "../utils/isSubsetOf";
 import { evalConstantExpression } from "../constEval";
 import { resolveABIType, intMapFormats } from "./resolveABITypeRef";
 import { enabledExternals } from "../config/features";
@@ -897,13 +898,13 @@ export function resolveDescriptors(ctx: CompilerContext) {
                 const paramSet = new Set(
                     a.params.map((typedId) => idText(typedId.name)),
                 );
-                if (!paramSet.isSubsetOf(shuffleArgSet)) {
+                if (!isSubsetOf(paramSet, shuffleArgSet)) {
                     throwCompilationError(
                         "asm argument rearrangement must mention all function parameters",
                         a.loc,
                     );
                 }
-                if (!shuffleArgSet.isSubsetOf(paramSet)) {
+                if (!isSubsetOf(shuffleArgSet, paramSet)) {
                     throwCompilationError(
                         "asm argument rearrangement must mention only function parameters",
                         a.loc,
@@ -961,13 +962,13 @@ export function resolveDescriptors(ctx: CompilerContext) {
                 // mutating functions also return `self` arg (implicitly in Tact, but explicitly in FunC)
                 retTupleSize += isMutating ? 1 : 0;
                 const returnValueSet = new Set([...Array(retTupleSize).keys()]);
-                if (!returnValueSet.isSubsetOf(shuffleRetSet)) {
+                if (!isSubsetOf(returnValueSet, shuffleRetSet)) {
                     throwCompilationError(
                         `asm return rearrangement must mention all return position numbers: [0..${retTupleSize - 1}]`,
                         a.loc,
                     );
                 }
-                if (!shuffleRetSet.isSubsetOf(returnValueSet)) {
+                if (!isSubsetOf(shuffleRetSet, returnValueSet)) {
                     throwCompilationError(
                         `asm return rearrangement must mention only valid return position numbers: [0..${retTupleSize - 1}]`,
                         a.loc,

--- a/src/utils/isSubsetOf.spec.ts
+++ b/src/utils/isSubsetOf.spec.ts
@@ -1,0 +1,91 @@
+import { ReadonlySetLike, isSubsetOf } from "./isSubsetOf";
+
+// Tests are adapted from:
+// https://github.com/zloirock/core-js/blob/227a758ef96fa585a66cc1e89741e7d0bb696f48/tests/unit-global/es.set.is-subset-of.js
+
+describe("isSubsetOf", () => {
+    /* eslint-disable @typescript-eslint/no-explicit-any */
+    let s1: Set<any>;
+    let s2: ReadonlySetLike<unknown>;
+
+    it("should implement isSubsetOf correctly", () => {
+        s1 = new Set([1]);
+        s2 = new Set([1, 2, 3]);
+        expect(isSubsetOf(s1, s2)).toBe(true);
+
+        s1 = new Set([1]);
+        s2 = new Set([2, 3, 4]);
+        expect(isSubsetOf(s1, s2)).toBe(false);
+
+        s1 = new Set([1, 2, 3]);
+        s2 = new Set([5, 4, 3, 2, 1]);
+        expect(isSubsetOf(s1, s2)).toBe(true);
+
+        s1 = new Set([1, 2, 3]);
+        s2 = new Set([5, 4, 3, 2]);
+        expect(isSubsetOf(s1, s2)).toBe(false);
+
+        s1 = new Set([1]);
+        s2 = createSetLike([1, 2, 3]);
+        expect(isSubsetOf(s1, s2)).toBe(true);
+
+        s1 = new Set([1]);
+        s2 = createSetLike([2, 3, 4]);
+        expect(isSubsetOf(s1, s2)).toBe(false);
+
+        s1 = new Set([1, 2, 3]);
+        s2 = createSetLike([5, 4, 3, 2, 1]);
+        expect(isSubsetOf(s1, s2)).toBe(true);
+
+        s1 = new Set([1, 2, 3]);
+        s2 = createSetLike([5, 4, 3, 2]);
+        expect(isSubsetOf(s1, s2)).toBe(false);
+
+        s1 = new Set([1, 2, 3]);
+        s2 = new Set([1]);
+        expect(isSubsetOf(s1, s2)).toBe(false);
+
+        s1 = new Set([1, 2, 3]);
+        s2 = new Set();
+        expect(isSubsetOf(s1, s2)).toBe(false);
+
+        s1 = new Set();
+        s2 = new Set([1, 2, 3]);
+        expect(isSubsetOf(s1, s2)).toBe(true);
+    });
+});
+
+// Helper functions are adapted from:
+// https://github.com/zloirock/core-js/blob/227a758ef96fa585a66cc1e89741e7d0bb696f48/tests/helpers/helpers.js
+
+function createSetLike<T>(elements: T[]): ReadonlySetLike<T> {
+    return {
+        size: elements.length,
+        has(value: T): boolean {
+            return includes(elements, value);
+        },
+        keys(): Iterator<T> {
+            return createIterator(elements);
+        },
+    };
+}
+
+function includes<T>(target: T[], wanted: T) {
+    return target.some((element) => element === wanted);
+}
+
+function createIterator<T>(elements: T[]): Iterator<T> {
+    let index = 0;
+    const iterator = {
+        called: false,
+        /* eslint-disable @typescript-eslint/no-explicit-any */
+        next(): IteratorResult<any> {
+            iterator.called = true;
+            return {
+                value: elements[index++],
+                done: index > elements.length,
+            };
+        },
+    };
+    return iterator;
+}

--- a/src/utils/isSubsetOf.ts
+++ b/src/utils/isSubsetOf.ts
@@ -1,0 +1,38 @@
+/** Taken from TypeScript collection lib to perfectly match the .isSubsetOf signature */
+export interface ReadonlySetLike<T> {
+    /**
+     * Despite its name, returns an iterator of the values in the set-like.
+     */
+    keys(): Iterator<T>;
+    /**
+     * @returns a boolean indicating whether an element with the specified value exists in the set-like or not.
+     */
+    has(value: T): boolean;
+    /**
+     * @returns the number of (unique) elements in the set-like.
+     */
+    readonly size: number;
+}
+
+/**
+ * @returns a boolean indicating whether all the elements in Set `one` are also in the `other`.
+ */
+export function isSubsetOf<T>(
+    one: Set<T>,
+    other: ReadonlySetLike<unknown>,
+): boolean {
+    // If the builtin method exists, just call it
+    if ("isSubsetOf" in Set.prototype) {
+        return one.isSubsetOf(other);
+    }
+    // If not, provide the implementation
+    if (one.size > other.size) {
+        return false;
+    }
+    for (const element of one) {
+        if (!other.has(element)) {
+            return false;
+        }
+    }
+    return true;
+}


### PR DESCRIPTION
<!--
IMPORTANT:
If your PR doesn't close a particular issue, please, create the issue first and describe the whole context: what you're adding/changing and why you're doing so. And only then open the Pull Request, which would close that issue!
-->

Essentially, just `cherry-pick`ed the one commit that introduced the global `isSubsetOf()` function.

## Issue

Closes #1078.

## Checklist

- [ ] I have updated CHANGELOG.md
- [x] I have run all the tests locally and no test failure was reported
- [x] I have run the linter, formatter and spellchecker
- [x] I did not do unrelated and/or undiscussed refactorings
