### PR TITLE
refactor: move `errors.ts`

### DIFF
--- a/src/abi/global.ts
+++ b/src/abi/global.ts
@@ -7,7 +7,7 @@ import {
     writeString,
 } from "../generator/writers/writeConstant";
 import { writeExpression } from "../generator/writers/writeExpression";
-import { throwCompilationError } from "../errors";
+import { throwCompilationError } from "../error/errors";
 import { getErrorId } from "../types/resolveErrors";
 import { AbiFunction } from "./AbiFunction";
 import { sha256_sync } from "@ton/crypto";

--- a/src/abi/map.ts
+++ b/src/abi/map.ts
@@ -4,7 +4,7 @@ import { TypeRef } from "../types/types";
 import { WriterContext } from "../generator/Writer";
 import { ops } from "../generator/writers/ops";
 import { writeExpression } from "../generator/writers/writeExpression";
-import { throwCompilationError } from "../errors";
+import { throwCompilationError } from "../error/errors";
 import { getType } from "../types/resolveDescriptors";
 import { AbiFunction } from "./AbiFunction";
 import { AstExpression } from "../grammar/ast";

--- a/src/abi/struct.ts
+++ b/src/abi/struct.ts
@@ -1,6 +1,6 @@
 import { ops } from "../generator/writers/ops";
 import { writeExpression } from "../generator/writers/writeExpression";
-import { throwCompilationError } from "../errors";
+import { throwCompilationError } from "../error/errors";
 import { getType } from "../types/resolveDescriptors";
 import { AbiFunction } from "./AbiFunction";
 

--- a/src/bindings/typescript/serializers.ts
+++ b/src/bindings/typescript/serializers.ts
@@ -1,6 +1,6 @@
 import { ABITypeRef } from "@ton/core";
 import { Writer } from "../../utils/Writer";
-import { throwInternalCompilerError } from "../../errors";
+import { throwInternalCompilerError } from "../../error/errors";
 
 const primitiveTypes = [
     "int",

--- a/src/bindings/typescript/writeStruct.ts
+++ b/src/bindings/typescript/writeStruct.ts
@@ -1,7 +1,7 @@
 import { ABIType, ABITypeRef } from "@ton/core";
 import { serializers } from "./serializers";
 import { AllocationCell, AllocationOperation } from "../../storage/operation";
-import { throwInternalCompilerError } from "../../errors";
+import { throwInternalCompilerError } from "../../error/errors";
 import { Writer } from "../../utils/Writer";
 
 export const maxTupleSize = 15;

--- a/src/bindings/writeTypescript.ts
+++ b/src/bindings/writeTypescript.ts
@@ -14,7 +14,7 @@ import {
     writeTupleSerializer,
 } from "./typescript/writeStruct";
 import { AllocationCell } from "../storage/operation";
-import { throwInternalCompilerError } from "../errors";
+import { throwInternalCompilerError } from "../error/errors";
 import { topologicalSort } from "../utils/utils";
 import {
     allocate,

--- a/src/constEval.ts
+++ b/src/constEval.ts
@@ -6,7 +6,7 @@ import {
     isLiteral,
     AstLiteral,
 } from "./grammar/ast";
-import { TactConstEvalError, throwInternalCompilerError } from "./errors";
+import { TactConstEvalError, throwInternalCompilerError } from "./error/errors";
 import { AstUtil } from "./optimizer/util";
 import { ExpressionTransformer } from "./optimizer/types";
 import { StandardOptimizer } from "./optimizer/standardOptimizer";

--- a/src/error/display-to-json.ts
+++ b/src/error/display-to-json.ts
@@ -2,7 +2,7 @@
  * Render error message to JSON for tests
  */
 
-import { throwInternalCompilerError } from "../errors";
+import { throwInternalCompilerError } from "./errors";
 import { SrcInfo } from "../grammar";
 import { srcInfoEqual } from "../grammar/src-info";
 import { ErrorDisplay } from "./display";

--- a/src/error/display-to-string.ts
+++ b/src/error/display-to-string.ts
@@ -3,7 +3,7 @@
  */
 
 import { ErrorDisplay } from "./display";
-import { locationStr } from "../errors";
+import { locationStr } from "./errors";
 
 export const displayToString: ErrorDisplay<string> = {
     text: (text) => text,

--- a/src/error/errors.ts
+++ b/src/error/errors.ts
@@ -1,7 +1,7 @@
 import path from "path";
 import { cwd } from "process";
-import { AstFuncId, AstId, AstTypeId } from "./grammar/ast";
-import { SrcInfo } from "./grammar";
+import { AstFuncId, AstId, AstTypeId } from "../grammar/ast";
+import { SrcInfo } from "../grammar";
 
 export class TactError extends Error {
     readonly loc?: SrcInfo;

--- a/src/generator/writers/writeExpression.ts
+++ b/src/generator/writers/writeExpression.ts
@@ -12,7 +12,7 @@ import {
     TactConstEvalError,
     throwCompilationError,
     throwInternalCompilerError,
-} from "../../errors";
+} from "../../error/errors";
 import { getExpType } from "../../types/resolveExpression";
 import {
     getStaticConstant,

--- a/src/generator/writers/writeFunction.ts
+++ b/src/generator/writers/writeFunction.ts
@@ -22,7 +22,7 @@ import { cast } from "./cast";
 import { resolveFuncTupleType } from "./resolveFuncTupleType";
 import { ops } from "./ops";
 import { freshIdentifier } from "./freshIdentifier";
-import { idTextErr, throwInternalCompilerError } from "../../errors";
+import { idTextErr, throwInternalCompilerError } from "../../error/errors";
 import { ppAsmShuffle } from "../../prettyPrinter";
 
 export function writeCastedExpression(

--- a/src/generator/writers/writeSerialization.ts
+++ b/src/generator/writers/writeSerialization.ts
@@ -1,5 +1,5 @@
 import { contractErrors } from "../../abi/errors";
-import { throwInternalCompilerError } from "../../errors";
+import { throwInternalCompilerError } from "../../error/errors";
 import { dummySrcInfo, ItemOrigin } from "../../grammar";
 import { AllocationCell, AllocationOperation } from "../../storage/operation";
 import { StorageAllocation } from "../../storage/StorageAllocation";

--- a/src/grammar/ast.ts
+++ b/src/grammar/ast.ts
@@ -1,5 +1,5 @@
 import { Address, Cell, Slice } from "@ton/core";
-import { throwInternalCompilerError } from "../errors";
+import { throwInternalCompilerError } from "../error/errors";
 import { dummySrcInfo, SrcInfo } from "./src-info";
 
 export type AstModule = {

--- a/src/grammar/clone.ts
+++ b/src/grammar/clone.ts
@@ -1,5 +1,5 @@
 import { AstNode, FactoryAst } from "./ast";
-import { throwInternalCompilerError } from "../errors";
+import { throwInternalCompilerError } from "../error/errors";
 
 export function cloneNode<T extends AstNode>(
     src: T,

--- a/src/grammar/compare.ts
+++ b/src/grammar/compare.ts
@@ -56,7 +56,7 @@ import {
     AstStatementDestruct,
 } from "./ast";
 import { AstRenamer } from "./rename";
-import { throwInternalCompilerError } from "../errors";
+import { throwInternalCompilerError } from "../error/errors";
 import JSONbig from "json-bigint";
 
 /**

--- a/src/grammar/hash.ts
+++ b/src/grammar/hash.ts
@@ -26,7 +26,7 @@ import {
     AstAsmInstruction,
 } from "./ast";
 import { createHash } from "crypto";
-import { throwInternalCompilerError } from "../errors";
+import { throwInternalCompilerError } from "../error/errors";
 import JSONbig from "json-bigint";
 
 export type AstHash = string;

--- a/src/grammar/next/index.ts
+++ b/src/grammar/next/index.ts
@@ -2,7 +2,10 @@ import * as $ from "@tonstudio/parser-runtime";
 import * as A from "../ast";
 import * as G from "./grammar";
 import type { $ast } from "./grammar";
-import { TactCompilationError, throwInternalCompilerError } from "../../errors";
+import {
+    TactCompilationError,
+    throwInternalCompilerError,
+} from "../../error/errors";
 import { SyntaxErrors, syntaxErrorSchema } from "../parser-error";
 import { AstSchema, getAstSchema } from "../ast-typed";
 import { getSrcInfo, ItemOrigin } from "../src-info";

--- a/src/grammar/prev/grammar.ts
+++ b/src/grammar/prev/grammar.ts
@@ -1,6 +1,6 @@
 import { Node, IterationNode, NonterminalNode } from "ohm-js";
 import tactGrammar from "./grammar.ohm-bundle";
-import { throwInternalCompilerError } from "../../errors";
+import { throwInternalCompilerError } from "../../error/errors";
 import {
     AstAugmentedAssignOperation,
     AstConstantAttribute,

--- a/src/grammar/prev/parser-error.ts
+++ b/src/grammar/prev/parser-error.ts
@@ -1,6 +1,6 @@
 import { MatchResult } from "ohm-js";
 import { ErrorDisplay } from "../../error/display";
-import { TactCompilationError } from "../../errors";
+import { TactCompilationError } from "../../error/errors";
 import { syntaxErrorSchema } from "../parser-error";
 import { ItemOrigin, SrcInfo } from "../src-info";
 import { getSrcInfoFromOhm } from "./src-info";

--- a/src/grammar/sort.ts
+++ b/src/grammar/sort.ts
@@ -5,7 +5,7 @@ import {
     AstContractAttribute,
     AstNode,
 } from "./ast";
-import { throwInternalCompilerError } from "../errors";
+import { throwInternalCompilerError } from "../error/errors";
 
 /**
  * Provides utilities to sort lists of AST nodes.

--- a/src/grammar/src-info.ts
+++ b/src/grammar/src-info.ts
@@ -1,4 +1,4 @@
-import { throwInternalCompilerError } from "../errors";
+import { throwInternalCompilerError } from "../error/errors";
 
 export type ItemOrigin = "stdlib" | "user";
 

--- a/src/grammar/store.ts
+++ b/src/grammar/store.ts
@@ -6,7 +6,7 @@ import {
     AstTypeDecl,
     AstAsmFunctionDef,
 } from "./ast";
-import { throwInternalCompilerError } from "../errors";
+import { throwInternalCompilerError } from "../error/errors";
 import { CompilerContext, createContextStore } from "../context";
 import { ItemOrigin } from "./src-info";
 import { Parser } from "./grammar";

--- a/src/imports/resolveImports.ts
+++ b/src/imports/resolveImports.ts
@@ -1,6 +1,6 @@
 import { ItemOrigin, Parser } from "../grammar";
 import { VirtualFileSystem } from "../vfs/VirtualFileSystem";
-import { throwCompilationError } from "../errors";
+import { throwCompilationError } from "../error/errors";
 import { resolveLibrary } from "./resolveLibrary";
 
 export function resolveImports(args: {

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,7 +6,7 @@ export {
     TactInternalCompilerError,
     TactConstEvalError,
     TactErrorCollection,
-} from "./errors";
+} from "./error/errors";
 export {
     optionsSchema,
     projectSchema,

--- a/src/interpreter.ts
+++ b/src/interpreter.ts
@@ -9,7 +9,7 @@ import {
     idTextErr,
     throwConstEvalError,
     throwInternalCompilerError,
-} from "./errors";
+} from "./error/errors";
 import {
     AstAddress,
     AstBinaryOperation,

--- a/src/main.ts
+++ b/src/main.ts
@@ -16,4 +16,4 @@ export { createVirtualFileSystem } from "./vfs/createVirtualFileSystem";
 export * from "./browser";
 export * from "./verify";
 export * from "./logger";
-export * from "./errors";
+export * from "./error/errors";

--- a/src/node.ts
+++ b/src/node.ts
@@ -4,7 +4,7 @@ import { ConfigProject, Config, parseConfig } from "./config/parseConfig";
 import { createNodeFileSystem } from "./vfs/createNodeFileSystem";
 import { build } from "./pipeline/build";
 import { LogLevel, Logger } from "./logger";
-import { TactErrorCollection } from "./errors";
+import { TactErrorCollection } from "./error/errors";
 
 type AdditionalCliOptions = {
     mode?: ConfigProject["mode"];

--- a/src/optimizer/test/partial-eval.spec.ts
+++ b/src/optimizer/test/partial-eval.spec.ts
@@ -13,7 +13,7 @@ import { AssociativeRule3 } from "../associative";
 import { evalBinaryOp, evalUnaryOp } from "../../interpreter";
 import { getParser } from "../../grammar";
 import { defaultParser } from "../../grammar/grammar";
-import { throwInternalCompilerError } from "../../errors";
+import { throwInternalCompilerError } from "../../error/errors";
 
 const MAX: string =
     "115792089237316195423570985008687907853269984665640564039457584007913129639935";

--- a/src/pipeline/build.ts
+++ b/src/pipeline/build.ts
@@ -20,7 +20,7 @@ import { compile } from "./compile";
 import { precompile } from "./precompile";
 import { getCompilerVersion } from "./version";
 import { FactoryAst, getAstFactory, idText } from "../grammar/ast";
-import { TactErrorCollection } from "../errors";
+import { TactErrorCollection } from "../error/errors";
 import { getParser, Parser } from "../grammar";
 import { defaultParser } from "../grammar/grammar";
 

--- a/src/storage/allocator.ts
+++ b/src/storage/allocator.ts
@@ -4,7 +4,7 @@ import {
     AllocationOperation,
     AllocationOperationType,
 } from "./operation";
-import { throwInternalCompilerError } from "../errors";
+import { throwInternalCompilerError } from "../error/errors";
 
 const ALLOCATOR_RESERVE_BIT = 1;
 const ALLOCATOR_RESERVE_REF = 1;

--- a/src/storage/resolveAllocation.ts
+++ b/src/storage/resolveAllocation.ts
@@ -7,7 +7,7 @@ import { AllocationOperation } from "./operation";
 import { allocate, getAllocationOperationFromField } from "./allocator";
 import { createABITypeRefFromTypeRef } from "../types/resolveABITypeRef";
 import { funcInitIdOf } from "../generator/writers/id";
-import { throwInternalCompilerError } from "../errors";
+import { throwInternalCompilerError } from "../error/errors";
 import { idText } from "../grammar/ast";
 
 const store = createContextStore<StorageAllocation>();

--- a/src/types/resolveABITypeRef.ts
+++ b/src/types/resolveABITypeRef.ts
@@ -17,7 +17,7 @@ import {
     idTextErr,
     throwCompilationError,
     throwInternalCompilerError,
-} from "../errors";
+} from "../error/errors";
 import { TypeRef } from "./types";
 import { CompilerContext } from "../context";
 import { getType } from "./resolveDescriptors";

--- a/src/types/resolveDescriptors.ts
+++ b/src/types/resolveDescriptors.ts
@@ -24,7 +24,7 @@ import {
     idTextErr,
     throwCompilationError,
     throwInternalCompilerError,
-} from "../errors";
+} from "../error/errors";
 import { CompilerContext, createContextStore, Store } from "../context";
 import {
     ConstantDescription,

--- a/src/types/resolveErrors.ts
+++ b/src/types/resolveErrors.ts
@@ -3,7 +3,7 @@ import { CompilerContext, createContextStore } from "../context";
 import { AstNode, FactoryAst, isRequire } from "../grammar/ast";
 import { traverse } from "../grammar/iterators";
 import { evalConstantExpression } from "../constEval";
-import { throwInternalCompilerError } from "../errors";
+import { throwInternalCompilerError } from "../error/errors";
 import {
     getAllStaticFunctions,
     getAllTypes,

--- a/src/types/resolveExpression.ts
+++ b/src/types/resolveExpression.ts
@@ -22,7 +22,7 @@ import {
     AstCommentValue,
     AstStructValue,
 } from "../grammar/ast";
-import { idTextErr, throwCompilationError } from "../errors";
+import { idTextErr, throwCompilationError } from "../error/errors";
 import { CompilerContext, createContextStore } from "../context";
 import {
     getAllTypes,
@@ -37,7 +37,7 @@ import { StatementContext } from "./resolveStatements";
 import { MapFunctions } from "../abi/map";
 import { GlobalFunctions } from "../abi/global";
 import { isAssignable, moreGeneralType } from "./subtyping";
-import { throwInternalCompilerError } from "../errors";
+import { throwInternalCompilerError } from "../error/errors";
 import { StructFunctions } from "../abi/struct";
 import { prettyPrint } from "../prettyPrinter";
 

--- a/src/types/resolveSignatures.ts
+++ b/src/types/resolveSignatures.ts
@@ -6,7 +6,7 @@ import {
     idTextErr,
     throwConstEvalError,
     throwInternalCompilerError,
-} from "../errors";
+} from "../error/errors";
 import { getType, getAllTypes } from "./resolveDescriptors";
 import {
     BinaryReceiverSelector,
@@ -14,7 +14,7 @@ import {
     ReceiverDescription,
     TypeDescription,
 } from "./types";
-import { throwCompilationError } from "../errors";
+import { throwCompilationError } from "../error/errors";
 import { AstNumber, AstReceiver, FactoryAst } from "../grammar/ast";
 import { commentPseudoOpcode } from "../generator/writers/writeRouter";
 import { sha256_sync } from "@ton/crypto";

--- a/src/types/resolveStatements.ts
+++ b/src/types/resolveStatements.ts
@@ -17,7 +17,7 @@ import {
     throwCompilationError,
     throwConstEvalError,
     throwInternalCompilerError,
-} from "../errors";
+} from "../error/errors";
 import {
     getAllStaticFunctions,
     getStaticConstant,

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -1,5 +1,5 @@
 import { ABIField } from "@ton/core";
-import { throwInternalCompilerError } from "../errors";
+import { throwInternalCompilerError } from "../error/errors";
 import {
     AstConstantDef,
     AstFunctionDef,

--- a/src/utils/tricks.ts
+++ b/src/utils/tricks.ts
@@ -89,7 +89,7 @@ export const match = <const I extends any[]>(
     }) as MV<Flat<I>, never>;
 };
 
-import { throwInternalCompilerError } from "../errors";
+import { throwInternalCompilerError } from "../error/errors";
 
 /**
  * Convert union to intersection. See https://stackoverflow.com/q/50374908

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -1,4 +1,4 @@
-import { throwInternalCompilerError } from "../errors";
+import { throwInternalCompilerError } from "../error/errors";
 
 export function topologicalSort<T>(src: T[], references: (src: T) => T[]) {
     const result: T[] = [];


### PR DESCRIPTION
## Issue

Move `errors.ts` to the same folder as the rest of error-handling code

Towards https://github.com/tact-lang/tact/issues/1269.

## Checklist

- [ ] I have updated CHANGELOG.md
- [x] I have run all the tests locally and no test failure was reported
- [x] I have run the linter, formatter and spellchecker
- [x] I did not do unrelated and/or undiscussed refactorings
