### PR TITLE
chore(docs): mark latest features as not released yet

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -2,6 +2,10 @@
 
 - [ ] Improve the changelog for `vX.Y.Z`: grammar, wording, polishing
 - [ ] Make sure there are no open issues for the [vX.Y.Z milestone](https://github.com/tact-lang/tact/issues?q=is%3Aopen+is%3Aissue+milestone%3AvX.Y.Z) (except for the current one, of course)
+- [ ] Remove "(not released yet)" from docs:
+  - [ ] `cd docs` — important as to not change the texts elsewhere, such as in code comments
+  - [ ] `regex='([sS]ince Tact \d\.\d) \(not released yet\)'; rg "$regex" -r '$1'` (or similar with `grep`) — to preview the changes
+  - [ ] `regex='([sS]ince Tact \d\.\d) \(not released yet\)'; rg "$regex" -l | xargs sd "$regex" '$1'` (or similar with `grep` and `sed`) — to apply the changes
 - [ ] Bump Tact version in:
   - [ ] [`package.json`](./package.json) file
   - [ ] [CHANGELOG.md](./CHANGELOG.md): `Unreleased` -> `vX.Y.Z`
@@ -16,7 +20,6 @@
   $ git checkout vX.Y.Z
   $ yarn all && npm publish
   ```
-- [ ] Update [tact-docs](https://github.com/tact-lang/tact-docs) with the most recent Tact features (tracked in: )
 - [ ] Request or perform the plugins/parsers/tools updates and releases:
   - [ ] <https://github.com/tact-lang/tact-template> (tracked in: )
   - [ ] <https://github.com/tact-lang/tree-sitter-tact> (tracked in: )

--- a/cspell.json
+++ b/cspell.json
@@ -126,7 +126,8 @@
   "ignoreRegExpList": [
     "\\b[xB]\\{[a-fA-F0-9]*_?\\}", // binary literals in Fift-asm
     "\\b0[xX][a-fA-F0-9_]*\\b", // hexadecimal numbers
-    "\\b(?:address|crc32|cell|slice|rawSlice)\\(\".+\"\\)" // some comptime functions
+    "\\b(?:address|crc32|cell|slice|rawSlice)\\(\".+\"\\)", // some comptime functions
+    "ince Tact " // regex in RELEASE.md
   ],
   "flagWords": [],
   "ignorePaths": [

--- a/docs/src/content/docs/book/exit-codes.mdx
+++ b/docs/src/content/docs/book/exit-codes.mdx
@@ -62,8 +62,8 @@ Exit code     | Origin                              | Brief description
 [$133$](#133) | Tact compiler ([Compute phase][c])  | Contract stopped. Reserved, but never thrown.
 [$134$](#134) | Tact compiler ([Compute phase][c])  | Invalid argument.
 [$135$](#135) | Tact compiler ([Compute phase][c])  | Code of a contract was not found.
-~~[$136$](#136)~~ | ~~Tact compiler ([Compute phase][c])~~  | ~~Invalid address.~~ Removed since Tact 1.6
-~~[$137$](#137)~~ | ~~Tact compiler ([Compute phase][c])~~  | ~~Masterchain support is not enabled for this contract.~~ Removed since Tact 1.6
+~~[$136$](#136)~~ | ~~Tact compiler ([Compute phase][c])~~  | ~~Invalid address.~~ Removed since Tact 1.6 (not released yet)
+~~[$137$](#137)~~ | ~~Tact compiler ([Compute phase][c])~~  | ~~Masterchain support is not enabled for this contract.~~ Removed since Tact 1.6 (not released yet)
 
 :::note
 
@@ -625,7 +625,7 @@ If the code of the contract doesn't match the one saved in TypeScript wrappers, 
 
 ### 136: Invalid address {#136}
 
-<Badge text="Removed since Tact 1.6" variant="tip" size="medium"/><p/>
+<Badge text="Removed since Tact 1.6 (not released yet)" variant="tip" size="medium"/><p/>
 
 A value of type [`Address{:tact}`][p] is valid in Tact when:
 
@@ -648,7 +648,7 @@ try {
 
 ### 137: Masterchain support is not enabled for this contract {#137}
 
-<Badge text="Removed since Tact 1.6" variant="tip" size="medium"/><p/>
+<Badge text="Removed since Tact 1.6 (not released yet)" variant="tip" size="medium"/><p/>
 
 Prior to removal, any attempts to point to masterchain (ID $-1$) or otherwise interact with it without enabling masterchain support were throwing an exception with exit code $137$: `Masterchain support is not enabled for this contract`.
 

--- a/docs/src/content/docs/book/functions.mdx
+++ b/docs/src/content/docs/book/functions.mdx
@@ -150,7 +150,7 @@ contract Treasure {
 
 ### Explicit resolution of method ID collisions
 
-<Badge text="Available since Tact 1.6" variant="tip" size="medium"/><p/>
+<Badge text="Available since Tact 1.6 (not released yet)" variant="tip" size="medium"/><p/>
 
 Like other functions in TON contracts, getters have their _unique_ associated function selectors, which are $19$-bit signed integer identifiers commonly called _method IDs_.
 

--- a/docs/src/content/docs/book/maps.mdx
+++ b/docs/src/content/docs/book/maps.mdx
@@ -98,7 +98,7 @@ if (gotButUnsure != null) {
 
 ### Replace values, `.replace()` {#replace}
 
-<Badge text="Available since Tact 1.6" variant="tip" size="medium"/><p/>
+<Badge text="Available since Tact 1.6 (not released yet)" variant="tip" size="medium"/><p/>
 
 To replace the value under a key, if such a key exists, use the `.replace(){:tact}` [method](/book/functions#extension-function). It returns `true{:tact}` on successful replacement and `false{:tact}` otherwise.
 
@@ -140,7 +140,7 @@ replaced2; // false
 
 ### Replace and get old value, `.replaceGet()` {#replaceget}
 
-<Badge text="Available since Tact 1.6" variant="tip" size="medium"/><p/>
+<Badge text="Available since Tact 1.6 (not released yet)" variant="tip" size="medium"/><p/>
 
 Like [`.replace()`](#replace), but instead of returning a [`Bool{:tact}`](/book/types#booleans) it returns the old (pre-replacement) value on successful replacement and [`null{:tact}`](/book/optionals) otherwise.
 

--- a/docs/src/content/docs/book/message-mode.mdx
+++ b/docs/src/content/docs/book/message-mode.mdx
@@ -13,7 +13,7 @@ It's possible to use raw [`Int{:tact}`][int] values and manually provide them fo
 
 Mode value | Constant name                 | Description
 ---------: | :---------------------------- | -----------
-$0$        | <Badge text="Since Tact 1.6" variant="tip"/> `SendDefaultMode{:tact}` | Ordinary message (default).
+$0$        | <Badge text="Since Tact 1.6 (not released yet)" variant="tip"/> `SendDefaultMode{:tact}` | Ordinary message (default).
 $64$       | `SendRemainingValue{:tact}`   | Carry all the remaining value of the inbound message in addition to the value initially indicated in the new message.
 $128$      | `SendRemainingBalance{:tact}` | Carry all the remaining balance of the current smart contract instead of the value originally indicated in the message.
 

--- a/docs/src/content/docs/book/statements.mdx
+++ b/docs/src/content/docs/book/statements.mdx
@@ -100,7 +100,7 @@ value += 5;     // augmented assignment (one of the many, see below)
 
 ## Destructuring assignment
 
-<Badge text="Available since Tact 1.6" variant="tip" size="medium"/><p/>
+<Badge text="Available since Tact 1.6 (not released yet)" variant="tip" size="medium"/><p/>
 
 The destructuring assignment is a concise way to unpack [Structs][s] and [Messages][m] into distinct variables. It mirrors the [instantiation syntax](/book/expressions#instantiation), but instead of creating a new [Struct][s] or [Message][m] it binds every field or some of the fields to their respective variables.
 

--- a/docs/src/content/docs/book/structs-and-messages.mdx
+++ b/docs/src/content/docs/book/structs-and-messages.mdx
@@ -118,7 +118,7 @@ message(0x7362d09c) TokenNotification {
 
 This is useful for cases where you want to handle certain opcodes of a given smart contract, such as [Jetton standard](https://github.com/ton-blockchain/TEPs/blob/master/text/0074-jettons-standard.md). The short-list of opcodes this contract is able to process is [given here in FunC](https://github.com/ton-blockchain/token-contract/blob/main/ft/op-codes.fc). They serve as an interface to the smart contract.
 
-<Badge text="Available since Tact 1.6" variant="tip" size="small"/> A message opcode can be any [compile-time](/ref/core-comptime) expression that evaluates to a positive $32$-bit integer, so the following is also valid:
+<Badge text="Available since Tact 1.6 (not released yet)" variant="tip" size="small"/> A message opcode can be any [compile-time](/ref/core-comptime) expression that evaluates to a positive $32$-bit integer, so the following is also valid:
 
 ```tact
 // This Message overwrites its unique id (opcode) with 898001897,

--- a/docs/src/content/docs/zh-cn/book/functions.mdx
+++ b/docs/src/content/docs/zh-cn/book/functions.mdx
@@ -139,7 +139,7 @@ contract Treasure {
 ```
 ### 明确解决方法 ID 碰撞问题
 
-<Badge text="Available since Tact 1.6" variant="tip" size="medium"/><p/>
+<Badge text="Available since Tact 1.6 (not released yet)" variant="tip" size="medium"/><p/>
 
 与 TVM 合约中的其他函数一样，getters 也有其*独特*的相关函数选择器，即一些整数 ID（称为*方法 ID*）。
 其中一些整数是为内部目的保留的，例如 -4, -3, -2, -1, 0 是保留 ID，而 


### PR DESCRIPTION
Adjusted the RELEASE.md with the inverse commands to remove such notes upon the release.

Since all new feature docs are written right with the PRs that introduce those features, removed the outdated check for tracking documentation updates.

<!--
IMPORTANT:
If your PR doesn't close a particular issue, please, create the issue first and describe the whole context: what you're adding/changing and why you're doing so. And only then open the Pull Request, which would close that issue!
-->

## Issue

Closes #1228.

## Checklist

- [x] I have run the linter, formatter and spellchecker
- [x] I did not do unrelated and/or undiscussed refactorings
