### PR TITLE
fix: remove duplicate line and column info from error messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Forbid "remainder" field at the middle of a contract storage: PR [#1301](https://github.com/tact-lang/tact/pull/1301)
 - Forbid the `override` modifier for functions without the corresponding super-function: PR [#1302](https://github.com/tact-lang/tact/pull/1302)
 - Format empty blocks without extra empty line: PR [#1346](https://github.com/tact-lang/tact/pull/1346)
+- Remove duplicate line and column info from error messages: PR [#1362](https://github.com/tact-lang/tact/pull/1362)
 
 ### Docs
 

--- a/src/grammar/next/__snapshots__/grammar.spec.ts.snap
+++ b/src/grammar/next/__snapshots__/grammar.spec.ts.snap
@@ -2,7 +2,6 @@
 
 exports[`grammar should fail abstract-const-without-modifier 1`] = `
 "<unknown>:2:5: Abstract constant doesn't have abstract modifier
-Line 2, col 5:
   1 | trait t {
 > 2 |     const c: Int;
           ^~~~~~~~~~~~~
@@ -12,7 +11,6 @@ Line 2, col 5:
 
 exports[`grammar should fail const-abstract-abstract 1`] = `
 "<unknown>:4:10: Duplicate constant attribute "abstract"
-Line 4, col 10:
   3 | 
 > 4 | abstract abstract const Foo: Int = 42;
                ^~~~~~~~
@@ -22,7 +20,6 @@ Line 4, col 10:
 
 exports[`grammar should fail const-override 1`] = `
 "<unknown>:4:1: Module-level constants do not support attributes
-Line 4, col 1:
   3 | 
 > 4 | override const Foo: Int = 42;
       ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -32,7 +29,6 @@ Line 4, col 1:
 
 exports[`grammar should fail const-override-override 1`] = `
 "<unknown>:4:10: Duplicate constant attribute "override"
-Line 4, col 10:
   3 | 
 > 4 | override override const Foo: Int = 42;
                ^~~~~~~~
@@ -42,7 +38,6 @@ Line 4, col 10:
 
 exports[`grammar should fail const-override-virtual 1`] = `
 "<unknown>:4:1: Module-level constants do not support attributes
-Line 4, col 1:
   3 | 
 > 4 | override virtual const Foo: Int = 42;
       ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -52,7 +47,6 @@ Line 4, col 1:
 
 exports[`grammar should fail const-virtual 1`] = `
 "<unknown>:4:1: Module-level constants do not support attributes
-Line 4, col 1:
   3 | 
 > 4 | virtual const Foo: Int = 42;
       ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -62,7 +56,6 @@ Line 4, col 1:
 
 exports[`grammar should fail const-virtual-override 1`] = `
 "<unknown>:4:1: Module-level constants do not support attributes
-Line 4, col 1:
   3 | 
 > 4 | virtual override const Foo: Int = 42;
       ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -72,7 +65,6 @@ Line 4, col 1:
 
 exports[`grammar should fail const-virtual-virtual 1`] = `
 "<unknown>:4:9: Duplicate constant attribute "virtual"
-Line 4, col 9:
   3 | 
 > 4 | virtual virtual const Foo: Int = 42;
               ^~~~~~~
@@ -82,7 +74,6 @@ Line 4, col 9:
 
 exports[`grammar should fail contract-const-abstract 1`] = `
 "<unknown>:5:3: Constant definition requires an initializer
-Line 5, col 3:
   4 | contract TestContract {
 > 5 |   abstract const Foo: Int;
         ^~~~~~~~~~~~~~~~~~~~~~~~
@@ -92,7 +83,6 @@ Line 5, col 3:
 
 exports[`grammar should fail contract-const-abstract-abstract 1`] = `
 "<unknown>:5:12: Duplicate constant attribute "abstract"
-Line 5, col 12:
   4 | contract TestContract {
 > 5 |   abstract abstract const Foo: Int = 42;
                  ^~~~~~~~
@@ -102,7 +92,6 @@ Line 5, col 12:
 
 exports[`grammar should fail contract-const-abstract-with-initializer 1`] = `
 "<unknown>:5:3: Non-abstract constant has abstract modifier
-Line 5, col 3:
   4 | contract TestContract {
 > 5 |   abstract const Foo: Int = 42;
         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -112,7 +101,6 @@ Line 5, col 3:
 
 exports[`grammar should fail contract-const-override-override 1`] = `
 "<unknown>:5:12: Duplicate constant attribute "override"
-Line 5, col 12:
   4 | contract TestContract {
 > 5 |   override override const Foo: Int = 42;
                  ^~~~~~~~
@@ -122,7 +110,6 @@ Line 5, col 12:
 
 exports[`grammar should fail contract-const-virtual-virtual 1`] = `
 "<unknown>:5:11: Duplicate constant attribute "virtual"
-Line 5, col 11:
   4 | contract TestContract {
 > 5 |   virtual virtual const Foo: Int = 42;
                 ^~~~~~~
@@ -132,7 +119,6 @@ Line 5, col 11:
 
 exports[`grammar should fail contract-empty-traits-list-with-keyword 1`] = `
 "<unknown>:1:20: Expected identifier
-Line 1, col 20:
 > 1 | contract Name with {}
                          ^
   2 | 
@@ -141,7 +127,6 @@ Line 1, col 20:
 
 exports[`grammar should fail contract-getter-parens-no-method-id 1`] = `
 "<unknown>:2:9: Expected "!", "(", "+", "-", "0", "\\"", "false", "initOf", "null", "true", "~", capitalized identifier, digit, or identifier
-Line 2, col 9:
   1 | contract Test {
 > 2 |     get() fun test(): Int {
               ^
@@ -151,7 +136,6 @@ Line 2, col 9:
 
 exports[`grammar should fail contract-init-trailing-comma-empty-params 1`] = `
 "<unknown>:2:10: Expected ")" or identifier
-Line 2, col 10:
   1 | contract Name {
 > 2 |     init(,) {}
                ^
@@ -161,7 +145,6 @@ Line 2, col 10:
 
 exports[`grammar should fail contract-trailing-comma-empty-traits-list 1`] = `
 "<unknown>:1:19: Expected identifier or not identifier character
-Line 1, col 19:
 > 1 | contract Name with, {}
                         ^
   2 | 
@@ -170,7 +153,6 @@ Line 1, col 19:
 
 exports[`grammar should fail contract-with-imports 1`] = `
 "<unknown>:6:1: Expected "@interface", "@name", "abstract", "asm", "const", "contract", "extends", "fun", "get", "inline", "message", "mutates", "override", "primitive", "struct", "trait", or "virtual"
-Line 6, col 1:
   5 | // all imports must be at the very top of the file
 > 6 | import "@stdlib/not-allowed";
       ^
@@ -180,7 +162,6 @@ Line 6, col 1:
 
 exports[`grammar should fail destructuring-duplicate-source-id 1`] = `
 "<unknown>:15:19: Duplicate field destructuring: "a"
-Line 15, col 19:
   14 |     let s = S{ a: 1, b: 2, c: 3 };
 > 15 |     let S { a: x, a: y } = s;
                          ^~~~
@@ -190,7 +171,6 @@ Line 15, col 19:
 
 exports[`grammar should fail expr-fun-call-trailing-comma-no-args 1`] = `
 "<unknown>:6:14: Expected "!", "(", ")", "+", "-", "0", "\\"", "false", "initOf", "null", "true", "~", capitalized identifier, digit, or identifier
-Line 6, col 14:
   5 | fun b(): Int {
 > 6 |     return a(,);
                    ^
@@ -200,7 +180,6 @@ Line 6, col 14:
 
 exports[`grammar should fail expr-method-call-trailing-comma-no-args 1`] = `
 "<unknown>:2:24: Expected "!", "(", ")", "+", "-", "0", "\\"", "false", "initOf", "null", "true", "~", capitalized identifier, digit, or identifier
-Line 2, col 24:
   1 | fun another() {
 > 2 |     return 42.toString(,);
                              ^
@@ -210,7 +189,6 @@ Line 2, col 24:
 
 exports[`grammar should fail funcid-native-fun-arith-operator 1`] = `
 "<unknown>:1:7: Reserved FunC identifier
-Line 1, col 7:
 > 1 | @name(/)
             ^
   2 | native idTest();
@@ -219,7 +197,6 @@ Line 1, col 7:
 
 exports[`grammar should fail funcid-native-fun-assign-operator 1`] = `
 "<unknown>:1:7: Reserved FunC identifier
-Line 1, col 7:
 > 1 | @name(^>>=)
             ^~~~
   2 | native idTest();
@@ -228,7 +205,6 @@ Line 1, col 7:
 
 exports[`grammar should fail funcid-native-fun-bitwise-operator 1`] = `
 "<unknown>:1:7: Expected FunC identifier
-Line 1, col 7:
 > 1 | @name(~)
             ^
   2 | native idTest();
@@ -237,7 +213,6 @@ Line 1, col 7:
 
 exports[`grammar should fail funcid-native-fun-comma 1`] = `
 "<unknown>:1:19: Expected ")"
-Line 1, col 19:
 > 1 | @name(send_message,then_terminate)
                         ^
   2 | native idTest();
@@ -246,7 +221,6 @@ Line 1, col 19:
 
 exports[`grammar should fail funcid-native-fun-comparison-operator 1`] = `
 "<unknown>:1:7: Reserved FunC identifier
-Line 1, col 7:
 > 1 | @name(<=>)
             ^~~
   2 | native idTest();
@@ -255,7 +229,6 @@ Line 1, col 7:
 
 exports[`grammar should fail funcid-native-fun-control-keyword 1`] = `
 "<unknown>:1:7: Reserved FunC identifier
-Line 1, col 7:
 > 1 | @name(elseifnot)
             ^~~~~~~~~
   2 | native idTest();
@@ -264,7 +237,6 @@ Line 1, col 7:
 
 exports[`grammar should fail funcid-native-fun-delimiter 1`] = `
 "<unknown>:1:7: Expected FunC identifier
-Line 1, col 7:
 > 1 | @name([)
             ^
   2 | native idTest();
@@ -273,7 +245,6 @@ Line 1, col 7:
 
 exports[`grammar should fail funcid-native-fun-directive 1`] = `
 "<unknown>:1:7: Reserved FunC identifier
-Line 1, col 7:
 > 1 | @name(#include)
             ^~~~~~~~
   2 | native idTest();
@@ -282,7 +253,6 @@ Line 1, col 7:
 
 exports[`grammar should fail funcid-native-fun-dot 1`] = `
 "<unknown>:1:10: Expected ")"
-Line 1, col 10:
 > 1 | @name(msg.sender)
                ^
   2 | native idTest();
@@ -291,7 +261,6 @@ Line 1, col 10:
 
 exports[`grammar should fail funcid-native-fun-keyword 1`] = `
 "<unknown>:1:7: Reserved FunC identifier
-Line 1, col 7:
 > 1 | @name(global)
             ^~~~~~
   2 | native idTest();
@@ -300,7 +269,6 @@ Line 1, col 7:
 
 exports[`grammar should fail funcid-native-fun-multiline-comments 1`] = `
 "<unknown>:1:7: Invalid FunC identifier
-Line 1, col 7:
 > 1 | @name({-aaa-})
             ^~~~~~~
   2 | native idTest();
@@ -309,7 +277,6 @@ Line 1, col 7:
 
 exports[`grammar should fail funcid-native-fun-number 1`] = `
 "<unknown>:1:7: FunC identifier cannot be a number
-Line 1, col 7:
 > 1 | @name(123)
             ^~~
   2 | native idTest();
@@ -318,7 +285,6 @@ Line 1, col 7:
 
 exports[`grammar should fail funcid-native-fun-number-decimal 1`] = `
 "<unknown>:1:7: FunC identifier cannot be a number
-Line 1, col 7:
 > 1 | @name(0)
             ^
   2 | native idTest();
@@ -327,7 +293,6 @@ Line 1, col 7:
 
 exports[`grammar should fail funcid-native-fun-number-hexadecimal 1`] = `
 "<unknown>:1:7: FunC identifier cannot be a number
-Line 1, col 7:
 > 1 | @name(0x0)
             ^~~
   2 | native idTest();
@@ -336,7 +301,6 @@ Line 1, col 7:
 
 exports[`grammar should fail funcid-native-fun-number-hexadecimal-2 1`] = `
 "<unknown>:1:7: FunC identifier cannot be a number
-Line 1, col 7:
 > 1 | @name(0xDEADBEEF)
             ^~~~~~~~~~
   2 | native idTest();
@@ -345,7 +309,6 @@ Line 1, col 7:
 
 exports[`grammar should fail funcid-native-fun-number-neg-decimal 1`] = `
 "<unknown>:1:7: FunC identifier cannot be a number
-Line 1, col 7:
 > 1 | @name(-1)
             ^~
   2 | native idTest();
@@ -354,7 +317,6 @@ Line 1, col 7:
 
 exports[`grammar should fail funcid-native-fun-number-neg-hexadecimal 1`] = `
 "<unknown>:1:7: FunC identifier cannot be a number
-Line 1, col 7:
 > 1 | @name(-0x0)
             ^~~~
   2 | native idTest();
@@ -363,7 +325,6 @@ Line 1, col 7:
 
 exports[`grammar should fail funcid-native-fun-only-underscore 1`] = `
 "<unknown>:1:7: Reserved FunC identifier
-Line 1, col 7:
 > 1 | @name(_)
             ^
   2 | native idTest();
@@ -372,7 +333,6 @@ Line 1, col 7:
 
 exports[`grammar should fail funcid-native-fun-parens 1`] = `
 "<unknown>:1:11: Expected ")"
-Line 1, col 11:
 > 1 | @name(take(first)Entry)
                 ^
   2 | native idTest();
@@ -381,7 +341,6 @@ Line 1, col 11:
 
 exports[`grammar should fail funcid-native-fun-semicolons 1`] = `
 "<unknown>:1:9: Expected ")"
-Line 1, col 9:
 > 1 | @name(pa;;in"\`aaa\`")
               ^
   2 | native idTest();
@@ -390,7 +349,6 @@ Line 1, col 9:
 
 exports[`grammar should fail funcid-native-fun-space 1`] = `
 "<unknown>:1:11: Expected ")"
-Line 1, col 11:
 > 1 | @name(foo foo)
                 ^
   2 | native idTest();
@@ -399,7 +357,6 @@ Line 1, col 11:
 
 exports[`grammar should fail funcid-native-fun-square-brackets 1`] = `
 "<unknown>:1:11: Expected ")"
-Line 1, col 11:
 > 1 | @name(take[some]entry)
                 ^
   2 | native idTest();
@@ -408,7 +365,6 @@ Line 1, col 11:
 
 exports[`grammar should fail funcid-native-fun-string 1`] = `
 "<unknown>:1:7: Invalid FunC identifier
-Line 1, col 7:
 > 1 | @name("not_a_string)
             ^~~~~~~~~~~~~
   2 | native idTest();
@@ -417,7 +373,6 @@ Line 1, col 7:
 
 exports[`grammar should fail funcid-native-fun-type-keyword 1`] = `
 "<unknown>:1:7: Reserved FunC identifier
-Line 1, col 7:
 > 1 | @name(->)
             ^~
   2 | native idTest();
@@ -426,7 +381,6 @@ Line 1, col 7:
 
 exports[`grammar should fail funcid-native-fun-unclosed-parens 1`] = `
 "<unknown>:1:9: Expected ")"
-Line 1, col 9:
 > 1 | @name(aa(bb)
               ^
   2 | native idTest();
@@ -435,7 +389,6 @@ Line 1, col 9:
 
 exports[`grammar should fail ident-cannot-be-if-reserved-word 1`] = `
 "<unknown>:2:9: Expected capitalized identifier or identifier
-Line 2, col 9:
   1 | fun hello(): Int {
 > 2 |     let if: Int = 0;
               ^
@@ -445,7 +398,6 @@ Line 2, col 9:
 
 exports[`grammar should fail ident-contract-cannot-start-with-__gen 1`] = `
 "<unknown>:1:10: Variable name cannot start with "__gen"
-Line 1, col 10:
 > 1 | contract __gen_a {
                ^~~~~~~
   2 | 
@@ -454,7 +406,6 @@ Line 1, col 10:
 
 exports[`grammar should fail ident-fun-cannot-start-with-__gen 1`] = `
 "<unknown>:1:5: Variable name cannot start with "__gen"
-Line 1, col 5:
 > 1 | fun __gen_hello(): Int {
           ^~~~~~~~~~~
   2 |     
@@ -463,7 +414,6 @@ Line 1, col 5:
 
 exports[`grammar should fail ident-fun-param-cannot-start-with-__gen 1`] = `
 "<unknown>:1:10: Variable name cannot start with "__gen"
-Line 1, col 10:
 > 1 | fun main(__gen: Int): Int {
                ^~~~~
   2 |     return 0;
@@ -472,7 +422,6 @@ Line 1, col 10:
 
 exports[`grammar should fail ident-fun-param-cannot-start-with-__tact 1`] = `
 "<unknown>:2:11: Variable name cannot start with "__tact"
-Line 2, col 11:
   1 | contract A {
 > 2 |     fun b(__tact: Int) {
                 ^~~~~~
@@ -482,7 +431,6 @@ Line 2, col 11:
 
 exports[`grammar should fail ident-init-param-cannot-start-with-__tact 1`] = `
 "<unknown>:2:10: Variable name cannot start with "__tact"
-Line 2, col 10:
   1 | contract A {
 > 2 |     init(__tact: Int) {
                ^~~~~~
@@ -492,7 +440,6 @@ Line 2, col 10:
 
 exports[`grammar should fail ident-let-cannot-start-with-__gen 1`] = `
 "<unknown>:2:9: Variable name cannot start with "__gen"
-Line 2, col 9:
   1 | fun hello(): Int {
 > 2 |     let __gen_a: Int = 0;
               ^~~~~~~
@@ -502,7 +449,6 @@ Line 2, col 9:
 
 exports[`grammar should fail ident-let-cannot-start-with-__tact 1`] = `
 "<unknown>:2:9: Variable name cannot start with "__tact"
-Line 2, col 9:
   1 | fun hello(): Int {
 > 2 |     let __tact_a: Int = 0;
               ^~~~~~~~
@@ -512,7 +458,6 @@ Line 2, col 9:
 
 exports[`grammar should fail ident-struct-cannot-start-with-__gen 1`] = `
 "<unknown>:1:8: Expected capitalized identifier
-Line 1, col 8:
 > 1 | struct __genA {
              ^
   2 |     a: Int;
@@ -521,7 +466,6 @@ Line 1, col 8:
 
 exports[`grammar should fail item-fun-non-void-trailing-comma-no-params 1`] = `
 "<unknown>:1:14: Expected ")" or identifier
-Line 1, col 14:
 > 1 | fun function(,) : Int {
                    ^
   2 |     return 42;
@@ -530,7 +474,6 @@ Line 1, col 14:
 
 exports[`grammar should fail item-fun-void-trailing-comma-no-params 1`] = `
 "<unknown>:1:14: Expected ")" or identifier
-Line 1, col 14:
 > 1 | fun function(,) {}
                    ^
   2 | 
@@ -539,7 +482,6 @@ Line 1, col 14:
 
 exports[`grammar should fail item-fun-without-body 1`] = `
 "<unknown>:1:1: Abstract function doesn't have abstract modifier
-Line 1, col 1:
 > 1 | fun testFunc(): Int;
       ^~~~~~~~~~~~~~~~~~~~
 "
@@ -547,7 +489,6 @@ Line 1, col 1:
 
 exports[`grammar should fail item-native-fun-not-void-decl-trailing-comma-no-params 1`] = `
 "<unknown>:2:31: Expected ")" or identifier
-Line 2, col 31:
   1 | @name(native_name_2)
 > 2 | native testNativeFuncWithType(,): Int;
                                     ^
@@ -556,7 +497,6 @@ Line 2, col 31:
 
 exports[`grammar should fail item-native-fun-void-decl-trailing-comma-no-params 1`] = `
 "<unknown>:2:23: Expected ")" or identifier
-Line 2, col 23:
   1 | @name(native_name_1)
 > 2 | native testNativeFunc(,);
                             ^
@@ -565,7 +505,6 @@ Line 2, col 23:
 
 exports[`grammar should fail items-asm-fun-1 1`] = `
 "<unknown>:1:5: Expected ")", "->", or identifier
-Line 1, col 5:
 > 1 | asm(1 0) extends fun loadCoins(self: Slice): Int {
           ^
   2 |     LDVARUINT16
@@ -574,7 +513,6 @@ Line 1, col 5:
 
 exports[`grammar should fail items-asm-fun-2 1`] = `
 "<unknown>:1:9: Expected ")", "->", or identifier
-Line 1, col 9:
 > 1 | asm(c b 42) extends fun storeDict(b: Builder, c: Cell) {
               ^
   2 |     STDICT
@@ -583,7 +521,6 @@ Line 1, col 9:
 
 exports[`grammar should fail items-asm-fun-3 1`] = `
 "<unknown>:1:14: Expected digit
-Line 1, col 14:
 > 1 | asm(s len -> len 1 0) extends fun loadInt(self: Slice, len: Int): Int {
                    ^
   2 |     LDIX
@@ -592,7 +529,6 @@ Line 1, col 14:
 
 exports[`grammar should fail items-asm-fun-4 1`] = `
 "<unknown>:1:7: Expected digit
-Line 1, col 7:
 > 1 | asm(->) extends fun loadInt(self: Slice, len: Int): Int {
             ^
   2 |     LDIX
@@ -601,7 +537,6 @@ Line 1, col 7:
 
 exports[`grammar should fail items-asm-fun-5 1`] = `
 "<unknown>:3:5: Expected "@interface", "@name", "abstract", "asm", "const", "contract", "extends", "fun", "get", "inline", "message", "mutates", "override", "primitive", "struct", "trait", or "virtual"
-Line 3, col 5:
   2 |     { INC } : }
 > 3 |     5 }
           ^
@@ -611,7 +546,6 @@ Line 3, col 5:
 
 exports[`grammar should fail literal-dec-trailing-underscore 1`] = `
 "<unknown>:2:16: Expected digit
-Line 2, col 16:
   1 | fun test_fun(): Int {
 > 2 |     return 123_;
                      ^
@@ -621,7 +555,6 @@ Line 2, col 16:
 
 exports[`grammar should fail literal-double-underscore 1`] = `
 "<unknown>:2:20: Expected digit
-Line 2, col 20:
   1 | fun test_fun(): Int {
 > 2 |     return 123_123__123;
                          ^
@@ -631,7 +564,6 @@ Line 2, col 20:
 
 exports[`grammar should fail literal-hex-trailing-underscore 1`] = `
 "<unknown>:2:18: Expected hexadecimal digit
-Line 2, col 18:
   1 | fun test_fun(): Int {
 > 2 |     return 0x123_;
                        ^
@@ -641,7 +573,6 @@ Line 2, col 18:
 
 exports[`grammar should fail literal-no-underscore-after-0b 1`] = `
 "<unknown>:2:14: Expected "0" or "1"
-Line 2, col 14:
   1 | fun test_fun(): Int {
 > 2 |     return 0b_00101010;
                    ^
@@ -651,7 +582,6 @@ Line 2, col 14:
 
 exports[`grammar should fail literal-no-underscores-if-leading-zero 1`] = `
 "<unknown>:2:12: Numbers with leading zeroes cannot use underscores for JS compatibility
-Line 2, col 12:
   1 | fun test_fun(): Int {
 > 2 |     return 012_3;
                  ^~~~~
@@ -661,7 +591,6 @@ Line 2, col 12:
 
 exports[`grammar should fail literal-non-binary-digits 1`] = `
 "<unknown>:2:15: Expected "!!", "!=", "%", "&", "&&", "(", "*", "+", "-", ".", "/", "0", "1", ";", "<", "<<", "<=", "==", ">", ">=", ">>", "?", "^", "_", "|", "||", or "}"
-Line 2, col 15:
   1 | fun test_fun(): Int {
 > 2 |     return 0b123;
                     ^
@@ -671,7 +600,6 @@ Line 2, col 15:
 
 exports[`grammar should fail literal-underscore-after-leading-zero 1`] = `
 "<unknown>:2:12: Numbers with leading zeroes cannot use underscores for JS compatibility
-Line 2, col 12:
   1 | fun test_fun(): Int {
 > 2 |     return 0_123;
                  ^~~~~
@@ -681,7 +609,6 @@ Line 2, col 12:
 
 exports[`grammar should fail struct-double-semicolon 1`] = `
 "<unknown>:2:19: Expected "}" or identifier
-Line 2, col 19:
   1 | // too many semicolons
 > 2 | struct A { x: Int;; }
                         ^
@@ -691,7 +618,6 @@ Line 2, col 19:
 
 exports[`grammar should fail struct-missing-semicolon-between-fields 1`] = `
 "<unknown>:2:19: Expected ";", "=", "?", "as", or "}"
-Line 2, col 19:
   1 | // missing ; between fields
 > 2 | struct B { x: Int y: Int }
                         ^
@@ -701,7 +627,6 @@ Line 2, col 19:
 
 exports[`grammar should fail struct-missing-semicolon-between-fields-with-initializer 1`] = `
 "<unknown>:2:24: Expected "!!", "!=", "%", "&", "&&", "(", "*", "+", "-", ".", "/", ";", "<", "<<", "<=", "==", ">", ">=", ">>", "?", "^", "|", "||", or "}"
-Line 2, col 24:
   1 | // missing ; between fields
 > 2 | struct B { x: Int = 42 y: Int }
                              ^
@@ -711,7 +636,6 @@ Line 2, col 24:
 
 exports[`grammar should fail trait-const-abstract-with-initializer 1`] = `
 "<unknown>:5:3: Non-abstract constant has abstract modifier
-Line 5, col 3:
   4 | trait TestContract {
 > 5 |   abstract const Foo: Int = 42;
         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -721,7 +645,6 @@ Line 5, col 3:
 
 exports[`grammar should fail trait-empty-traits-list-with-keyword 1`] = `
 "<unknown>:1:17: Expected identifier
-Line 1, col 17:
 > 1 | trait Name with {}
                       ^
   2 | 
@@ -730,7 +653,6 @@ Line 1, col 17:
 
 exports[`grammar should fail trait-fun-non-void-trailing-comma-no-params 1`] = `
 "<unknown>:2:39: Expected ")" or identifier
-Line 2, col 39:
   1 | trait Test {
 > 2 |     abstract fun testAbstractWithType(,): Int;
                                             ^
@@ -740,7 +662,6 @@ Line 2, col 39:
 
 exports[`grammar should fail trait-fun-void-trailing-comma-no-params 1`] = `
 "<unknown>:2:31: Expected ")" or identifier
-Line 2, col 31:
   1 | trait Test {
 > 2 |     abstract fun testAbstract(,);
                                     ^
@@ -750,7 +671,6 @@ Line 2, col 31:
 
 exports[`grammar should fail trait-trailing-comma-empty-traits-list 1`] = `
 "<unknown>:1:16: Expected identifier or not identifier character
-Line 1, col 16:
 > 1 | trait Name with, {}
                      ^
   2 | 
@@ -759,7 +679,6 @@ Line 1, col 16:
 
 exports[`grammar should fail type-ident-msg-should-be-capitalized 1`] = `
 "<unknown>:1:14: Expected capitalized identifier
-Line 1, col 14:
 > 1 | message(123) foo {
                    ^
   2 |     signature: Slice;
@@ -768,7 +687,6 @@ Line 1, col 14:
 
 exports[`grammar should fail type-ident-struct-should-be-capitalized 1`] = `
 "<unknown>:1:8: Expected capitalized identifier
-Line 1, col 8:
 > 1 | struct lowercaseIdForType {
              ^
   2 |     a: Int;

--- a/src/grammar/prev/__snapshots__/grammar.spec.ts.snap
+++ b/src/grammar/prev/__snapshots__/grammar.spec.ts.snap
@@ -2,7 +2,6 @@
 
 exports[`grammar should fail abstract-const-without-modifier 1`] = `
 "<unknown>:2:5: Abstract constant doesn't have abstract modifier
-Line 2, col 5:
   1 | trait t {
 > 2 |     const c: Int;
           ^~~~~~~~~~~~~
@@ -12,7 +11,6 @@ Line 2, col 5:
 
 exports[`grammar should fail const-abstract-abstract 1`] = `
 "<unknown>:4:10: Duplicate constant attribute "abstract"
-Line 4, col 10:
   3 | 
 > 4 | abstract abstract const Foo: Int = 42;
                ^~~~~~~~
@@ -22,7 +20,6 @@ Line 4, col 10:
 
 exports[`grammar should fail const-override 1`] = `
 "<unknown>:4:1: Module-level constants do not support attributes
-Line 4, col 1:
   3 | 
 > 4 | override const Foo: Int = 42;
       ^~~~~~~~
@@ -32,7 +29,6 @@ Line 4, col 1:
 
 exports[`grammar should fail const-override-override 1`] = `
 "<unknown>:4:10: Duplicate constant attribute "override"
-Line 4, col 10:
   3 | 
 > 4 | override override const Foo: Int = 42;
                ^~~~~~~~
@@ -42,7 +38,6 @@ Line 4, col 10:
 
 exports[`grammar should fail const-override-virtual 1`] = `
 "<unknown>:4:1: Module-level constants do not support attributes
-Line 4, col 1:
   3 | 
 > 4 | override virtual const Foo: Int = 42;
       ^~~~~~~~
@@ -52,7 +47,6 @@ Line 4, col 1:
 
 exports[`grammar should fail const-virtual 1`] = `
 "<unknown>:4:1: Module-level constants do not support attributes
-Line 4, col 1:
   3 | 
 > 4 | virtual const Foo: Int = 42;
       ^~~~~~~
@@ -62,7 +56,6 @@ Line 4, col 1:
 
 exports[`grammar should fail const-virtual-override 1`] = `
 "<unknown>:4:1: Module-level constants do not support attributes
-Line 4, col 1:
   3 | 
 > 4 | virtual override const Foo: Int = 42;
       ^~~~~~~
@@ -72,7 +65,6 @@ Line 4, col 1:
 
 exports[`grammar should fail const-virtual-virtual 1`] = `
 "<unknown>:4:9: Duplicate constant attribute "virtual"
-Line 4, col 9:
   3 | 
 > 4 | virtual virtual const Foo: Int = 42;
               ^~~~~~~
@@ -83,7 +75,6 @@ Line 4, col 9:
 exports[`grammar should fail contract-const-abstract 1`] = `
 "<unknown>:5:26: Expected "="
 
-Line 5, col 26:
   4 | contract TestContract {
 > 5 |   abstract const Foo: Int;
                                ^
@@ -93,7 +84,6 @@ Line 5, col 26:
 
 exports[`grammar should fail contract-const-abstract-abstract 1`] = `
 "<unknown>:5:12: Duplicate constant attribute "abstract"
-Line 5, col 12:
   4 | contract TestContract {
 > 5 |   abstract abstract const Foo: Int = 42;
                  ^~~~~~~~
@@ -103,7 +93,6 @@ Line 5, col 12:
 
 exports[`grammar should fail contract-const-abstract-with-initializer 1`] = `
 "<unknown>:5:3: Non-abstract constant has abstract modifier
-Line 5, col 3:
   4 | contract TestContract {
 > 5 |   abstract const Foo: Int = 42;
         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -113,7 +102,6 @@ Line 5, col 3:
 
 exports[`grammar should fail contract-const-override-override 1`] = `
 "<unknown>:5:12: Duplicate constant attribute "override"
-Line 5, col 12:
   4 | contract TestContract {
 > 5 |   override override const Foo: Int = 42;
                  ^~~~~~~~
@@ -123,7 +111,6 @@ Line 5, col 12:
 
 exports[`grammar should fail contract-const-virtual-virtual 1`] = `
 "<unknown>:5:11: Duplicate constant attribute "virtual"
-Line 5, col 11:
   4 | contract TestContract {
 > 5 |   virtual virtual const Foo: Int = 42;
                 ^~~~~~~
@@ -134,7 +121,6 @@ Line 5, col 11:
 exports[`grammar should fail contract-empty-traits-list-with-keyword 1`] = `
 "<unknown>:1:20: Expected "_", "A".."Z", or "a".."z"
 
-Line 1, col 20:
 > 1 | contract Name with {}
                          ^
   2 | 
@@ -144,7 +130,6 @@ Line 1, col 20:
 exports[`grammar should fail contract-getter-parens-no-method-id 1`] = `
 "<unknown>:2:9: Expected "\\"", "initOf", "null", "_", "A".."Z", "a".."z", "false", "true", "0", "1".."9", "0O", "0o", "0B", "0b", "0X", "0x", "(", "~", "!", "+", or "-"
 
-Line 2, col 9:
   1 | contract Test {
 > 2 |     get() fun test(): Int {
               ^
@@ -154,7 +139,6 @@ Line 2, col 9:
 
 exports[`grammar should fail contract-init-trailing-comma-empty-params 1`] = `
 "<unknown>:2:10: Empty parameter list should not have a dangling comma
-Line 2, col 10:
   1 | contract Name {
 > 2 |     init(,) {}
                ^
@@ -165,7 +149,6 @@ Line 2, col 10:
 exports[`grammar should fail contract-trailing-comma-empty-traits-list 1`] = `
 "<unknown>:1:19: Expected "_", "A".."Z", or "a".."z"
 
-Line 1, col 19:
 > 1 | contract Name with, {}
                         ^
   2 | 
@@ -175,7 +158,6 @@ Line 1, col 19:
 exports[`grammar should fail contract-with-imports 1`] = `
 "<unknown>:6:1: Expected end of input, "trait", "contract", "message", "struct", "const", "@name", "asm", "fun", or "primitive"
 
-Line 6, col 1:
   5 | // all imports must be at the very top of the file
 > 6 | import "@stdlib/not-allowed";
       ^
@@ -185,7 +167,6 @@ Line 6, col 1:
 
 exports[`grammar should fail destructuring-duplicate-source-id 1`] = `
 "<unknown>:15:19: Duplicate field destructuring: "a"
-Line 15, col 19:
   14 |     let s = S{ a: 1, b: 2, c: 3 };
 > 15 |     let S { a: x, a: y } = s;
                          ^~~~
@@ -195,7 +176,6 @@ Line 15, col 19:
 
 exports[`grammar should fail expr-fun-call-trailing-comma-no-args 1`] = `
 "<unknown>:6:14: Empty parameter list should not have a dangling comma
-Line 6, col 14:
   5 | fun b(): Int {
 > 6 |     return a(,);
                    ^
@@ -205,7 +185,6 @@ Line 6, col 14:
 
 exports[`grammar should fail expr-method-call-trailing-comma-no-args 1`] = `
 "<unknown>:2:24: Empty parameter list should not have a dangling comma
-Line 2, col 24:
   1 | fun another() {
 > 2 |     return 42.toString(,);
                              ^
@@ -216,7 +195,6 @@ Line 2, col 24:
 exports[`grammar should fail funcid-native-fun-arith-operator 1`] = `
 "<unknown>:1:7: Expected not a funcInvalidId or "\`"
 
-Line 1, col 7:
 > 1 | @name(/)
             ^
   2 | native idTest();
@@ -226,7 +204,6 @@ Line 1, col 7:
 exports[`grammar should fail funcid-native-fun-assign-operator 1`] = `
 "<unknown>:1:7: Expected not a funcInvalidId or "\`"
 
-Line 1, col 7:
 > 1 | @name(^>>=)
             ^
   2 | native idTest();
@@ -236,7 +213,6 @@ Line 1, col 7:
 exports[`grammar should fail funcid-native-fun-bitwise-operator 1`] = `
 "<unknown>:1:8: Expected not (a whiteSpace or "(" or ")" or "[" or "]" or "," or "." or ";" or "~") or "\`"
 
-Line 1, col 8:
 > 1 | @name(~)
              ^
   2 | native idTest();
@@ -246,7 +222,6 @@ Line 1, col 8:
 exports[`grammar should fail funcid-native-fun-comma 1`] = `
 "<unknown>:1:19: Expected ")"
 
-Line 1, col 19:
 > 1 | @name(send_message,then_terminate)
                         ^
   2 | native idTest();
@@ -256,7 +231,6 @@ Line 1, col 19:
 exports[`grammar should fail funcid-native-fun-comparison-operator 1`] = `
 "<unknown>:1:7: Expected not a funcInvalidId or "\`"
 
-Line 1, col 7:
 > 1 | @name(<=>)
             ^
   2 | native idTest();
@@ -266,7 +240,6 @@ Line 1, col 7:
 exports[`grammar should fail funcid-native-fun-control-keyword 1`] = `
 "<unknown>:1:7: Expected not a funcInvalidId or "\`"
 
-Line 1, col 7:
 > 1 | @name(elseifnot)
             ^
   2 | native idTest();
@@ -276,7 +249,6 @@ Line 1, col 7:
 exports[`grammar should fail funcid-native-fun-delimiter 1`] = `
 "<unknown>:1:7: Expected not a funcInvalidId or "\`"
 
-Line 1, col 7:
 > 1 | @name([)
             ^
   2 | native idTest();
@@ -286,7 +258,6 @@ Line 1, col 7:
 exports[`grammar should fail funcid-native-fun-directive 1`] = `
 "<unknown>:1:7: Expected not a funcInvalidId or "\`"
 
-Line 1, col 7:
 > 1 | @name(#include)
             ^
   2 | native idTest();
@@ -296,7 +267,6 @@ Line 1, col 7:
 exports[`grammar should fail funcid-native-fun-dot 1`] = `
 "<unknown>:1:10: Expected ")"
 
-Line 1, col 10:
 > 1 | @name(msg.sender)
                ^
   2 | native idTest();
@@ -306,7 +276,6 @@ Line 1, col 10:
 exports[`grammar should fail funcid-native-fun-keyword 1`] = `
 "<unknown>:1:7: Expected not a funcInvalidId or "\`"
 
-Line 1, col 7:
 > 1 | @name(global)
             ^
   2 | native idTest();
@@ -316,7 +285,6 @@ Line 1, col 7:
 exports[`grammar should fail funcid-native-fun-multiline-comments 1`] = `
 "<unknown>:1:7: Expected not ("\\"" or "{-")
 
-Line 1, col 7:
 > 1 | @name({-aaa-})
             ^
   2 | native idTest();
@@ -326,7 +294,6 @@ Line 1, col 7:
 exports[`grammar should fail funcid-native-fun-number 1`] = `
 "<unknown>:1:7: Expected not a funcInvalidId or "\`"
 
-Line 1, col 7:
 > 1 | @name(123)
             ^
   2 | native idTest();
@@ -336,7 +303,6 @@ Line 1, col 7:
 exports[`grammar should fail funcid-native-fun-number-decimal 1`] = `
 "<unknown>:1:7: Expected not a funcInvalidId or "\`"
 
-Line 1, col 7:
 > 1 | @name(0)
             ^
   2 | native idTest();
@@ -346,7 +312,6 @@ Line 1, col 7:
 exports[`grammar should fail funcid-native-fun-number-hexadecimal 1`] = `
 "<unknown>:1:7: Expected not a funcInvalidId or "\`"
 
-Line 1, col 7:
 > 1 | @name(0x0)
             ^
   2 | native idTest();
@@ -356,7 +321,6 @@ Line 1, col 7:
 exports[`grammar should fail funcid-native-fun-number-hexadecimal-2 1`] = `
 "<unknown>:1:7: Expected not a funcInvalidId or "\`"
 
-Line 1, col 7:
 > 1 | @name(0xDEADBEEF)
             ^
   2 | native idTest();
@@ -366,7 +330,6 @@ Line 1, col 7:
 exports[`grammar should fail funcid-native-fun-number-neg-decimal 1`] = `
 "<unknown>:1:7: Expected not a funcInvalidId or "\`"
 
-Line 1, col 7:
 > 1 | @name(-1)
             ^
   2 | native idTest();
@@ -376,7 +339,6 @@ Line 1, col 7:
 exports[`grammar should fail funcid-native-fun-number-neg-hexadecimal 1`] = `
 "<unknown>:1:7: Expected not a funcInvalidId or "\`"
 
-Line 1, col 7:
 > 1 | @name(-0x0)
             ^
   2 | native idTest();
@@ -386,7 +348,6 @@ Line 1, col 7:
 exports[`grammar should fail funcid-native-fun-only-underscore 1`] = `
 "<unknown>:1:7: Expected not a funcInvalidId or "\`"
 
-Line 1, col 7:
 > 1 | @name(_)
             ^
   2 | native idTest();
@@ -396,7 +357,6 @@ Line 1, col 7:
 exports[`grammar should fail funcid-native-fun-parens 1`] = `
 "<unknown>:1:11: Expected ")"
 
-Line 1, col 11:
 > 1 | @name(take(first)Entry)
                 ^
   2 | native idTest();
@@ -406,7 +366,6 @@ Line 1, col 11:
 exports[`grammar should fail funcid-native-fun-semicolons 1`] = `
 "<unknown>:1:9: Expected ")"
 
-Line 1, col 9:
 > 1 | @name(pa;;in"\`aaa\`")
               ^
   2 | native idTest();
@@ -416,7 +375,6 @@ Line 1, col 9:
 exports[`grammar should fail funcid-native-fun-space 1`] = `
 "<unknown>:1:11: Expected ")"
 
-Line 1, col 11:
 > 1 | @name(foo foo)
                 ^
   2 | native idTest();
@@ -426,7 +384,6 @@ Line 1, col 11:
 exports[`grammar should fail funcid-native-fun-square-brackets 1`] = `
 "<unknown>:1:11: Expected ")"
 
-Line 1, col 11:
 > 1 | @name(take[some]entry)
                 ^
   2 | native idTest();
@@ -436,7 +393,6 @@ Line 1, col 11:
 exports[`grammar should fail funcid-native-fun-string 1`] = `
 "<unknown>:1:7: Expected not ("\\"" or "{-")
 
-Line 1, col 7:
 > 1 | @name("not_a_string)
             ^
   2 | native idTest();
@@ -446,7 +402,6 @@ Line 1, col 7:
 exports[`grammar should fail funcid-native-fun-type-keyword 1`] = `
 "<unknown>:1:7: Expected not a funcInvalidId or "\`"
 
-Line 1, col 7:
 > 1 | @name(->)
             ^
   2 | native idTest();
@@ -456,7 +411,6 @@ Line 1, col 7:
 exports[`grammar should fail funcid-native-fun-unclosed-parens 1`] = `
 "<unknown>:1:9: Expected ")"
 
-Line 1, col 9:
 > 1 | @name(aa(bb)
               ^
   2 | native idTest();
@@ -466,7 +420,6 @@ Line 1, col 9:
 exports[`grammar should fail ident-cannot-be-if-reserved-word 1`] = `
 "<unknown>:2:9: Expected "A".."Z" or not a reservedWord
 
-Line 2, col 9:
   1 | fun hello(): Int {
 > 2 |     let if: Int = 0;
               ^
@@ -476,7 +429,6 @@ Line 2, col 9:
 
 exports[`grammar should fail ident-contract-cannot-start-with-__gen 1`] = `
 "<unknown>:1:10: Variable name cannot start with "__gen"
-Line 1, col 10:
 > 1 | contract __gen_a {
                ^~~~~~~
   2 | 
@@ -485,7 +437,6 @@ Line 1, col 10:
 
 exports[`grammar should fail ident-fun-cannot-start-with-__gen 1`] = `
 "<unknown>:1:5: Variable name cannot start with "__gen"
-Line 1, col 5:
 > 1 | fun __gen_hello(): Int {
           ^~~~~~~~~~~
   2 |     
@@ -494,7 +445,6 @@ Line 1, col 5:
 
 exports[`grammar should fail ident-fun-param-cannot-start-with-__gen 1`] = `
 "<unknown>:1:10: Variable name cannot start with "__gen"
-Line 1, col 10:
 > 1 | fun main(__gen: Int): Int {
                ^~~~~
   2 |     return 0;
@@ -503,7 +453,6 @@ Line 1, col 10:
 
 exports[`grammar should fail ident-fun-param-cannot-start-with-__tact 1`] = `
 "<unknown>:2:11: Variable name cannot start with "__tact"
-Line 2, col 11:
   1 | contract A {
 > 2 |     fun b(__tact: Int) {
                 ^~~~~~
@@ -513,7 +462,6 @@ Line 2, col 11:
 
 exports[`grammar should fail ident-init-param-cannot-start-with-__tact 1`] = `
 "<unknown>:2:10: Variable name cannot start with "__tact"
-Line 2, col 10:
   1 | contract A {
 > 2 |     init(__tact: Int) {
                ^~~~~~
@@ -523,7 +471,6 @@ Line 2, col 10:
 
 exports[`grammar should fail ident-let-cannot-start-with-__gen 1`] = `
 "<unknown>:2:9: Variable name cannot start with "__gen"
-Line 2, col 9:
   1 | fun hello(): Int {
 > 2 |     let __gen_a: Int = 0;
               ^~~~~~~
@@ -533,7 +480,6 @@ Line 2, col 9:
 
 exports[`grammar should fail ident-let-cannot-start-with-__tact 1`] = `
 "<unknown>:2:9: Variable name cannot start with "__tact"
-Line 2, col 9:
   1 | fun hello(): Int {
 > 2 |     let __tact_a: Int = 0;
               ^~~~~~~~
@@ -544,7 +490,6 @@ Line 2, col 9:
 exports[`grammar should fail ident-struct-cannot-start-with-__gen 1`] = `
 "<unknown>:1:8: Expected "A".."Z"
 
-Line 1, col 8:
 > 1 | struct __genA {
              ^
   2 |     a: Int;
@@ -553,7 +498,6 @@ Line 1, col 8:
 
 exports[`grammar should fail item-fun-non-void-trailing-comma-no-params 1`] = `
 "<unknown>:1:14: Empty parameter list should not have a dangling comma
-Line 1, col 14:
 > 1 | fun function(,) : Int {
                    ^
   2 |     return 42;
@@ -562,7 +506,6 @@ Line 1, col 14:
 
 exports[`grammar should fail item-fun-void-trailing-comma-no-params 1`] = `
 "<unknown>:1:14: Empty parameter list should not have a dangling comma
-Line 1, col 14:
 > 1 | fun function(,) {}
                    ^
   2 | 
@@ -572,7 +515,6 @@ Line 1, col 14:
 exports[`grammar should fail item-fun-without-body 1`] = `
 "<unknown>:1:20: Expected "{"
 
-Line 1, col 20:
 > 1 | fun testFunc(): Int;
                          ^
 "
@@ -580,7 +522,6 @@ Line 1, col 20:
 
 exports[`grammar should fail item-native-fun-not-void-decl-trailing-comma-no-params 1`] = `
 "<unknown>:2:31: Empty parameter list should not have a dangling comma
-Line 2, col 31:
   1 | @name(native_name_2)
 > 2 | native testNativeFuncWithType(,): Int;
                                     ^
@@ -589,7 +530,6 @@ Line 2, col 31:
 
 exports[`grammar should fail item-native-fun-void-decl-trailing-comma-no-params 1`] = `
 "<unknown>:2:23: Empty parameter list should not have a dangling comma
-Line 2, col 23:
   1 | @name(native_name_1)
 > 2 | native testNativeFunc(,);
                             ^
@@ -599,7 +539,6 @@ Line 2, col 23:
 exports[`grammar should fail items-asm-fun-1 1`] = `
 "<unknown>:1:5: Expected ")"
 
-Line 1, col 5:
 > 1 | asm(1 0) extends fun loadCoins(self: Slice): Int {
           ^
   2 |     LDVARUINT16
@@ -609,7 +548,6 @@ Line 1, col 5:
 exports[`grammar should fail items-asm-fun-2 1`] = `
 "<unknown>:1:9: Expected ")", "->", "_", "A".."Z", or "a".."z"
 
-Line 1, col 9:
 > 1 | asm(c b 42) extends fun storeDict(b: Builder, c: Cell) {
               ^
   2 |     STDICT
@@ -619,7 +557,6 @@ Line 1, col 9:
 exports[`grammar should fail items-asm-fun-3 1`] = `
 "<unknown>:1:14: Expected "0" or "1".."9"
 
-Line 1, col 14:
 > 1 | asm(s len -> len 1 0) extends fun loadInt(self: Slice, len: Int): Int {
                    ^
   2 |     LDIX
@@ -629,7 +566,6 @@ Line 1, col 14:
 exports[`grammar should fail items-asm-fun-4 1`] = `
 "<unknown>:1:7: Expected "0" or "1".."9"
 
-Line 1, col 7:
 > 1 | asm(->) extends fun loadInt(self: Slice, len: Int): Int {
             ^
   2 |     LDIX
@@ -639,7 +575,6 @@ Line 1, col 7:
 exports[`grammar should fail items-asm-fun-5 1`] = `
 "<unknown>:3:5: Expected end of input, "trait", "contract", "message", "struct", "const", "@name", "asm", "fun", or "primitive"
 
-Line 3, col 5:
   2 |     { INC } : }
 > 3 |     5 }
           ^
@@ -650,7 +585,6 @@ Line 3, col 5:
 exports[`grammar should fail literal-dec-trailing-underscore 1`] = `
 "<unknown>:2:16: Expected a digit
 
-Line 2, col 16:
   1 | fun test_fun(): Int {
 > 2 |     return 123_;
                      ^
@@ -661,7 +595,6 @@ Line 2, col 16:
 exports[`grammar should fail literal-double-underscore 1`] = `
 "<unknown>:2:20: Expected a digit
 
-Line 2, col 20:
   1 | fun test_fun(): Int {
 > 2 |     return 123_123__123;
                          ^
@@ -672,7 +605,6 @@ Line 2, col 20:
 exports[`grammar should fail literal-hex-trailing-underscore 1`] = `
 "<unknown>:2:18: Expected a hexadecimal digit
 
-Line 2, col 18:
   1 | fun test_fun(): Int {
 > 2 |     return 0x123_;
                        ^
@@ -683,7 +615,6 @@ Line 2, col 18:
 exports[`grammar should fail literal-no-underscore-after-0b 1`] = `
 "<unknown>:2:14: Expected "1" or "0"
 
-Line 2, col 14:
   1 | fun test_fun(): Int {
 > 2 |     return 0b_00101010;
                    ^
@@ -694,7 +625,6 @@ Line 2, col 14:
 exports[`grammar should fail literal-no-underscores-if-leading-zero 1`] = `
 "<unknown>:2:15: Expected "}" or ";"
 
-Line 2, col 15:
   1 | fun test_fun(): Int {
 > 2 |     return 012_3;
                     ^
@@ -705,7 +635,6 @@ Line 2, col 15:
 exports[`grammar should fail literal-non-binary-digits 1`] = `
 "<unknown>:2:15: Expected "}" or ";"
 
-Line 2, col 15:
   1 | fun test_fun(): Int {
 > 2 |     return 0b123;
                     ^
@@ -716,7 +645,6 @@ Line 2, col 15:
 exports[`grammar should fail literal-underscore-after-leading-zero 1`] = `
 "<unknown>:2:13: Expected "}" or ";"
 
-Line 2, col 13:
   1 | fun test_fun(): Int {
 > 2 |     return 0_123;
                   ^
@@ -727,7 +655,6 @@ Line 2, col 13:
 exports[`grammar should fail struct-double-semicolon 1`] = `
 "<unknown>:2:19: Expected "}"
 
-Line 2, col 19:
   1 | // too many semicolons
 > 2 | struct A { x: Int;; }
                         ^
@@ -738,7 +665,6 @@ Line 2, col 19:
 exports[`grammar should fail struct-missing-semicolon-between-fields 1`] = `
 "<unknown>:2:19: Expected "}", ";", "=", "as", or "?"
 
-Line 2, col 19:
   1 | // missing ; between fields
 > 2 | struct B { x: Int y: Int }
                         ^
@@ -749,7 +675,6 @@ Line 2, col 19:
 exports[`grammar should fail struct-missing-semicolon-between-fields-with-initializer 1`] = `
 "<unknown>:2:24: Expected "}", ";", ".", "!!", "%", "/", "*", ">>", "<<", "-", "+", "==", "!=", "<=", "<", ">=", ">", "^", "&", "&&", "|", "?", or "||"
 
-Line 2, col 24:
   1 | // missing ; between fields
 > 2 | struct B { x: Int = 42 y: Int }
                              ^
@@ -759,7 +684,6 @@ Line 2, col 24:
 
 exports[`grammar should fail trait-const-abstract-with-initializer 1`] = `
 "<unknown>:5:3: Non-abstract constant has abstract modifier
-Line 5, col 3:
   4 | trait TestContract {
 > 5 |   abstract const Foo: Int = 42;
         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -770,7 +694,6 @@ Line 5, col 3:
 exports[`grammar should fail trait-empty-traits-list-with-keyword 1`] = `
 "<unknown>:1:17: Expected "_", "A".."Z", or "a".."z"
 
-Line 1, col 17:
 > 1 | trait Name with {}
                       ^
   2 | 
@@ -779,7 +702,6 @@ Line 1, col 17:
 
 exports[`grammar should fail trait-fun-non-void-trailing-comma-no-params 1`] = `
 "<unknown>:2:39: Empty parameter list should not have a dangling comma
-Line 2, col 39:
   1 | trait Test {
 > 2 |     abstract fun testAbstractWithType(,): Int;
                                             ^
@@ -789,7 +711,6 @@ Line 2, col 39:
 
 exports[`grammar should fail trait-fun-void-trailing-comma-no-params 1`] = `
 "<unknown>:2:31: Empty parameter list should not have a dangling comma
-Line 2, col 31:
   1 | trait Test {
 > 2 |     abstract fun testAbstract(,);
                                     ^
@@ -800,7 +721,6 @@ Line 2, col 31:
 exports[`grammar should fail trait-trailing-comma-empty-traits-list 1`] = `
 "<unknown>:1:16: Expected "_", "A".."Z", or "a".."z"
 
-Line 1, col 16:
 > 1 | trait Name with, {}
                      ^
   2 | 
@@ -810,7 +730,6 @@ Line 1, col 16:
 exports[`grammar should fail type-ident-msg-should-be-capitalized 1`] = `
 "<unknown>:1:14: Expected "A".."Z"
 
-Line 1, col 14:
 > 1 | message(123) foo {
                    ^
   2 |     signature: Slice;
@@ -820,7 +739,6 @@ Line 1, col 14:
 exports[`grammar should fail type-ident-struct-should-be-capitalized 1`] = `
 "<unknown>:1:8: Expected "A".."Z"
 
-Line 1, col 8:
 > 1 | struct lowercaseIdForType {
              ^
   2 |     a: Int;

--- a/src/grammar/src-info.ts
+++ b/src/grammar/src-info.ts
@@ -211,9 +211,7 @@ const getErrorPrinter = ({
             return `${prefix} ${paddedLineNum} ${text}`;
         });
 
-        // Add header and concatenate lines
-        const header = `Line ${firstLineNum + 1}, col ${(lines[firstLineNum]?.startOfError ?? 0) + 1}:`;
-        return [header, ...paddedLines].join("\n") + "\n";
+        return paddedLines.join("\n") + "\n";
     };
 
     const getLineAndColumn = (str: string, range: Range) => {

--- a/src/types/__snapshots__/resolveDescriptors.spec.ts.snap
+++ b/src/types/__snapshots__/resolveDescriptors.spec.ts.snap
@@ -2,7 +2,6 @@
 
 exports[`resolveDescriptors should fail descriptors for asm-fun-shuffle-arg-duplicate 1`] = `
 "<unknown>:3:1: asm argument rearrangement cannot have duplicates
-Line 3, col 1:
   2 | 
 > 3 | asm(x x) fun foo(x: Int) {
       ^~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -12,7 +11,6 @@ Line 3, col 1:
 
 exports[`resolveDescriptors should fail descriptors for asm-fun-shuffle-arg-missing-and-non-existent-param 1`] = `
 "<unknown>:3:1: asm argument rearrangement must mention all function parameters
-Line 3, col 1:
   2 | 
 > 3 | asm(x extra) fun foo(x: Int, y: Int) {
       ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -22,7 +20,6 @@ Line 3, col 1:
 
 exports[`resolveDescriptors should fail descriptors for asm-fun-shuffle-arg-missing-param 1`] = `
 "<unknown>:3:1: asm argument rearrangement must mention all function parameters
-Line 3, col 1:
   2 | 
 > 3 | asm(x) fun foo(x: Int, y: Int) {
       ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -32,7 +29,6 @@ Line 3, col 1:
 
 exports[`resolveDescriptors should fail descriptors for asm-fun-shuffle-arg-non-existent-param 1`] = `
 "<unknown>:3:1: asm argument rearrangement must mention only function parameters
-Line 3, col 1:
   2 | 
 > 3 | asm(x extra) fun foo(x: Int) {
       ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -42,7 +38,6 @@ Line 3, col 1:
 
 exports[`resolveDescriptors should fail descriptors for asm-fun-shuffle-ret-duplicate 1`] = `
 "<unknown>:3:1: asm return rearrangement cannot have duplicates
-Line 3, col 1:
   2 | 
 > 3 | asm(-> 0 0) fun foo(x: Int): Int {
       ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -52,7 +47,6 @@ Line 3, col 1:
 
 exports[`resolveDescriptors should fail descriptors for asm-fun-shuffle-ret-missing-position 1`] = `
 "<unknown>:4:1: asm return rearrangement must mention all return position numbers: [0..1]
-Line 4, col 1:
   3 | 
 > 4 | asm(-> 0) fun foo(x: Int, y: Int): Pair {
       ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -62,7 +56,6 @@ Line 4, col 1:
 
 exports[`resolveDescriptors should fail descriptors for asm-fun-shuffle-ret-non-existent-position 1`] = `
 "<unknown>:4:1: asm return rearrangement must mention only valid return position numbers: [0..1]
-Line 4, col 1:
   3 | 
 > 4 | asm(-> 2 1 0) fun foo(x: Int, y: Int): Pair {
       ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -72,7 +65,6 @@ Line 4, col 1:
 
 exports[`resolveDescriptors should fail descriptors for const-decl-default-field-wrong-initializer-type copy 1`] = `
 "<unknown>:4:17: Constant "C" has declared type "Bool", but its initializer has incompatible type "Int"
-Line 4, col 17:
   3 | 
 > 4 | const C: Bool = 42;
                       ^~
@@ -82,7 +74,6 @@ Line 4, col 17:
 
 exports[`resolveDescriptors should fail descriptors for const-eval-overflow 1`] = `
 "<unknown>:8:26: Cannot evaluate expression to a constant: the number of bits shifted ('-1073741824') must be within [0..256] range
-Line 8, col 26:
   7 | 
 > 8 | const a: Int = 1 + (1 >> -1073741824);
                                ^~~~~~~~~~~
@@ -92,7 +83,6 @@ Line 8, col 26:
 
 exports[`resolveDescriptors should fail descriptors for contract-bounced-receiver-int 1`] = `
 "<unknown>:17:3: Bounce receive function can only accept bounced message, message or Slice
-Line 17, col 3:
   16 |   
 > 17 |   bounced(src: Int) {
          ^~~~~~~~~~~~~~~~~~~
@@ -102,7 +92,6 @@ Line 17, col 3:
 
 exports[`resolveDescriptors should fail descriptors for contract-bounced-receiver-missing-type-1 1`] = `
 "<unknown>:2:14: Unknown bounced receiver parameter type: "A"
-Line 2, col 14:
   1 | contract Test {
 > 2 |   bounced(a: A) {}
                    ^
@@ -112,7 +101,6 @@ Line 2, col 14:
 
 exports[`resolveDescriptors should fail descriptors for contract-bounced-receiver-missing-type-2 1`] = `
 "<unknown>:2:14: Unknown bounced receiver parameter type: "A"
-Line 2, col 14:
   1 | contract Test {
 > 2 |   bounced(a: bounced<A>) {}
                    ^~~~~~~~~~
@@ -122,7 +110,6 @@ Line 2, col 14:
 
 exports[`resolveDescriptors should fail descriptors for contract-bounced-storage-var 1`] = `
 "<unknown>:15:3: bounced<A> is a runtime only type and can't be used as field
-Line 15, col 3:
   14 | contract Test {
 > 15 |   src: bounced<A>;
          ^~~~~~~~~~~~~~~
@@ -132,7 +119,6 @@ Line 15, col 3:
 
 exports[`resolveDescriptors should fail descriptors for contract-const-decl-default-field-wrong-initializer-type 1`] = `
 "<unknown>:5:21: Constant "C" has declared type "Bool", but its initializer has incompatible type "Int"
-Line 5, col 21:
   4 | contract Test {
 > 5 |     const C: Bool = 42;
                           ^~
@@ -142,7 +128,6 @@ Line 5, col 21:
 
 exports[`resolveDescriptors should fail descriptors for contract-const-override-virtual-no-keyword 1`] = `
 "<unknown>:9:3: Constant "Foo" is defined as virtual in trait "T": you are probably missing "override" keyword
-Line 9, col 3:
    8 | contract TestContract with T {
 >  9 |   const Foo: Int = 42;
          ^~~~~~~~~~~~~~~~~~~~
@@ -152,7 +137,6 @@ Line 9, col 3:
 
 exports[`resolveDescriptors should fail descriptors for contract-decl-remainder-in-the-middle 1`] = `
 "<unknown>:8:5: The "remainder" field can only be the last field of the contract
-Line 8, col 5:
   7 |     a: Int = 0;
 > 8 |     s: Cell as remaining;
           ^~~~~~~~~~~~~~~~~~~~
@@ -162,7 +146,6 @@ Line 8, col 5:
 
 exports[`resolveDescriptors should fail descriptors for contract-does-not-override-abstract-const 1`] = `
 "<unknown>:8:1: Trait "T" requires constant "Foo"
-Line 8, col 1:
   7 | 
 > 8 | contract TestContract with T {
       ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -172,7 +155,6 @@ Line 8, col 1:
 
 exports[`resolveDescriptors should fail descriptors for contract-does-not-override-abstract-getter 1`] = `
 "<unknown>:8:1: Trait "T" requires function "getter"
-Line 8, col 1:
   7 | 
 > 8 | contract TestContract with T {
       ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -182,7 +164,6 @@ Line 8, col 1:
 
 exports[`resolveDescriptors should fail descriptors for contract-duplicate-bounced-fallback 1`] = `
 "<unknown>:24:3: Fallback bounce receive function already exists
-Line 24, col 3:
   23 |   
 > 24 |   bounced(msg: Slice) {
          ^~~~~~~~~~~~~~~~~~~~~
@@ -192,7 +173,6 @@ Line 24, col 3:
 
 exports[`resolveDescriptors should fail descriptors for contract-duplicate-bounced1 1`] = `
 "<unknown>:24:3: Bounce receive function for "A" already exists
-Line 24, col 3:
   23 |   
 > 24 |   bounced(msg: bounced<A>) {
          ^~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -202,7 +182,6 @@ Line 24, col 3:
 
 exports[`resolveDescriptors should fail descriptors for contract-duplicate-bounced2 1`] = `
 "<unknown>:7:13: Bounce receive function for "Msg" already exists
-Line 7, col 13:
   6 |     bounced(msg: Msg) { }
 > 7 |     bounced(msg: Msg) { }
                   ^~~~~~~~
@@ -212,7 +191,6 @@ Line 7, col 13:
 
 exports[`resolveDescriptors should fail descriptors for contract-duplicate-external 1`] = `
 "<unknown>:7:14: Receive function for "Msg" already exists
-Line 7, col 14:
   6 |     external(msg: Msg) { }
 > 7 |     external(msg: Msg) { }
                    ^~~~~~~~
@@ -222,7 +200,6 @@ Line 7, col 14:
 
 exports[`resolveDescriptors should fail descriptors for contract-duplicate-external-fallback 1`] = `
 "<unknown>:20:5: Empty receive function already exists
-Line 20, col 5:
   19 | 
 > 20 |     external() {
            ^~~~~~~~~~~~
@@ -232,7 +209,6 @@ Line 20, col 5:
 
 exports[`resolveDescriptors should fail descriptors for contract-duplicate-init 1`] = `
 "<unknown>:13:5: Init function already exists
-Line 13, col 5:
   12 | 
 > 13 |     init(a: Bool) {
            ^~~~~~~~~~~~~~~
@@ -242,7 +218,6 @@ Line 13, col 5:
 
 exports[`resolveDescriptors should fail descriptors for contract-duplicate-receiver 1`] = `
 "<unknown>:7:13: Receive function for "Msg" already exists
-Line 7, col 13:
   6 |     receive(msg: Msg) { }
 > 7 |     receive(msg: Msg) { }
                   ^~~~~~~~
@@ -252,7 +227,6 @@ Line 7, col 13:
 
 exports[`resolveDescriptors should fail descriptors for contract-duplicate-storage-var 1`] = `
 "<unknown>:11:3: Field "b" already exists
-Line 11, col 3:
   10 |   b: Int;
 > 11 |   b: Int;
          ^~~~~~
@@ -262,7 +236,6 @@ Line 11, col 3:
 
 exports[`resolveDescriptors should fail descriptors for contract-duplicates-in-trait-list 1`] = `
 "<unknown>:7:1: The list of inherited traits for contract "Test" has duplicates
-Line 7, col 1:
   6 | 
 > 7 | contract Test with Foo, Foo { }
       ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -272,7 +245,6 @@ Line 7, col 1:
 
 exports[`resolveDescriptors should fail descriptors for contract-getter-override-virtual-no-keyword 1`] = `
 "<unknown>:9:3: Function "getter" is defined as virtual in trait "T": you are probably missing "override" keyword
-Line 9, col 3:
    8 | contract TestContract with T {
 >  9 |   get fun getter(): Int { return 43 }
          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -282,7 +254,6 @@ Line 9, col 3:
 
 exports[`resolveDescriptors should fail descriptors for contract-missing-type 1`] = `
 "<unknown>:12:23: Type "Point" not found
-Line 12, col 23:
   11 |     }
 > 12 |     get fun hello2(): Point {
                              ^~~~~
@@ -292,7 +263,6 @@ Line 12, col 23:
 
 exports[`resolveDescriptors should fail descriptors for contract-receiver-int 1`] = `
 "<unknown>:13:3: Receive function can only accept message, Slice or String
-Line 13, col 3:
   12 | contract Pair {
 > 13 |   receive(src: Int) {
          ^~~~~~~~~~~~~~~~~~~
@@ -302,7 +272,6 @@ Line 13, col 3:
 
 exports[`resolveDescriptors should fail descriptors for contract-receiver-optional-msg 1`] = `
 "<unknown>:13:3: Receive function can only accept non-optional message types
-Line 13, col 3:
   12 | contract Pair {
 > 13 |   receive(src: B?) {
          ^~~~~~~~~~~~~~~~~~
@@ -312,7 +281,6 @@ Line 13, col 3:
 
 exports[`resolveDescriptors should fail descriptors for contract-receiver-struct 1`] = `
 "<unknown>:13:3: Receive function can only accept message
-Line 13, col 3:
   12 | contract Pair {
 > 13 |   receive(src: B) {
          ^~~~~~~~~~~~~~~~~
@@ -322,7 +290,6 @@ Line 13, col 3:
 
 exports[`resolveDescriptors should fail descriptors for contract-without-as-typed-field-inherited-with-it 1`] = `
 "<unknown>:10:5: Trait "Foo" requires field "f" of type "Int", but "Int as coins" given
-Line 10, col 5:
    9 | contract SomeContract with Foo {
 > 10 |     f: Int as coins;
            ^~~~~~~~~~~~~~~
@@ -332,7 +299,6 @@ Line 10, col 5:
 
 exports[`resolveDescriptors should fail descriptors for expr-bitwise-not-bool-in-const1 1`] = `
 "<unknown>:4:16: Invalid type "Bool" for unary operator "~"
-Line 4, col 16:
   3 | 
 > 4 | const a: Int = ~ true;
                      ^~~~~~
@@ -341,7 +307,6 @@ Line 4, col 16:
 
 exports[`resolveDescriptors should fail descriptors for expr-bitwise-not-bool-in-const2 1`] = `
 "<unknown>:4:17: Invalid type "Bool" for unary operator "~"
-Line 4, col 17:
   3 | 
 > 4 | const a: Bool = ~ true;
                       ^~~~~~
@@ -350,7 +315,6 @@ Line 4, col 17:
 
 exports[`resolveDescriptors should fail descriptors for extend-fun-cannot-be-defined-within-contract 1`] = `
 "<unknown>:3:5: Extend functions cannot be defined within a contract
-Line 3, col 5:
   2 | contract Foo {
 > 3 |     extends fun Bar(self: Int, a: Int): Int {}    
           ^~~~~~~
@@ -360,7 +324,6 @@ Line 3, col 5:
 
 exports[`resolveDescriptors should fail descriptors for extend-fun-cannot-be-defined-within-trait 1`] = `
 "<unknown>:3:5: Extend functions cannot be defined within a contract
-Line 3, col 5:
   2 | trait Foo {
 > 3 |     extends fun Bar(self: Int, a: Int): Int {}    
           ^~~~~~~
@@ -370,7 +333,6 @@ Line 3, col 5:
 
 exports[`resolveDescriptors should fail descriptors for extend-fun-missing-type 1`] = `
 "<unknown>:1:32: Type "Bar" not found
-Line 1, col 32:
 > 1 | extends fun Foo(self: String): Bar {
                                      ^~~
   2 |     return "";
@@ -379,7 +341,6 @@ Line 1, col 32:
 
 exports[`resolveDescriptors should fail descriptors for extend-fun-must-have-at-least-one-parameter 1`] = `
 "<unknown>:2:1: Extend functions must have at least one parameter
-Line 2, col 1:
   1 | primitive Int;
 > 2 | extends fun Bar(): Int {}
       ^~~~~~~
@@ -388,7 +349,6 @@ Line 2, col 1:
 
 exports[`resolveDescriptors should fail descriptors for getter-outside-contract 1`] = `
 "<unknown>:8:1: Getters must be defined within a contract
-Line 8, col 1:
   7 | 
 > 8 | get fun sample(a: Int): Int {
       ^~~
@@ -398,7 +358,6 @@ Line 8, col 1:
 
 exports[`resolveDescriptors should fail descriptors for message-decl-remainder-in-the-middle 1`] = `
 "<unknown>:8:5: The "remainder" field can only be the last field of the message
-Line 8, col 5:
   7 |     a: Int;
 > 8 |     s: Cell as remaining;
           ^~~~~~~~~~~~~~~~~~~~
@@ -408,7 +367,6 @@ Line 8, col 5:
 
 exports[`resolveDescriptors should fail descriptors for message-negative-opcode-1 1`] = `
 "<unknown>:1:9: Opcode of message "Foo" is negative ('-1') which is not allowed
-Line 1, col 9:
 > 1 | message(-1) Foo { }
               ^~
   2 | 
@@ -417,7 +375,6 @@ Line 1, col 9:
 
 exports[`resolveDescriptors should fail descriptors for message-negative-opcode-2 1`] = `
 "<unknown>:1:9: Opcode of message "Foo" is negative ('-1') which is not allowed
-Line 1, col 9:
 > 1 | message(42 - 43) Foo { }
               ^~~~~~~
   2 | 
@@ -426,7 +383,6 @@ Line 1, col 9:
 
 exports[`resolveDescriptors should fail descriptors for message-opcode-div-by-zero 1`] = `
 "<unknown>:3:14: Cannot evaluate expression to a constant: divisor expression must be non-zero
-Line 3, col 14:
   2 | 
 > 3 | message(42 / 0) DivByZeroOpcode { }
                    ^
@@ -436,7 +392,6 @@ Line 3, col 14:
 
 exports[`resolveDescriptors should fail descriptors for message-opcode-too-large-1 1`] = `
 "<unknown>:1:9: Opcode of message "Foo" is too large ('137438953471'): it must fit into 32 bits
-Line 1, col 9:
 > 1 | message(0x1_FFFFF_FFFF) Foo { }
               ^~~~~~~~~~~~~~
   2 | 
@@ -445,7 +400,6 @@ Line 1, col 9:
 
 exports[`resolveDescriptors should fail descriptors for message-opcode-too-large-2 1`] = `
 "<unknown>:1:9: Opcode of message "Foo" is too large ('8589737985'): it must fit into 32 bits
-Line 1, col 9:
 > 1 | message(0xFFFF * 0x1FFFF) Foo { }
               ^~~~~~~~~~~~~~~~
   2 | 
@@ -454,7 +408,6 @@ Line 1, col 9:
 
 exports[`resolveDescriptors should fail descriptors for message-opcode-zero-1 1`] = `
 "<unknown>:4:9: Opcode of message "ZeroOpcode" is zero: those are reserved for text comments and cannot be used for message structs
-Line 4, col 9:
   3 | // zero opcodes are reserved for string comments
 > 4 | message(0) ZeroOpcode { }
               ^
@@ -464,7 +417,6 @@ Line 4, col 9:
 
 exports[`resolveDescriptors should fail descriptors for message-opcode-zero-2 1`] = `
 "<unknown>:4:9: Opcode of message "ZeroOpcode" is zero: those are reserved for text comments and cannot be used for message structs
-Line 4, col 9:
   3 | // zero opcodes are reserved for string comments
 > 4 | message(pow(2, 4) - 16) ZeroOpcode { }
               ^~~~~~~~~~~~~~
@@ -474,7 +426,6 @@ Line 4, col 9:
 
 exports[`resolveDescriptors should fail descriptors for method-first-param-not-self1 1`] = `
 "<unknown>:8:17: Extend function must have first parameter named "self"
-Line 8, col 17:
   7 | 
 > 8 | extends fun inc(a: Int): Int {
                       ^~~~~~
@@ -484,7 +435,6 @@ Line 8, col 17:
 
 exports[`resolveDescriptors should fail descriptors for method-first-param-not-self2 1`] = `
 "<unknown>:8:17: Parameter name "self" is reserved
-Line 8, col 17:
   7 | 
 > 8 | fun inc(a: Int, self: Int): Int {
                       ^~~~~~~~~
@@ -494,7 +444,6 @@ Line 8, col 17:
 
 exports[`resolveDescriptors should fail descriptors for native-fun-getter 1`] = `
 "<unknown>:9:1: Native functions cannot be getters
-Line 9, col 1:
   8 | @name(hello_world)
 > 9 | get native sample(a: Int): Int;
       ^~~
@@ -503,7 +452,6 @@ Line 9, col 1:
 
 exports[`resolveDescriptors should fail descriptors for override-for-non-existing-function-in-contract-from-base-trait 1`] = `
 "<unknown>:6:5: Function "foo" overrides nothing, remove "override" modifier or inherit any traits with this function
-Line 6, col 5:
   5 | contract Test {
 > 6 |     override fun foo() {}
           ^~~~~~~~~~~~~~~~~~~~~
@@ -513,7 +461,6 @@ Line 6, col 5:
 
 exports[`resolveDescriptors should fail descriptors for override-for-non-existing-function-in-contract-with-inheritance 1`] = `
 "<unknown>:5:5: Function "foo" overrides nothing, remove "override" modifier
-Line 5, col 5:
   4 | contract Test with T {
 > 5 |     override fun foo() {}
           ^~~~~~~~~~~~~~~~~~~~~
@@ -523,7 +470,6 @@ Line 5, col 5:
 
 exports[`resolveDescriptors should fail descriptors for override-for-non-existing-function-in-contract-with-multi-inheritance 1`] = `
 "<unknown>:11:5: Function "foo" overrides nothing, remove "override" modifier
-Line 11, col 5:
   10 | contract Test with T, T2 {
 > 11 |     override fun foo() {}
            ^~~~~~~~~~~~~~~~~~~~~
@@ -533,7 +479,6 @@ Line 11, col 5:
 
 exports[`resolveDescriptors should fail descriptors for override-for-non-existing-function-in-contract-without-inheritance 1`] = `
 "<unknown>:4:5: Function "foo" overrides nothing, remove "override" modifier or inherit any traits with this function
-Line 4, col 5:
   3 | contract Test {
 > 4 |     override fun foo() {}
           ^~~~~~~~~~~~~~~~~~~~~
@@ -543,7 +488,6 @@ Line 4, col 5:
 
 exports[`resolveDescriptors should fail descriptors for override-for-non-existing-function-in-trait-from-base-trait-2 1`] = `
 "<unknown>:6:5: Function "foo" overrides nothing, remove "override" modifier or inherit any traits with this function
-Line 6, col 5:
   5 | trait Test {
 > 6 |     override fun foo() {}
           ^~~~~~~~~~~~~~~~~~~~~
@@ -553,7 +497,6 @@ Line 6, col 5:
 
 exports[`resolveDescriptors should fail descriptors for override-for-non-existing-function-in-trait-with-diamond-inheritance 1`] = `
 "<unknown>:16:5: Function "foo" overrides nothing, remove "override" modifier
-Line 16, col 5:
   15 | trait Test with T2, T3 {
 > 16 |     override fun foo() {}
            ^~~~~~~~~~~~~~~~~~~~~
@@ -563,7 +506,6 @@ Line 16, col 5:
 
 exports[`resolveDescriptors should fail descriptors for override-for-non-existing-function-in-trait-with-inheritance 1`] = `
 "<unknown>:5:5: Function "foo" overrides nothing, remove "override" modifier
-Line 5, col 5:
   4 | trait Test with T {
 > 5 |     override fun foo() {}
           ^~~~~~~~~~~~~~~~~~~~~
@@ -573,7 +515,6 @@ Line 5, col 5:
 
 exports[`resolveDescriptors should fail descriptors for override-for-non-existing-function-in-trait-with-multi-inheritance 1`] = `
 "<unknown>:11:5: Function "foo" overrides nothing, remove "override" modifier
-Line 11, col 5:
   10 | trait Test with T, T2 {
 > 11 |     override fun foo() {}
            ^~~~~~~~~~~~~~~~~~~~~
@@ -583,7 +524,6 @@ Line 11, col 5:
 
 exports[`resolveDescriptors should fail descriptors for override-for-non-existing-function-in-trait-without-inheritance-2 1`] = `
 "<unknown>:4:5: Function "foo" overrides nothing, remove "override" modifier or inherit any traits with this function
-Line 4, col 5:
   3 | trait Test {
 > 4 |     override fun foo() {}
           ^~~~~~~~~~~~~~~~~~~~~
@@ -593,7 +533,6 @@ Line 4, col 5:
 
 exports[`resolveDescriptors should fail descriptors for scope-contract-shadows-contract 1`] = `
 "<unknown>:12:1: Type "Main" already exists
-Line 12, col 1:
   11 | 
 > 12 | contract Main {
        ^~~~~~~~~~~~~~~
@@ -603,7 +542,6 @@ Line 12, col 1:
 
 exports[`resolveDescriptors should fail descriptors for scope-duplicate-method 1`] = `
 "<unknown>:12:1: Function "hello" already exists in type "Main"
-Line 12, col 1:
   11 | 
 > 12 | extends fun hello(self: Main): Bool {
        ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -613,7 +551,6 @@ Line 12, col 1:
 
 exports[`resolveDescriptors should fail descriptors for scope-fun-shadows-builtin-dumpStack 1`] = `
 "<unknown>:1:1: Static function "dumpStack" already exists
-Line 1, col 1:
 > 1 | fun dumpStack() {
       ^~~~~~~~~~~~~~~~~
   2 | 
@@ -622,7 +559,6 @@ Line 1, col 1:
 
 exports[`resolveDescriptors should fail descriptors for scope-fun-shadows-builtin-ton 1`] = `
 "<unknown>:1:1: Static function "ton" already exists
-Line 1, col 1:
 > 1 | fun ton() {
       ^~~~~~~~~~~
   2 | 
@@ -631,7 +567,6 @@ Line 1, col 1:
 
 exports[`resolveDescriptors should fail descriptors for scope-fun-shadows-fun 1`] = `
 "<unknown>:16:1: Struct "Main" must have at least one field
-Line 16, col 1:
   15 | 
 > 16 | struct Main {
        ^~~~~~~~~~~~~
@@ -641,7 +576,6 @@ Line 16, col 1:
 
 exports[`resolveDescriptors should fail descriptors for scope-internal-fun-shadows-internal-fun 1`] = `
 "<unknown>:8:1: Function "hello" already exists in type "Main"
-Line 8, col 1:
   7 | 
 > 8 | contract Main {
       ^~~~~~~~~~~~~~~
@@ -651,7 +585,6 @@ Line 8, col 1:
 
 exports[`resolveDescriptors should fail descriptors for scope-param-shadows-param 1`] = `
 "<unknown>:9:24: Parameter name "a" is already used
-Line 9, col 24:
    8 | contract Main {
 >  9 |     fun hello(a: Bool, a: Int): Int {
                               ^~~~~~
@@ -661,7 +594,6 @@ Line 9, col 24:
 
 exports[`resolveDescriptors should fail descriptors for scope-storage-var-shadows-trait-const 1`] = `
 "<unknown>:8:3: Contract Foo inherits constant "storageReserve" from its traits and hence cannot have a storage variable with the same name
-Line 8, col 3:
   7 |   // is a virtual constant defined in BaseTrait
 > 8 |   storageReserve: Int;
         ^~~~~~~~~~~~~~~~~~~
@@ -671,7 +603,6 @@ Line 8, col 3:
 
 exports[`resolveDescriptors should fail descriptors for scope-struct-shadows-contract 1`] = `
 "<unknown>:12:1: Type "Main" already exists
-Line 12, col 1:
   11 | 
 > 12 | struct Main {
        ^~~~~~~~~~~~~
@@ -681,7 +612,6 @@ Line 12, col 1:
 
 exports[`resolveDescriptors should fail descriptors for scope-struct-shadows-struct 1`] = `
 "<unknown>:12:1: Type "Main" already exists
-Line 12, col 1:
   11 | 
 > 12 | struct Main {
        ^~~~~~~~~~~~~
@@ -691,7 +621,6 @@ Line 12, col 1:
 
 exports[`resolveDescriptors should fail descriptors for struct-decl-clash-with-int 1`] = `
 "<unknown>:3:1: Type "Int" already exists
-Line 3, col 1:
   2 | 
 > 3 | struct Int { s: Int = 42 }
       ^~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -701,7 +630,6 @@ Line 3, col 1:
 
 exports[`resolveDescriptors should fail descriptors for struct-decl-default-field-wrong-initializer-type 1`] = `
 "<unknown>:3:22: Struct field "s" has declared type "Bool", but its initializer has incompatible type "Int"
-Line 3, col 22:
   2 | 
 > 3 | struct S { s: Bool = 42 }
                            ^~
@@ -711,7 +639,6 @@ Line 3, col 22:
 
 exports[`resolveDescriptors should fail descriptors for struct-decl-duplicate-decl 1`] = `
 "<unknown>:10:1: Type "Pair" already exists
-Line 10, col 1:
    9 | 
 > 10 | struct Pair {
        ^~~~~~~~~~~~~
@@ -721,7 +648,6 @@ Line 10, col 1:
 
 exports[`resolveDescriptors should fail descriptors for struct-decl-duplicate-field 1`] = `
 "<unknown>:8:3: Field "b" already exists
-Line 8, col 3:
   7 |   b: Int;
 > 8 |   b: Int;
         ^~~~~~
@@ -731,7 +657,6 @@ Line 8, col 3:
 
 exports[`resolveDescriptors should fail descriptors for struct-decl-empty-not-allowed 1`] = `
 "<unknown>:3:1: Struct "Main" must have at least one field
-Line 3, col 1:
   2 | 
 > 3 | struct Main { }
       ^~~~~~~~~~~~~~~
@@ -740,7 +665,6 @@ Line 3, col 1:
 
 exports[`resolveDescriptors should fail descriptors for struct-decl-mutually-recursive 1`] = `
 "<unknown>:4:8: Mutually recursive types are not supported: types "A1", "A2" form a cycle
-Line 4, col 8:
   3 | 
 > 4 | struct A1 {
              ^~
@@ -750,7 +674,6 @@ Line 4, col 8:
 
 exports[`resolveDescriptors should fail descriptors for struct-decl-remainder-in-the-middle 1`] = `
 "<unknown>:8:5: The "remainder" field can only be the last field of the struct
-Line 8, col 5:
   7 |     a: Int;
 > 8 |     s: Cell as remaining;
           ^~~~~~~~~~~~~~~~~~~~
@@ -760,7 +683,6 @@ Line 8, col 5:
 
 exports[`resolveDescriptors should fail descriptors for struct-decl-self-reference 1`] = `
 "<unknown>:4:8: Self-referencing types are not supported: type "A" refers to itself in its definition
-Line 4, col 8:
   3 | 
 > 4 | struct A {
              ^
@@ -770,7 +692,6 @@ Line 4, col 8:
 
 exports[`resolveDescriptors should fail descriptors for struct-decl-self-reference-map 1`] = `
 "<unknown>:4:8: Self-referencing types are not supported: type "A" refers to itself in its definition
-Line 4, col 8:
   3 | 
 > 4 | struct A {
              ^
@@ -780,7 +701,6 @@ Line 4, col 8:
 
 exports[`resolveDescriptors should fail descriptors for trait-duplicates-in-trait-list 1`] = `
 "<unknown>:7:1: The list of inherited traits for trait "Test" has duplicates
-Line 7, col 1:
   6 | 
 > 7 | trait Test with Foo, Foo { }
       ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -790,7 +710,6 @@ Line 7, col 1:
 
 exports[`resolveDescriptors should fail descriptors for trait-field-initialized 1`] = `
 "<unknown>:2:14: Trait field cannot have an initializer
-Line 2, col 14:
   1 | trait T {
 > 2 |     a: Int = 42; // error
                    ^~
@@ -800,7 +719,6 @@ Line 2, col 14:
 
 exports[`resolveDescriptors should fail descriptors for trait-with-as-typed-field-for-contract 1`] = `
 "<unknown>:10:5: Trait "Foo" requires field "f" of type "Int as int32", but "Int" given
-Line 10, col 5:
    9 | contract SomeContract with Foo {
 > 10 |     f: Int;
            ^~~~~~
@@ -810,7 +728,6 @@ Line 10, col 5:
 
 exports[`resolveDescriptors should fail descriptors for trait-with-as-typed-field-for-contract-with-other-specialization 1`] = `
 "<unknown>:10:5: Trait "Foo" requires field "f" of type "Int as int32", but "Int as int16" given
-Line 10, col 5:
    9 | contract SomeContract with Foo {
 > 10 |     f: Int as int16 = 0;
            ^~~~~~~~~~~~~~~~~~~
@@ -820,7 +737,6 @@ Line 10, col 5:
 
 exports[`resolveDescriptors should fail descriptors for trait-with-as-typed-field-for-contract-with-other-type 1`] = `
 "<unknown>:10:1: Trait "Foo" requires field "f" of type "Int"
-Line 10, col 1:
    9 | 
 > 10 | contract SomeContract with Foo {
        ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -830,7 +746,6 @@ Line 10, col 1:
 
 exports[`resolveDescriptors should fail descriptors for trait-with-as-typed-field-for-trait 1`] = `
 "<unknown>:10:5: Trait "Foo" requires field "f" of type "Int as int32", but "Int" given
-Line 10, col 5:
    9 | trait SomeTrait with Foo {
 > 10 |     f: Int;
            ^~~~~~
@@ -840,7 +755,6 @@ Line 10, col 5:
 
 exports[`resolveDescriptors should fail descriptors for trait-with-as-typed-field-for-trait-with-other-specialization 1`] = `
 "<unknown>:10:5: Trait "Foo" requires field "f" of type "Int as int32", but "Int as int16" given
-Line 10, col 5:
    9 | trait SomeTrait with Foo {
 > 10 |     f: Int as int16;
            ^~~~~~~~~~~~~~~
@@ -850,7 +764,6 @@ Line 10, col 5:
 
 exports[`resolveDescriptors should fail descriptors for trait-with-as-typed-field-for-trait-with-other-type 1`] = `
 "<unknown>:10:1: Trait "Foo" requires field "f" of type "Int"
-Line 10, col 1:
    9 | 
 > 10 | trait SomeTrait with Foo {
        ^~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -860,7 +773,6 @@ Line 10, col 1:
 
 exports[`resolveDescriptors should fail descriptors for trait-with-as-typed-field-in-diamond-inheritance-and-other-specialization 1`] = `
 "<unknown>:21:5: Trait "T2" requires field "f2" of type "Int as int32", but "Int as int16" given
-Line 21, col 5:
   20 |     f1: Int as int32;
 > 21 |     f2: Int as int16;
            ^~~~~~~~~~~~~~~~
@@ -870,7 +782,6 @@ Line 21, col 5:
 
 exports[`resolveDescriptors should fail descriptors for trait-with-as-typed-field-with-unsupported-format 1`] = `
 "<unknown>:6:5: Unsupported format "foo"
-Line 6, col 5:
   5 | trait Foo {
 > 6 |     f: Int as foo;
           ^~~~~~~~~~~~~
@@ -880,7 +791,6 @@ Line 6, col 5:
 
 exports[`resolveDescriptors should fail descriptors for trait-with-as-typed-int257-field-for-trait-with-as-typed-coins-field 1`] = `
 "<unknown>:10:5: Trait "Trait" requires field "i" of type "Int as int257", but "Int as coins" given
-Line 10, col 5:
    9 | contract Foo with Trait {
 > 10 |     i: Int as coins = 0;
            ^~~~~~~~~~~~~~~~~~~
@@ -890,7 +800,6 @@ Line 10, col 5:
 
 exports[`resolveDescriptors should fail descriptors for trait-without-as-typed-field-inherited-with-it 1`] = `
 "<unknown>:10:5: Trait "Foo" requires field "f" of type "Int", but "Int as int32" given
-Line 10, col 5:
    9 | trait SomeTrait with Foo {
 > 10 |     f: Int as int32;
            ^~~~~~~~~~~~~~~
@@ -900,7 +809,6 @@ Line 10, col 5:
 
 exports[`resolveDescriptors should fail descriptors for wf-type-const 1`] = `
 "<unknown>:4:19: Invalid map type. Check https://docs.tact-lang.org/book/maps#allowed-types
-Line 4, col 19:
   3 | 
 > 4 | const m: map<Int, String> = null;
                         ^~~~~~
@@ -910,7 +818,6 @@ Line 4, col 19:
 
 exports[`resolveDescriptors should fail descriptors for wf-type-contract-const 1`] = `
 "<unknown>:6:23: Invalid map type. Check https://docs.tact-lang.org/book/maps#allowed-types
-Line 6, col 23:
   5 | contract Test {
 > 6 |     const m: map<Int, String> = null;
                             ^~~~~~
@@ -920,7 +827,6 @@ Line 6, col 23:
 
 exports[`resolveDescriptors should fail descriptors for wf-type-contract-const-incorrect-annotation 1`] = `
 "<unknown>:6:34: "Address" type cannot have as-annotation
-Line 6, col 34:
   5 | contract Test {
 > 6 |     const m: map<Int, Address as uint32> = null;
                                        ^~~~~~
@@ -930,7 +836,6 @@ Line 6, col 34:
 
 exports[`resolveDescriptors should fail descriptors for wf-type-contract-getter 1`] = `
 "<unknown>:6:29: Invalid map type. Check https://docs.tact-lang.org/book/maps#allowed-types
-Line 6, col 29:
   5 | contract Test {
 > 6 |     get fun foo(): map<Int, String> {
                                   ^~~~~~
@@ -940,7 +845,6 @@ Line 6, col 29:
 
 exports[`resolveDescriptors should fail descriptors for wf-type-contract-incorrect-map-key-annotation-coins 1`] = `
 "<unknown>:6:19: "coins" is invalid as-annotation for map key type "Int"
-Line 6, col 19:
   5 | contract Test {
 > 6 |     m: map<Int as coins, Address> = emptyMap();
                         ^~~~~
@@ -950,7 +854,6 @@ Line 6, col 19:
 
 exports[`resolveDescriptors should fail descriptors for wf-type-contract-incorrect-map-key-annotation-varint16 1`] = `
 "<unknown>:6:19: "varint16" is invalid as-annotation for map key type "Int"
-Line 6, col 19:
   5 | contract Test {
 > 6 |     m: map<Int as varint16, Address> = emptyMap();
                         ^~~~~~~~
@@ -960,7 +863,6 @@ Line 6, col 19:
 
 exports[`resolveDescriptors should fail descriptors for wf-type-contract-incorrect-map-key-annotation-varint32 1`] = `
 "<unknown>:6:19: "varint32" is invalid as-annotation for map key type "Int"
-Line 6, col 19:
   5 | contract Test {
 > 6 |     m: map<Int as varint32, Address> = emptyMap();
                         ^~~~~~~~
@@ -970,7 +872,6 @@ Line 6, col 19:
 
 exports[`resolveDescriptors should fail descriptors for wf-type-contract-incorrect-map-key-annotation-varuint16 1`] = `
 "<unknown>:6:19: "varuint16" is invalid as-annotation for map key type "Int"
-Line 6, col 19:
   5 | contract Test {
 > 6 |     m: map<Int as varuint16, Address> = emptyMap();
                         ^~~~~~~~~
@@ -980,7 +881,6 @@ Line 6, col 19:
 
 exports[`resolveDescriptors should fail descriptors for wf-type-contract-incorrect-map-key-annotation-varuint32 1`] = `
 "<unknown>:6:19: "varuint32" is invalid as-annotation for map key type "Int"
-Line 6, col 19:
   5 | contract Test {
 > 6 |     m: map<Int as varuint32, Address> = emptyMap();
                         ^~~~~~~~~
@@ -990,7 +890,6 @@ Line 6, col 19:
 
 exports[`resolveDescriptors should fail descriptors for wf-type-fun-param 1`] = `
 "<unknown>:4:16: Invalid map type. Check https://docs.tact-lang.org/book/maps#allowed-types
-Line 4, col 16:
   3 | 
 > 4 | fun foo(m: map<Bool, Int>) { }
                      ^~~~

--- a/src/types/__snapshots__/resolveStatements.spec.ts.snap
+++ b/src/types/__snapshots__/resolveStatements.spec.ts.snap
@@ -2,7 +2,6 @@
 
 exports[`resolveStatements should fail statements for assign-augmented-const-contract 1`] = `
 "<unknown>:8:9: Modifications of constant expressions are not allowed
-Line 8, col 9:
   7 |     fun bar() {
 > 8 |         self.foo += 1 // <-- trying to assign to a constant
               ^~~~~~~~
@@ -12,7 +11,6 @@ Line 8, col 9:
 
 exports[`resolveStatements should fail statements for assign-augmented-const-global 1`] = `
 "<unknown>:6:5: Modifications of constant expressions are not allowed
-Line 6, col 5:
   5 | fun bar() {
 > 6 |     foo += 1 // <-- trying to assign to a constant
           ^~~
@@ -22,7 +20,6 @@ Line 6, col 5:
 
 exports[`resolveStatements should fail statements for assign-augmented-const-struct-contract 1`] = `
 "<unknown>:12:9: Modifications of constant expressions are not allowed
-Line 12, col 9:
   11 |         self.baz.x += 1; // ok
 > 12 |         self.foo.y -= 1 // <-- trying to assign to a constant
                ^~~~~~~~~~
@@ -32,7 +29,6 @@ Line 12, col 9:
 
 exports[`resolveStatements should fail statements for assign-augmented-const-struct-global 1`] = `
 "<unknown>:10:5: Modifications of constant expressions are not allowed
-Line 10, col 5:
    9 |     baz.x += 1; // ok
 > 10 |     foo.y -= 1 // <-- trying to assign to a constant
            ^~~~~
@@ -42,7 +38,6 @@ Line 10, col 5:
 
 exports[`resolveStatements should fail statements for assign-const-contract 1`] = `
 "<unknown>:8:9: Modifications of constant expressions are not allowed
-Line 8, col 9:
   7 |     fun bar() {
 > 8 |         self.foo = 43 // <-- trying to assign to a constant
               ^~~~~~~~
@@ -52,7 +47,6 @@ Line 8, col 9:
 
 exports[`resolveStatements should fail statements for assign-const-global 1`] = `
 "<unknown>:6:5: Modifications of constant expressions are not allowed
-Line 6, col 5:
   5 | fun bar() {
 > 6 |     foo = 43 // <-- trying to assign to a constant
           ^~~
@@ -62,7 +56,6 @@ Line 6, col 5:
 
 exports[`resolveStatements should fail statements for assign-const-struct-contract 1`] = `
 "<unknown>:12:9: Modifications of constant expressions are not allowed
-Line 12, col 9:
   11 |         self.baz.x = 1; // ok
 > 12 |         self.foo.y = 42 // <-- trying to assign to a constant
                ^~~~~~~~~~
@@ -72,7 +65,6 @@ Line 12, col 9:
 
 exports[`resolveStatements should fail statements for assign-const-struct-global 1`] = `
 "<unknown>:10:5: Modifications of constant expressions are not allowed
-Line 10, col 5:
    9 |     baz.x = 1; // ok
 > 10 |     foo.y = 42 // <-- trying to assign to a constant
            ^~~~~
@@ -82,7 +74,6 @@ Line 10, col 5:
 
 exports[`resolveStatements should fail statements for bounced-type-is-smaller 1`] = `
 "<unknown>:23:22: Maximum size of the bounced message is 224 bytes, but the "c" field of type "A" cannot fit into it due to the size of previous fields or its own size, so it cannot be accessed. Make the type of the fields before this one smaller, or reduce the type of this field so that it fits into 224 bytes
-Line 23, col 22:
   22 |     let y: Bool = src.b;
 > 23 |     let z: Int = src.c;
                             ^
@@ -92,7 +83,6 @@ Line 23, col 22:
 
 exports[`resolveStatements should fail statements for contract-getter-with-method-id-1 1`] = `
 "<unknown>:5:9: Invalid type "String" for binary operator "+"
-Line 5, col 9:
   4 | contract Test {
 > 5 |     get(crc32("crc32") + "42") fun test(): Int {
               ^~~~~~~~~~~~~~~~~~~~~
@@ -102,7 +92,6 @@ Line 5, col 9:
 
 exports[`resolveStatements should fail statements for contract-getter-with-method-id-2 1`] = `
 "<unknown>:5:9: Getter's method id expression must be of type "Int" but it has type "Bool"
-Line 5, col 9:
   4 | contract Test {
 > 5 |     get(true) fun test(): Int {
               ^~~~
@@ -112,7 +101,6 @@ Line 5, col 9:
 
 exports[`resolveStatements should fail statements for contract-initof-wrong-arg 1`] = `
 "<unknown>:26:25: Invalid type "String" for argument "owner"
-Line 26, col 25:
   25 |     get fun newInit(): StateInit {
 > 26 |         return initOf A("hello");
                                ^~~~~~~
@@ -122,7 +110,6 @@ Line 26, col 25:
 
 exports[`resolveStatements should fail statements for expr-bitwise-not-bool 1`] = `
 "<unknown>:5:12: Invalid type "Bool" for unary operator "~"
-Line 5, col 12:
   4 | fun test(a: Bool): Int {
 > 5 |     return ~a;
                  ^~
@@ -132,7 +119,6 @@ Line 5, col 12:
 
 exports[`resolveStatements should fail statements for expr-conditional-branch-mismatch 1`] = `
 "<unknown>:5:43: Non-matching types "Bool" and "Int" for ternary branches
-Line 5, col 43:
   4 | fun sample(): Int {
 > 5 |     return (true ? true : false) ? true : 3;
                                                 ^
@@ -142,7 +128,6 @@ Line 5, col 43:
 
 exports[`resolveStatements should fail statements for expr-conditional-branch-mismatch-nested1 1`] = `
 "<unknown>:5:24: Non-matching types "Int" and "Bool" for ternary branches
-Line 5, col 24:
   4 | fun sample(): Int {
 > 5 |     return (true ? 1 : false) ? 2 : 3;
                              ^~~~~
@@ -152,7 +137,6 @@ Line 5, col 24:
 
 exports[`resolveStatements should fail statements for expr-conditional-branch-mismatch-nested2 1`] = `
 "<unknown>:5:39: Non-matching types "Bool" and "Int" for ternary branches
-Line 5, col 39:
   4 | fun sample(): Int {
 > 5 |     return true ? 1 : (false ? true : 2);
                                             ^
@@ -162,7 +146,6 @@ Line 5, col 39:
 
 exports[`resolveStatements should fail statements for expr-conditional-non-optional-result-expected1 1`] = `
 "<unknown>:6:5: Type mismatch: "Int?" is not assignable to "Int"
-Line 6, col 5:
   5 |     let cond: Bool = true;
 > 6 |     return cond ? 42 : x;
           ^~~~~~~~~~~~~~~~~~~~~
@@ -172,7 +155,6 @@ Line 6, col 5:
 
 exports[`resolveStatements should fail statements for expr-conditional-non-optional-result-expected2 1`] = `
 "<unknown>:6:5: Type mismatch: "Int?" is not assignable to "Int"
-Line 6, col 5:
   5 |     let cond: Bool = true;
 > 6 |     return cond ? x : 42;
           ^~~~~~~~~~~~~~~~~~~~~
@@ -182,7 +164,6 @@ Line 6, col 5:
 
 exports[`resolveStatements should fail statements for expr-conditional-non-optional-result-expected3 1`] = `
 "<unknown>:6:5: Type mismatch: "Int?" is not assignable to "Int"
-Line 6, col 5:
   5 |     let cond: Bool = true;
 > 6 |     let baz: Int = cond ? 42 : null;
           ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -192,7 +173,6 @@ Line 6, col 5:
 
 exports[`resolveStatements should fail statements for expr-conditional-result-mismatch 1`] = `
 "<unknown>:5:5: Type mismatch: "Bool" is not assignable to "Int"
-Line 5, col 5:
   4 | fun sample(): Int {
 > 5 |     return (true ? true : false) ? true : false;
           ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -202,7 +182,6 @@ Line 5, col 5:
 
 exports[`resolveStatements should fail statements for expr-conditional-void-branches copy 1`] = `
 "<unknown>:6:19: Expressions of "<void>" type cannot be used for conditional expression
-Line 6, col 19:
   5 | fun bar(): Int {
 > 6 |     let voidVar = true ? foo() : foo();
                         ^~~~~~~~~~~~~~~~~~~~
@@ -213,7 +192,6 @@ Line 6, col 19:
 exports[`resolveStatements should fail statements for expr-eq-bounced 1`] = `
 "<unknown>:6:10: Expressions of "bounced<S>" type cannot be used for (non)equality operator "=="
  See https://docs.tact-lang.org/book/operators#binary-equality
-Line 6, col 10:
   5 | fun foo(b: bounced<S>): Bool {
 > 6 |   return b == b;
                ^~~~~~
@@ -224,7 +202,6 @@ Line 6, col 10:
 exports[`resolveStatements should fail statements for expr-eq-builder 1`] = `
 "<unknown>:7:16: Expressions of "Builder" type cannot be used for (non)equality operator "=="
  See https://docs.tact-lang.org/book/operators#binary-equality
-Line 7, col 16:
   6 |     get fun foo(s: Builder): Bool {
 > 7 |         return s == s;
                      ^~~~~~
@@ -235,7 +212,6 @@ Line 7, col 16:
 exports[`resolveStatements should fail statements for expr-eq-contract 1`] = `
 "<unknown>:10:16: Expressions of "Test" type cannot be used for (non)equality operator "=="
  See https://docs.tact-lang.org/book/operators#binary-equality
-Line 10, col 16:
    9 |     get fun foo(): Bool {
 > 10 |         return self == self;
                       ^~~~~~~~~~~~
@@ -245,7 +221,6 @@ Line 10, col 16:
 
 exports[`resolveStatements should fail statements for expr-eq-int-bool 1`] = `
 "<unknown>:5:12: Incompatible types "Int" and "Bool" for binary operator "=="
-Line 5, col 12:
   4 | fun foo(x: Int): Bool {
 > 5 |     return x == true;
                  ^~~~~~~~~
@@ -255,7 +230,6 @@ Line 5, col 12:
 
 exports[`resolveStatements should fail statements for expr-eq-map-map 1`] = `
 "<unknown>:6:12: Incompatible types "map<Int, Address>" and "map<Address, Int>" for binary operator "=="
-Line 6, col 12:
   5 | fun foo(m1: map<Int, Address>, m2: map<Address, Int>): Bool {
 > 6 |     return m1 == m2;
                  ^~~~~~~~
@@ -266,7 +240,6 @@ Line 6, col 12:
 exports[`resolveStatements should fail statements for expr-eq-null-1 1`] = `
 "<unknown>:18:13: Expressions of "S" type cannot be used for (non)equality operator "!="
  See https://docs.tact-lang.org/book/operators#binary-equality
-Line 18, col 13:
   17 |     get fun test(): Int {
 > 18 |         if (self.s != null) {
                    ^~~~~~~~~~~~~~
@@ -277,7 +250,6 @@ Line 18, col 13:
 exports[`resolveStatements should fail statements for expr-eq-null-2 1`] = `
 "<unknown>:18:13: Expressions of "S" type cannot be used for (non)equality operator "!="
 See https://docs.tact-lang.org/book/operators#binary-equality
-Line 18, col 13:
   17 |     get fun test(): Int {
 > 18 |         if (null != self.s) {
                    ^~~~~~~~~~~~~~
@@ -287,7 +259,6 @@ Line 18, col 13:
 
 exports[`resolveStatements should fail statements for expr-eq-null-3 1`] = `
 "<unknown>:5:9: Incompatible types "<null>" and "Int" for binary operator "=="
-Line 5, col 9:
   4 |     let x: Int = 42;
 > 5 |     if (null == x) { return }
               ^~~~~~~~~
@@ -298,7 +269,6 @@ Line 5, col 9:
 exports[`resolveStatements should fail statements for expr-eq-null-bounced 1`] = `
 "<unknown>:7:10: Expressions of "bounced<S>" type cannot be used for (non)equality operator "=="
  See https://docs.tact-lang.org/book/operators#binary-equality
-Line 7, col 10:
   6 | fun foo(b: bounced<S>): Bool {
 > 7 |   return b == null;
                ^~~~~~~~~
@@ -309,7 +279,6 @@ Line 7, col 10:
 exports[`resolveStatements should fail statements for expr-eq-optional-builder 1`] = `
 "<unknown>:7:16: Expressions of "Builder?" type cannot be used for (non)equality operator "=="
  See https://docs.tact-lang.org/book/operators#binary-equality
-Line 7, col 16:
   6 |     get fun foo(s: Builder?): Bool {
 > 7 |         return s == s;
                      ^~~~~~
@@ -320,7 +289,6 @@ Line 7, col 16:
 exports[`resolveStatements should fail statements for expr-eq-optional-stringbuilder 1`] = `
 "<unknown>:7:16: Expressions of "StringBuilder?" type cannot be used for (non)equality operator "=="
  See https://docs.tact-lang.org/book/operators#binary-equality
-Line 7, col 16:
   6 |     get fun foo(s: StringBuilder?): Bool {
 > 7 |         return s == s;
                      ^~~~~~
@@ -331,7 +299,6 @@ Line 7, col 16:
 exports[`resolveStatements should fail statements for expr-eq-optional-struct 1`] = `
 "<unknown>:10:16: Expressions of "S?" type cannot be used for (non)equality operator "=="
  See https://docs.tact-lang.org/book/operators#binary-equality
-Line 10, col 16:
    9 |         let s: S? = S {x: 42, y: 0};
 > 10 |         return s == s;
                       ^~~~~~
@@ -342,7 +309,6 @@ Line 10, col 16:
 exports[`resolveStatements should fail statements for expr-eq-optional-struct-null 1`] = `
 "<unknown>:7:16: Expressions of "S" type cannot be used for (non)equality operator "=="
  See https://docs.tact-lang.org/book/operators#binary-equality
-Line 7, col 16:
   6 |     if (s != null) {
 > 7 |         return s!! == null
                      ^~~~~~~~~~~
@@ -353,7 +319,6 @@ Line 7, col 16:
 exports[`resolveStatements should fail statements for expr-eq-stringbuilder 1`] = `
 "<unknown>:7:16: Expressions of "StringBuilder" type cannot be used for (non)equality operator "=="
  See https://docs.tact-lang.org/book/operators#binary-equality
-Line 7, col 16:
   6 |     get fun foo(s: StringBuilder): Bool {
 > 7 |         return s == s;
                      ^~~~~~
@@ -364,7 +329,6 @@ Line 7, col 16:
 exports[`resolveStatements should fail statements for expr-eq-struct 1`] = `
 "<unknown>:10:16: Expressions of "S" type cannot be used for (non)equality operator "=="
  See https://docs.tact-lang.org/book/operators#binary-equality
-Line 10, col 16:
    9 |         let s: S = S {x: 42, y: 0};
 > 10 |         return s == s;
                       ^~~~~~
@@ -375,7 +339,6 @@ Line 10, col 16:
 exports[`resolveStatements should fail statements for expr-eq-void-null 1`] = `
 "<unknown>:6:12: Expressions of "<void>" type cannot be used for (non)equality operator "=="
  See https://docs.tact-lang.org/book/operators#binary-equality
-Line 6, col 12:
   5 | fun baz(): Bool {
 > 6 |     return foo() == null
                  ^~~~~~~~~~~~~
@@ -386,7 +349,6 @@ Line 6, col 12:
 exports[`resolveStatements should fail statements for expr-eq-void1 1`] = `
 "<unknown>:7:12: Expressions of "<void>" type cannot be used for (non)equality operator "=="
  See https://docs.tact-lang.org/book/operators#binary-equality
-Line 7, col 12:
   6 | fun baz(): Bool {
 > 7 |     return foo() == bar()
                  ^~~~~~~~~~~~~~
@@ -397,7 +359,6 @@ Line 7, col 12:
 exports[`resolveStatements should fail statements for expr-eq-void2 1`] = `
 "<unknown>:7:12: Expressions of "<void>" type cannot be used for (non)equality operator "!="
  See https://docs.tact-lang.org/book/operators#binary-equality
-Line 7, col 12:
   6 | fun baz(): Bool {
 > 7 |     return foo() != bar()
                  ^~~~~~~~~~~~~~
@@ -407,7 +368,6 @@ Line 7, col 12:
 
 exports[`resolveStatements should fail statements for expr-field-does-not-exist 1`] = `
 "<unknown>:14:7: Type "Slice" does not have a field named "bits"
-Line 14, col 7:
   13 |     let s: Slice = "123".asSlice();
 > 14 |     s.bits;
              ^~~~
@@ -417,7 +377,6 @@ Line 14, col 7:
 
 exports[`resolveStatements should fail statements for expr-field-does-not-exist-but-method-does 1`] = `
 "<unknown>:17:5: Type "Slice" does not have a field named "bits", did you mean "bits()" instead?
-Line 17, col 5:
   16 |     let s: Slice = "123".asSlice();
 > 17 |     s.bits;
            ^~~~~~
@@ -427,7 +386,6 @@ Line 17, col 5:
 
 exports[`resolveStatements should fail statements for expr-internal-fun-call-bool-param.tact 1`] = `
 "<unknown>:20:27: Invalid type "Bool" for argument "b"
-Line 20, col 27:
   19 |     fun f2(a: Int): Int {
 > 20 |         return self.f1(a, true);
                                  ^~~~
@@ -437,7 +395,6 @@ Line 20, col 27:
 
 exports[`resolveStatements should fail statements for expr-map-del-method-is-non-void 1`] = `
 "<unknown>:6:5: Type mismatch: "Bool" is not assignable to "<void>"
-Line 6, col 5:
   5 |     m.set(1, 2);
 > 6 |     return m.del(1);
           ^~~~~~~~~~~~~~~~
@@ -447,7 +404,6 @@ Line 6, col 5:
 
 exports[`resolveStatements should fail statements for expr-map-exists-method-not-bool 1`] = `
 "<unknown>:7:5: Type mismatch: "Bool" is not assignable to "Int"
-Line 7, col 5:
   6 |     m.set(1, 2);
 > 7 |     return m.exists(1);
           ^~~~~~~~~~~~~~~~~~~
@@ -457,7 +413,6 @@ Line 7, col 5:
 
 exports[`resolveStatements should fail statements for expr-map-exists-method-on-not-map 1`] = `
 "<unknown>:5:12: Type "Int" does not have a function named "exists"
-Line 5, col 12:
   4 | fun test(): Bool {
 > 5 |     return 42.exists(1);
                  ^~~~~~~~~~~~
@@ -467,7 +422,6 @@ Line 5, col 12:
 
 exports[`resolveStatements should fail statements for expr-method-does-not-exist-but-field-does 1`] = `
 "<unknown>:13:5: Type "S" does not have a function named "x()", did you mean field "x" instead?
-Line 13, col 5:
   12 |     let s: S = S{ x: 1 };
 > 13 |     s.x();
            ^~~~~
@@ -477,7 +431,6 @@ Line 13, col 5:
 
 exports[`resolveStatements should fail statements for expr-module-fun-call-bool-param 1`] = `
 "<unknown>:13:18: Invalid type "Bool" for argument "b"
-Line 13, col 18:
   12 | fun f2(a: Int): Int {
 > 13 |     return f1(a, true);
                         ^~~~
@@ -487,7 +440,6 @@ Line 13, col 18:
 
 exports[`resolveStatements should fail statements for expr-struct-duplicate-field 1`] = `
 "<unknown>:17:9: Duplicate fields "a"
-Line 17, col 9:
   16 |         a: 1,
 > 17 |         a: 2,
                ^~~~
@@ -497,7 +449,6 @@ Line 17, col 9:
 
 exports[`resolveStatements should fail statements for expr-struct-impossible-field-punning 1`] = `
 "<unknown>:14:26: Unknown fields "b" in type "A"
-Line 14, col 26:
   13 | fun function() {
 > 14 |     let D: A = A { x: a, b };
                                 ^
@@ -507,7 +458,6 @@ Line 14, col 26:
 
 exports[`resolveStatements should fail statements for expr-struct-missing-field 1`] = `
 "<unknown>:16:25: Missing field "c" in type "SomeStruct"
-Line 16, col 25:
   15 | fun main() {
 > 16 |     let a: SomeStruct = SomeStruct{
                                ^~~~~~~~~~~
@@ -517,7 +467,6 @@ Line 16, col 25:
 
 exports[`resolveStatements should fail statements for expr-struct-wrong-field-type 1`] = `
 "<unknown>:17:9: Invalid type "Bool" for field "b" with type "Int" in type "SomeStruct"
-Line 17, col 9:
   16 |         a: 1,
 > 17 |         b: false // Invalid type
                ^~~~~~~~
@@ -527,7 +476,6 @@ Line 17, col 9:
 
 exports[`resolveStatements should fail statements for expr-var-int-bool 1`] = `
 "<unknown>:9:5: Type mismatch: "Int" is not assignable to "Bool"
-Line 9, col 5:
    8 | fun isZero(x: Int): Bool {
 >  9 |     return x;
            ^~~~~~~~~
@@ -537,7 +485,6 @@ Line 9, col 5:
 
 exports[`resolveStatements should fail statements for expr-wrong-arity-internal-fun 1`] = `
 "<unknown>:20:16: Function "f1" expects 2 arguments, got 1
-Line 20, col 16:
   19 |     fun f2(a: Int): Int {
 > 20 |         return self.f1(a);
                       ^~~~~~~~~~
@@ -547,7 +494,6 @@ Line 20, col 16:
 
 exports[`resolveStatements should fail statements for expr-wrong-arity-module-fun 1`] = `
 "<unknown>:13:12: Function "f1" expects 2 arguments, got 1
-Line 13, col 12:
   12 | fun f2(a: Int): Int {
 > 13 |     return f1(a);
                   ^~~~~
@@ -558,7 +504,6 @@ Line 13, col 12:
 exports[`resolveStatements should fail statements for getter-collision 1`] = `
 "<unknown>:8:13: Method ID collision: getter 'pko' has the same method ID 103057 as getter 'getter1'
 Pick a different getter name or explicit method ID to avoid collisions
-Line 8, col 13:
   7 | 
 > 8 |     get fun pko() {
                   ^~~
@@ -569,7 +514,6 @@ Line 8, col 13:
 exports[`resolveStatements should fail statements for getter-collision-trait 1`] = `
 "<unknown>:8:13: Method ID collision: getter 'pko' has the same method ID 103057 as getter 'getter1'
 Pick a different getter name or explicit method ID to avoid collisions
-Line 8, col 13:
   7 | 
 > 8 |     get fun pko() {
                   ^~~
@@ -579,7 +523,6 @@ Line 8, col 13:
 
 exports[`resolveStatements should fail statements for getter-collision-with-reserved_opt1 1`] = `
 "<unknown>:10:9: method ids cannot overlap with Tact reserved method ids: 113617, 115390, 121275
-Line 10, col 9:
    9 | 
 > 10 |     get(115390) fun _lazy_deployment_completed(): String{
                ^~~~~~
@@ -589,7 +532,6 @@ Line 10, col 9:
 
 exports[`resolveStatements should fail statements for getter-collision-with-reserved_opt2 1`] = `
 "<unknown>:10:9: method ids cannot overlap with Tact reserved method ids: 113617, 115390, 121275
-Line 10, col 9:
    9 | 
 > 10 |     get(121275) fun _get_abi_ipfs(): Int{
                ^~~~~~
@@ -599,7 +541,6 @@ Line 10, col 9:
 
 exports[`resolveStatements should fail statements for getter-collision-with-reserved_opt3 1`] = `
 "<unknown>:10:9: method ids cannot overlap with Tact reserved method ids: 113617, 115390, 121275
-Line 10, col 9:
    9 | 
 > 10 |     get(113617) fun _supported_interfaces(): String{
                ^~~~~~
@@ -609,7 +550,6 @@ Line 10, col 9:
 
 exports[`resolveStatements should fail statements for getter-collision-with-reserved1 1`] = `
 "<unknown>:10:5: method ids cannot overlap with Tact reserved method ids: 113617, 115390, 121275
-Line 10, col 5:
    9 | 
 > 10 |     get fun lazy_deployment_completed(): String{
            ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -619,7 +559,6 @@ Line 10, col 5:
 
 exports[`resolveStatements should fail statements for getter-collision-with-reserved2 1`] = `
 "<unknown>:10:5: method ids cannot overlap with Tact reserved method ids: 113617, 115390, 121275
-Line 10, col 5:
    9 | 
 > 10 |     get fun get_abi_ipfs(): Int{
            ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -629,7 +568,6 @@ Line 10, col 5:
 
 exports[`resolveStatements should fail statements for getter-collision-with-reserved3 1`] = `
 "<unknown>:10:5: method ids cannot overlap with Tact reserved method ids: 113617, 115390, 121275
-Line 10, col 5:
    9 | 
 > 10 |     get fun supported_interfaces(): String{
            ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -640,7 +578,6 @@ Line 10, col 5:
 exports[`resolveStatements should fail statements for getter-collision-with-trait 1`] = `
 "<unknown>:4:13: Method ID collision: getter 'pko' has the same method ID 103057 as getter 'getter1'
 Pick a different getter name or explicit method ID to avoid collisions
-Line 4, col 13:
   3 | trait T {
 > 4 |     get fun pko() {
                   ^~~
@@ -650,7 +587,6 @@ Line 4, col 13:
 
 exports[`resolveStatements should fail statements for init-vars-analysis-if 1`] = `
 "<unknown>:10:5: Field "value" is not set
-Line 10, col 5:
    9 |     value: Int;
 > 10 |     init(arg: Bool) {
            ^~~~~~~~~~~~~~~~~
@@ -660,7 +596,6 @@ Line 10, col 5:
 
 exports[`resolveStatements should fail statements for init-vars-analysis-implicit-init 1`] = `
 "<unknown>:4:1: Field "test_field" is not set
-Line 4, col 1:
   3 | 
 > 4 | contract MyContract {
       ^~~~~~~~~~~~~~~~~~~~~
@@ -670,7 +605,6 @@ Line 4, col 1:
 
 exports[`resolveStatements should fail statements for init-vars-analysis-missing-storage-var 1`] = `
 "<unknown>:10:5: Field "value" is not set
-Line 10, col 5:
    9 |     value: Int;
 > 10 |     init() {
            ^~~~~~~~
@@ -680,7 +614,6 @@ Line 10, col 5:
 
 exports[`resolveStatements should fail statements for init-vars-analysis-used-uninit-storage-augmented-assign1 1`] = `
 "<unknown>:8:27: Field "value" is not initialized
-Line 8, col 27:
   7 |     init() {
 > 8 |         self.value = self.value + 1;
                                 ^~~~~
@@ -690,7 +623,6 @@ Line 8, col 27:
 
 exports[`resolveStatements should fail statements for init-vars-analysis-used-uninit-storage-augmented-assign2 1`] = `
 "<unknown>:7:5: Field "value" is not set
-Line 7, col 5:
   6 |     value: Int;
 > 7 |     init() {
           ^~~~~~~~
@@ -700,7 +632,6 @@ Line 7, col 5:
 
 exports[`resolveStatements should fail statements for init-vars-analysis-used-uninit-storage-override-fun-call 1`] = `
 "<unknown>:15:9: Cannot access self before init
-Line 15, col 9:
   14 |     init(arg: Bool) {
 > 15 |         self.execute();
                ^~~~~~~~~~~~~~
@@ -710,7 +641,6 @@ Line 15, col 9:
 
 exports[`resolveStatements should fail statements for init-vars-analysis-used-uninit-storage-struct1 1`] = `
 "<unknown>:17:27: Field "value2" is not initialized
-Line 17, col 27:
   16 |     init(arg: Bool) {
 > 17 |         self.value = self.value2.a + 1;
                                  ^~~~~~
@@ -720,7 +650,6 @@ Line 17, col 27:
 
 exports[`resolveStatements should fail statements for init-vars-analysis-used-uninit-storage-struct2 1`] = `
 "<unknown>:17:40: Field "value" is not initialized
-Line 17, col 40:
   16 |     init(arg: Bool) {
 > 17 |         self.value2 = A{ a: 1, b: self.value };
                                               ^~~~~
@@ -730,7 +659,6 @@ Line 17, col 40:
 
 exports[`resolveStatements should fail statements for init-vars-analysis-used-uninit-storage-var 1`] = `
 "<unknown>:12:27: Field "value2" is not initialized
-Line 12, col 27:
   11 |     init(arg: Bool) {
 > 12 |         self.value = self.value2 + 1;
                                  ^~~~~~
@@ -740,7 +668,6 @@ Line 12, col 27:
 
 exports[`resolveStatements should fail statements for init-vars-analysis-used-uninit-storage-var-fun-call 1`] = `
 "<unknown>:16:9: Cannot access self before init
-Line 16, col 9:
   15 |     init(arg: Bool) {
 > 16 |         self.update();
                ^~~~~~~~~~~~~
@@ -750,7 +677,6 @@ Line 16, col 9:
 
 exports[`resolveStatements should fail statements for init-vars-analysis-with-if-else 1`] = `
 "<unknown>:10:5: Field "value" is not set
-Line 10, col 5:
    9 |     value: Int;
 > 10 |     init(arg: Bool) {
            ^~~~~~~~~~~~~~~~~
@@ -760,7 +686,6 @@ Line 10, col 5:
 
 exports[`resolveStatements should fail statements for init-vars-analysis-with-if-elseif 1`] = `
 "<unknown>:10:5: Field "value" is not set
-Line 10, col 5:
    9 |     value: Int;
 > 10 |     init(arg: Bool) {
            ^~~~~~~~~~~~~~~~~
@@ -770,7 +695,6 @@ Line 10, col 5:
 
 exports[`resolveStatements should fail statements for return-analysis-catch-if 1`] = `
 "<unknown>:4:1: Function does not always return a result. Adding 'return' statement(s) should fix the issue.
-Line 4, col 1:
   3 | 
 > 4 | fun notAlwaysReachableReturn(b: Bool): Int {
       ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -780,7 +704,6 @@ Line 4, col 1:
 
 exports[`resolveStatements should fail statements for return-analysis-do-if 1`] = `
 "<unknown>:4:1: Function does not always return a result. Adding 'return' statement(s) should fix the issue.
-Line 4, col 1:
   3 | 
 > 4 | fun notAlwaysReachableReturn(b: Bool): Int {
       ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -790,7 +713,6 @@ Line 4, col 1:
 
 exports[`resolveStatements should fail statements for return-analysis-if 1`] = `
 "<unknown>:6:5: Function does not always return a result. Adding 'return' statement(s) should fix the issue.
-Line 6, col 5:
   5 | contract Foo {
 > 6 |     get fun notAlwaysReachableReturn(b: Bool): Int {
           ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -800,7 +722,6 @@ Line 6, col 5:
 
 exports[`resolveStatements should fail statements for return-analysis-if-inside-block-statement 1`] = `
 "<unknown>:6:5: Function does not always return a result. Adding 'return' statement(s) should fix the issue.
-Line 6, col 5:
   5 | contract Foo {
 > 6 |     get fun notAlwaysReachableReturn(b: Bool): Int {
           ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -810,7 +731,6 @@ Line 6, col 5:
 
 exports[`resolveStatements should fail statements for return-analysis-if-with-block-statement 1`] = `
 "<unknown>:6:5: Function does not always return a result. Adding 'return' statement(s) should fix the issue.
-Line 6, col 5:
   5 | contract Foo {
 > 6 |     get fun notAlwaysReachableReturn(b: Bool): Int {
           ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -820,7 +740,6 @@ Line 6, col 5:
 
 exports[`resolveStatements should fail statements for return-analysis-non-void1 1`] = `
 "<unknown>:6:5: Function does not always return a result. Adding 'return' statement(s) should fix the issue.
-Line 6, col 5:
   5 | contract Foo {
 > 6 |     get fun noReturn(): Int {
           ^~~~~~~~~~~~~~~~~~~~~~~~~
@@ -830,7 +749,6 @@ Line 6, col 5:
 
 exports[`resolveStatements should fail statements for return-analysis-non-void2 1`] = `
 "<unknown>:6:5: Function does not always return a result. Adding 'return' statement(s) should fix the issue.
-Line 6, col 5:
   5 | contract Foo {
 > 6 |     get fun noReturn(): Int {
           ^~~~~~~~~~~~~~~~~~~~~~~~~
@@ -840,7 +758,6 @@ Line 6, col 5:
 
 exports[`resolveStatements should fail statements for return-analysis-repeat 1`] = `
 "<unknown>:4:1: Function does not always return a result. Adding 'return' statement(s) should fix the issue.
-Line 4, col 1:
   3 | 
 > 4 | fun notAlwaysReachableReturn(n: Int): Int {
       ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -850,7 +767,6 @@ Line 4, col 1:
 
 exports[`resolveStatements should fail statements for return-analysis-separate-ifs 1`] = `
 "<unknown>:4:1: Function does not always return a result. Adding 'return' statement(s) should fix the issue.
-Line 4, col 1:
   3 | 
 > 4 | fun notAlwaysReachableReturn(b: Bool): Int {
       ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -860,7 +776,6 @@ Line 4, col 1:
 
 exports[`resolveStatements should fail statements for return-analysis-throw-wrapped 1`] = `
 "<unknown>:15:1: Function does not always return a result. Adding 'return' statement(s) should fix the issue.
-Line 15, col 1:
   14 | 
 > 15 | fun notAlwaysReachableReturn(b: Bool): Int {
        ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -870,7 +785,6 @@ Line 15, col 1:
 
 exports[`resolveStatements should fail statements for return-analysis-try1 1`] = `
 "<unknown>:4:1: Function does not always return a result. Adding 'return' statement(s) should fix the issue.
-Line 4, col 1:
   3 | 
 > 4 | fun notAlwaysReachableReturn(b: Bool): Int {
       ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -880,7 +794,6 @@ Line 4, col 1:
 
 exports[`resolveStatements should fail statements for return-analysis-try2 1`] = `
 "<unknown>:7:1: Function does not always return a result. Adding 'return' statement(s) should fix the issue.
-Line 7, col 1:
   6 | 
 > 7 | fun notAlwaysReachableReturn(b: Bool): Int {
       ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -890,7 +803,6 @@ Line 7, col 1:
 
 exports[`resolveStatements should fail statements for return-analysis-while 1`] = `
 "<unknown>:4:1: Function does not always return a result. Adding 'return' statement(s) should fix the issue.
-Line 4, col 1:
   3 | 
 > 4 | fun notAlwaysReachableReturn(b: Bool): Int {
       ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -900,7 +812,6 @@ Line 4, col 1:
 
 exports[`resolveStatements should fail statements for stmt-assgn-int-string 1`] = `
 "<unknown>:9:5: Type mismatch: "String" is not assignable to "Int"
-Line 9, col 5:
    8 | fun isZero(x: Int): Bool {
 >  9 |     x = "hello world";
            ^~~~~~~~~~~~~~~~~~
@@ -910,7 +821,6 @@ Line 9, col 5:
 
 exports[`resolveStatements should fail statements for stmt-augmented-assgn-bool 1`] = `
 "<unknown>:5:5: Type error: Augmented assignment %= is only allowed for Int type
-Line 5, col 5:
   4 |     let a: Bool = false;
 > 5 |     a %= true;
           ^
@@ -920,7 +830,6 @@ Line 5, col 5:
 
 exports[`resolveStatements should fail statements for stmt-augmented-assgn-bool-int 1`] = `
 "<unknown>:9:5: Type error: Augmented assignment += is only allowed for Int type
-Line 9, col 5:
    8 | fun test(x: Bool): Bool {
 >  9 |     x += 1;
            ^
@@ -930,7 +839,6 @@ Line 9, col 5:
 
 exports[`resolveStatements should fail statements for stmt-augmented-assgn-int 1`] = `
 "<unknown>:5:5: Type error: Augmented assignment &&= is only allowed for Bool type
-Line 5, col 5:
   4 |     let a: Int = 1;
 > 5 |     a &&= 1;
           ^
@@ -940,7 +848,6 @@ Line 5, col 5:
 
 exports[`resolveStatements should fail statements for stmt-augmented-assgn-int-bool 1`] = `
 "<unknown>:9:5: Type error: Augmented assignment &&= is only allowed for Bool type
-Line 9, col 5:
    8 | fun test(x: Int): Int {
 >  9 |     x &&= true;
            ^
@@ -950,7 +857,6 @@ Line 9, col 5:
 
 exports[`resolveStatements should fail statements for stmt-augmented-assgn-not-matching 1`] = `
 "<unknown>:10:10: Type error: Augmented assignment += is only allowed for Int type
-Line 10, col 10:
    9 |     let x: Int = 42;
 > 10 |     x += true;
                 ^~~~
@@ -960,7 +866,6 @@ Line 10, col 10:
 
 exports[`resolveStatements should fail statements for stmt-augmented-assgn-string 1`] = `
 "<unknown>:5:5: Type error: Augmented assignment %= is only allowed for Int type
-Line 5, col 5:
   4 |     let a: String = "foo";
 > 5 |     a %= "bar";
           ^
@@ -970,7 +875,6 @@ Line 5, col 5:
 
 exports[`resolveStatements should fail statements for stmt-conditional-expr-stmt-void1 1`] = `
 "<unknown>:5:5: Expressions of "<void>" type cannot be used for conditional expression
-Line 5, col 5:
   4 | fun baz() {
 > 5 |     true ? foo() : bar();
           ^~~~~~~~~~~~~~~~~~~~
@@ -980,7 +884,6 @@ Line 5, col 5:
 
 exports[`resolveStatements should fail statements for stmt-destructuring-fields-duplicate-id 1`] = `
 "<unknown>:15:22: Variable already exists: "x"
-Line 15, col 22:
   14 |     let s = S{ a: 1, b: 2, c: 3 };
 > 15 |     let S { a: x, b: x, c: y } = s;
                             ^
@@ -990,7 +893,6 @@ Line 15, col 22:
 
 exports[`resolveStatements should fail statements for stmt-destructuring-fields-non-destructable 1`] = `
 "<unknown>:16:25: Type 'map<Int, Int>' cannot be destructured
-Line 16, col 25:
   15 |     let m: map<Int, Int> = emptyMap();
 > 16 |     let S { a, b, c } = m;
                                ^
@@ -1000,7 +902,6 @@ Line 16, col 25:
 
 exports[`resolveStatements should fail statements for stmt-destructuring-fields-non-destructable-opt 1`] = `
 "<unknown>:15:25: Type 'S?' is optional and cannot be destructured
-Line 15, col 25:
   14 |     let s: S? = S{ a: 1, b: 2, c: 3 };
 > 15 |     let S { a, b, c } = s;
                                ^
@@ -1010,7 +911,6 @@ Line 15, col 25:
 
 exports[`resolveStatements should fail statements for stmt-destructuring-fields-non-destructable2 1`] = `
 "<unknown>:16:29: Type 'Test' cannot be destructured
-Line 16, col 29:
   15 |         let s = S{ a: 1, b: 2, c: 3 };
 > 16 |         let S { a, b, c } = self;
                                    ^~~~
@@ -1020,7 +920,6 @@ Line 16, col 29:
 
 exports[`resolveStatements should fail statements for stmt-destructuring-fields-non-existing 1`] = `
 "<unknown>:15:19: Field '"d"' not found in type 'S'
-Line 15, col 19:
   14 |     let s = S{ a: 1, b: 2, c: 3 };
 > 15 |     let S { a, b, d: e } = s;
                          ^
@@ -1030,7 +929,6 @@ Line 15, col 19:
 
 exports[`resolveStatements should fail statements for stmt-destructuring-fields-non-existing-punned 1`] = `
 "<unknown>:15:16: Field '"bb"' not found in type 'S'
-Line 15, col 16:
   14 |     let s = S{ a: 1, b: 2, c: 3 };
 > 15 |     let S { a, bb, c } = s;
                       ^~
@@ -1040,7 +938,6 @@ Line 15, col 16:
 
 exports[`resolveStatements should fail statements for stmt-destructuring-fields-non-existing-punned2 1`] = `
 "<unknown>:15:19: Field '"d"' not found in type 'S'
-Line 15, col 19:
   14 |     let s = S{ a: 1, b: 2, c: 3 };
 > 15 |     let S { a, b, d } = s;
                          ^
@@ -1050,7 +947,6 @@ Line 15, col 19:
 
 exports[`resolveStatements should fail statements for stmt-destructuring-fields-non-existing-underscore 1`] = `
 "<unknown>:15:12: Field '"_"' not found in type 'S'
-Line 15, col 12:
   14 |     let s = S{ a: 1, b: 2, c: 3 };
 > 15 |     let S {_, b, c} =  s;
                   ^
@@ -1060,7 +956,6 @@ Line 15, col 12:
 
 exports[`resolveStatements should fail statements for stmt-destructuring-fields-shadowed-const-id 1`] = `
 "<unknown>:17:16: Variable "x" is trying to shadow an existing constant with the same name
-Line 17, col 16:
   16 |     let s = S{ a: 1, b: 2, c: 3 };
 > 17 |     let S { a: x, b: b, c: c } = s;
                       ^
@@ -1070,7 +965,6 @@ Line 17, col 16:
 
 exports[`resolveStatements should fail statements for stmt-destructuring-fields-shadowed-id 1`] = `
 "<unknown>:16:16: Variable already exists: "x"
-Line 16, col 16:
   15 |     let x = 0;
 > 16 |     let S { a: x, b: b, c: c } = s;
                       ^
@@ -1080,7 +974,6 @@ Line 16, col 16:
 
 exports[`resolveStatements should fail statements for stmt-destructuring-fields-wrong-count 1`] = `
 "<unknown>:15:5: Expected 3 fields, but got 2
-Line 15, col 5:
   14 |     let s = S{ a: 1, b: 2, c: 3 };
 > 15 |     let S { a, b } = s;
            ^~~~~~~~~~~~~~~~~~~
@@ -1090,7 +983,6 @@ Line 15, col 5:
 
 exports[`resolveStatements should fail statements for stmt-destructuring-fields-wrong-count2 1`] = `
 "<unknown>:15:5: Expected 3 fields, but got 4
-Line 15, col 5:
   14 |     let s = S{ a: 1, b: 2, c: 3 };
 > 15 |     let S { a, b, c, d } = s;
            ^~~~~~~~~~~~~~~~~~~~~~~~~
@@ -1100,7 +992,6 @@ Line 15, col 5:
 
 exports[`resolveStatements should fail statements for stmt-destructuring-fields-wrong-type 1`] = `
 "<unknown>:18:21: Type mismatch: "S2" is not assignable to "S1"
-Line 18, col 21:
   17 | fun testFunc(): Int {
 > 18 |     let S1 {x, y} = S2 {x: 42, y: 43};
                            ^~~~~~~~~~~~~~~~~
@@ -1110,7 +1001,6 @@ Line 18, col 21:
 
 exports[`resolveStatements should fail statements for stmt-do-int 1`] = `
 "<unknown>:9:5: Type mismatch: "Int" is not assignable to "Bool"
-Line 9, col 5:
    8 | fun isZero(x: Int): Bool {
 >  9 |     do {
            ^~~~
@@ -1120,7 +1010,6 @@ Line 9, col 5:
 
 exports[`resolveStatements should fail statements for stmt-foreach-non-map 1`] = `
 "<unknown>:8:22: foreach can only be used on maps, but "x" has type "Int"
-Line 8, col 22:
   7 | fun foo(x: Int) {
 > 8 |     foreach (k, v in x) {
                            ^
@@ -1130,7 +1019,6 @@ Line 8, col 22:
 
 exports[`resolveStatements should fail statements for stmt-foreach-non-path-map 1`] = `
 "<unknown>:12:22: foreach is only allowed over maps that are path expressions, i.e. identifiers, or sequences of direct contract/struct/message accesses, like "self.foo" or "self.structure.field"
-Line 12, col 22:
   11 | fun foo(x: Int) {
 > 12 |     foreach (k, v in mapFun()) {
                             ^~~~~~~~
@@ -1140,7 +1028,6 @@ Line 12, col 22:
 
 exports[`resolveStatements should fail statements for stmt-if-int 1`] = `
 "<unknown>:9:5: Type mismatch: "Int" is not assignable to "Bool"
-Line 9, col 5:
    8 | fun isZero(x: Int): Bool {
 >  9 |     if (x) {
            ^~~~~~~~
@@ -1150,7 +1037,6 @@ Line 9, col 5:
 
 exports[`resolveStatements should fail statements for stmt-let-unknown-type-inference 1`] = `
 "<unknown>:8:5: Cannot infer type for "a"
-Line 8, col 5:
   7 | fun test() {
 > 8 |     let a = null;
           ^~~~~~~~~~~~~
@@ -1160,7 +1046,6 @@ Line 8, col 5:
 
 exports[`resolveStatements should fail statements for stmt-let-unknown-type-inference2 1`] = `
 "<unknown>:8:5: Cannot infer type for "a"
-Line 8, col 5:
   7 | fun test() {
 > 8 |     let a = emptyMap();
           ^~~~~~~~~~~~~~~~~~~
@@ -1170,7 +1055,6 @@ Line 8, col 5:
 
 exports[`resolveStatements should fail statements for stmt-let-void-inference 1`] = `
 "<unknown>:12:9: The inferred type of variable "voidVar" is "void", which is not allowed
-Line 12, col 9:
   11 |     get fun foo(): Int {
 > 12 |         let voidVar = foo();
                ^~~~~~~~~~~~~~~~~~~~
@@ -1180,7 +1064,6 @@ Line 12, col 9:
 
 exports[`resolveStatements should fail statements for stmt-let-wrong-rhs 1`] = `
 "<unknown>:10:5: Type mismatch: "Int" is not assignable to "Bool"
-Line 10, col 5:
    9 |     let a: Int = 0;
 > 10 |     let b: Bool = 0;
            ^~~~~~~~~~~~~~~~
@@ -1190,7 +1073,6 @@ Line 10, col 5:
 
 exports[`resolveStatements should fail statements for stmt-repeat-bool 1`] = `
 "<unknown>:9:5: Type mismatch: "Bool" is not assignable to "Int"
-Line 9, col 5:
    8 | fun isZero(x: Int): Bool {
 >  9 |     repeat(true) {
            ^~~~~~~~~~~~~~
@@ -1200,7 +1082,6 @@ Line 9, col 5:
 
 exports[`resolveStatements should fail statements for stmt-return-from-try-and-catch 1`] = `
 "<unknown>:8:9: Type mismatch: "Int" is not assignable to "String"
-Line 8, col 9:
   7 |     } catch (e) {
 > 8 |         return e;
               ^~~~~~~~~
@@ -1210,7 +1091,6 @@ Line 8, col 9:
 
 exports[`resolveStatements should fail statements for stmt-return-void1 1`] = `
 "<unknown>:4:5: 'return' statement can only be used with non-void types
-Line 4, col 5:
   3 | fun bar() {
 > 4 |     return foo()
           ^~~~~~~~~~~~
@@ -1220,7 +1100,6 @@ Line 4, col 5:
 
 exports[`resolveStatements should fail statements for stmt-return-void2 1`] = `
 "<unknown>:6:5: Type mismatch: "Int" is not assignable to "<void>"
-Line 6, col 5:
   5 | fun bar() {
 > 6 |     return foo()
           ^~~~~~~~~~~~
@@ -1230,7 +1109,6 @@ Line 6, col 5:
 
 exports[`resolveStatements should fail statements for stmt-return-void3 1`] = `
 "<unknown>:3:18: The function fails to return a result of type "Int"
-Line 3, col 18:
   2 | 
 > 3 | fun bar(): Int { return }
                        ^~~~~~
@@ -1240,7 +1118,6 @@ Line 3, col 18:
 
 exports[`resolveStatements should fail statements for stmt-unboxing-expr-stmt-void 1`] = `
 "<unknown>:4:5: Type "<void>" is not optional
-Line 4, col 5:
   3 | fun bar() {
 > 4 |     foo()!!
           ^~~~~~~
@@ -1250,7 +1127,6 @@ Line 4, col 5:
 
 exports[`resolveStatements should fail statements for stmt-while-int 1`] = `
 "<unknown>:9:5: Type mismatch: "Int" is not assignable to "Bool"
-Line 9, col 5:
    8 | fun isZero(x: Int): Bool {
 >  9 |     while(x) {
            ^~~~~~~~~~
@@ -1260,7 +1136,6 @@ Line 9, col 5:
 
 exports[`resolveStatements should fail statements for usage-of-bounced-field-in-type-that-is-too-big 1`] = `
 "<unknown>:14:29: Maximum size of the bounced message is 224 bytes, but the "amount" field of type "Withdraw" cannot fit into it due to the size of previous fields or its own size, so it cannot be accessed. Make the type of the fields before this one smaller, or reduce the type of this field so that it fits into 224 bytes
-Line 14, col 29:
   13 |         self.balance += msg.data; // ok
 > 14 |         self.balance += msg.amount;
                                    ^~~~~~
@@ -1270,7 +1145,6 @@ Line 14, col 29:
 
 exports[`resolveStatements should fail statements for usage-of-bounced-field-in-type-that-is-too-big-2 1`] = `
 "<unknown>:26:29: Maximum size of the bounced message is 224 bytes, but the "amount" field of type "Withdraw" cannot fit into it due to the size of previous fields or its own size, so it cannot be accessed. Make the type of the fields before this one smaller, or reduce the type of this field so that it fits into 224 bytes
-Line 26, col 29:
   25 | 
 > 26 |         self.balance += msg.amount;
                                    ^~~~~~
@@ -1280,7 +1154,6 @@ Line 26, col 29:
 
 exports[`resolveStatements should fail statements for usage-of-bounced-field-that-is-too-big 1`] = `
 "<unknown>:12:29: Maximum size of the bounced message is 224 bytes, but the "amount" field of type "Withdraw" cannot fit into it because its too big, so it cannot be accessed. Reduce the type of this field so that it fits into 224 bytes
-Line 12, col 29:
   11 |     bounced(msg: bounced<Withdraw>){
 > 12 |         self.balance += msg.amount;
                                    ^~~~~~
@@ -1290,7 +1163,6 @@ Line 12, col 29:
 
 exports[`resolveStatements should fail statements for var-does-not-exist 1`] = `
 "<unknown>:5:9: Unable to resolve id 'nonExistentVariable'
-Line 5, col 9:
   4 |     receive() {
 > 5 |         nonExistentVariable = 42;
               ^~~~~~~~~~~~~~~~~~~
@@ -1300,7 +1172,6 @@ Line 5, col 9:
 
 exports[`resolveStatements should fail statements for var-does-not-exist2 1`] = `
 "<unknown>:13:9: Unable to resolve id 'someField', did you mean 'self.someField'?
-Line 13, col 9:
   12 |     receive() {
 > 13 |         someField = 42;
                ^~~~~~~~~
@@ -1310,7 +1181,6 @@ Line 13, col 9:
 
 exports[`resolveStatements should fail statements for var-does-not-exist3 1`] = `
 "<unknown>:17:9: Unable to resolve id 'someField', did you mean 'self.someField'?
-Line 17, col 9:
   16 |     receive() {
 > 17 |         someField = 42;
                ^~~~~~~~~
@@ -1320,7 +1190,6 @@ Line 17, col 9:
 
 exports[`resolveStatements should fail statements for var-does-not-exist4 1`] = `
 "<unknown>:9:9: Unable to resolve id 'someField', did you mean 'self.someField'?
-Line 9, col 9:
    8 |     receive() {
 >  9 |         someField = 42;
                ^~~~~~~~~
@@ -1330,7 +1199,6 @@ Line 9, col 9:
 
 exports[`resolveStatements should fail statements for var-scope-block-statement 1`] = `
 "<unknown>:6:13: Variable already exists: "a"
-Line 6, col 13:
   5 |     {
 > 6 |         let a: Int = 456;
                   ^
@@ -1340,7 +1208,6 @@ Line 6, col 13:
 
 exports[`resolveStatements should fail statements for var-scope-block-statement-use-after-block 1`] = `
 "<unknown>:7:12: Unable to resolve id 'a'
-Line 7, col 12:
   6 |     }
 > 7 |     return a;
                  ^
@@ -1350,7 +1217,6 @@ Line 7, col 12:
 
 exports[`resolveStatements should fail statements for var-scope-catch-does-not-shadow-outer-const 1`] = `
 "<unknown>:10:13: Variable "e" is trying to shadow an existing constant with the same name
-Line 10, col 13:
    9 |     } catch (err) {
 > 10 |         let e: String = "rty";
                    ^
@@ -1360,7 +1226,6 @@ Line 10, col 13:
 
 exports[`resolveStatements should fail statements for var-scope-catch-does-not-shadow-outer-var 1`] = `
 "<unknown>:9:13: Variable already exists: "e"
-Line 9, col 13:
    8 |     } catch (err) {
 >  9 |         let e: String = "rty";
                    ^
@@ -1370,7 +1235,6 @@ Line 9, col 13:
 
 exports[`resolveStatements should fail statements for var-scope-catch-param-does-not-shadow-outer-var 1`] = `
 "<unknown>:8:14: Variable already exists: "e"
-Line 8, col 14:
   7 |         return e;
 > 8 |     } catch (e) {
                    ^
@@ -1380,7 +1244,6 @@ Line 8, col 14:
 
 exports[`resolveStatements should fail statements for var-scope-catch-param-is-not-visible-in-try 1`] = `
 "<unknown>:5:16: Unable to resolve id 'e'
-Line 5, col 16:
   4 |     try {
 > 5 |         return e;
                      ^
@@ -1390,7 +1253,6 @@ Line 5, col 16:
 
 exports[`resolveStatements should fail statements for var-scope-const-shadowing-catch 1`] = `
 "<unknown>:7:12: Variable "foo" is trying to shadow an existing constant with the same name
-Line 7, col 12:
   6 |     try { }
 > 7 |     catch (foo) {   // <-- \`foo\` shadows global const \`foo\`
                  ^~~
@@ -1400,7 +1262,6 @@ Line 7, col 12:
 
 exports[`resolveStatements should fail statements for var-scope-const-shadowing-external-param 1`] = `
 "<unknown>:9:15: Variable "foo" is trying to shadow an existing constant with the same name
-Line 9, col 15:
    8 | contract Test {
 >  9 |     external (foo: Message) { // <-- \`foo\` shadows global const \`foo\`
                      ^~~
@@ -1410,7 +1271,6 @@ Line 9, col 15:
 
 exports[`resolveStatements should fail statements for var-scope-const-shadowing-foreach 1`] = `
 "<unknown>:7:14: Variable "foo" is trying to shadow an existing constant with the same name
-Line 7, col 14:
   6 |     let m: map<Int, Int> = null;
 > 7 |     foreach (foo, _ in m) {  // <--- attempt to shadow \`foo\` const
                    ^~~
@@ -1420,7 +1280,6 @@ Line 7, col 14:
 
 exports[`resolveStatements should fail statements for var-scope-const-shadowing-fun-param 1`] = `
 "<unknown>:5:9: Variable "foo" is trying to shadow an existing constant with the same name
-Line 5, col 9:
   4 | 
 > 5 | fun bar(foo: Int): Int {  // <-- fun param \`foo\` shadows global const \`foo\`
               ^~~
@@ -1430,7 +1289,6 @@ Line 5, col 9:
 
 exports[`resolveStatements should fail statements for var-scope-const-shadowing-let 1`] = `
 "<unknown>:6:9: Variable "foo" is trying to shadow an existing constant with the same name
-Line 6, col 9:
   5 | fun bar(): Int {
 > 6 |     let foo = 43;  // <-- local var \`foo\` shadows global const \`foo\`
               ^~~
@@ -1440,7 +1298,6 @@ Line 6, col 9:
 
 exports[`resolveStatements should fail statements for var-scope-const-shadowing-receiver-param 1`] = `
 "<unknown>:9:14: Variable "foo" is trying to shadow an existing constant with the same name
-Line 9, col 14:
    8 | contract Test {
 >  9 |     receive (foo: Message) { // <-- \`foo\` shadows global const \`foo\`
                     ^~~
@@ -1450,7 +1307,6 @@ Line 9, col 14:
 
 exports[`resolveStatements should fail statements for var-scope-do-until-shadows-outer-const 1`] = `
 "<unknown>:8:13: Variable "B" is trying to shadow an existing constant with the same name
-Line 8, col 13:
   7 |     do {
 > 8 |         let B: Int = a + 3;
                   ^
@@ -1460,7 +1316,6 @@ Line 8, col 13:
 
 exports[`resolveStatements should fail statements for var-scope-do-until-shadows-outer-var 1`] = `
 "<unknown>:7:13: Variable already exists: "b"
-Line 7, col 13:
   6 |     do {
 > 7 |         let b: Int = a + 3;
                   ^
@@ -1470,7 +1325,6 @@ Line 7, col 13:
 
 exports[`resolveStatements should fail statements for var-scope-external-shadows-param 1`] = `
 "<unknown>:8:13: Variable already exists: "foo"
-Line 8, col 13:
   7 |     external (foo: Message) {
 > 8 |         let foo: Int = 0;
                   ^~~
@@ -1480,7 +1334,6 @@ Line 8, col 13:
 
 exports[`resolveStatements should fail statements for var-scope-foreach-internal-var-does-not-escape 1`] = `
 "<unknown>:8:12: Unable to resolve id 'x'
-Line 8, col 12:
   7 |     }
 > 8 |     return x;
                  ^
@@ -1490,7 +1343,6 @@ Line 8, col 12:
 
 exports[`resolveStatements should fail statements for var-scope-foreach-key-does-not-escape 1`] = `
 "<unknown>:8:12: Unable to resolve id 'k'
-Line 8, col 12:
   7 |     }
 > 8 |     return k;
                  ^
@@ -1500,7 +1352,6 @@ Line 8, col 12:
 
 exports[`resolveStatements should fail statements for var-scope-foreach-key-shadows-map 1`] = `
 "<unknown>:5:14: Variable already exists: "m"
-Line 5, col 14:
   4 |     let m: map<Int, Int> = emptyMap();
 > 5 |     foreach (m, v in m) {
                    ^
@@ -1510,7 +1361,6 @@ Line 5, col 14:
 
 exports[`resolveStatements should fail statements for var-scope-foreach-key-shadows-outer-var 1`] = `
 "<unknown>:6:14: Variable already exists: "a"
-Line 6, col 14:
   5 |     let a: Int = 4;
 > 6 |     foreach (a, v in m) {
                    ^
@@ -1520,7 +1370,6 @@ Line 6, col 14:
 
 exports[`resolveStatements should fail statements for var-scope-foreach-shadows-outer-const 1`] = `
 "<unknown>:8:13: Variable "m" is trying to shadow an existing constant with the same name
-Line 8, col 13:
   7 |     foreach (k, v in m) {
 > 8 |         let m: map<Int, Int> = emptyMap();
                   ^
@@ -1530,7 +1379,6 @@ Line 8, col 13:
 
 exports[`resolveStatements should fail statements for var-scope-foreach-shadows-outer-map 1`] = `
 "<unknown>:7:13: Variable already exists: "m"
-Line 7, col 13:
   6 |     foreach (k, v in m) {
 > 7 |         let m: map<Int, Int> = emptyMap();
                   ^
@@ -1540,7 +1388,6 @@ Line 7, col 13:
 
 exports[`resolveStatements should fail statements for var-scope-foreach-shadows-outer-var 1`] = `
 "<unknown>:7:13: Variable already exists: "a"
-Line 7, col 13:
   6 |     foreach (k, v in m) {
 > 7 |         let a: Int = 5;
                   ^
@@ -1550,7 +1397,6 @@ Line 7, col 13:
 
 exports[`resolveStatements should fail statements for var-scope-foreach-val-does-not-escape 1`] = `
 "<unknown>:8:12: Unable to resolve id 'v'
-Line 8, col 12:
   7 |     }
 > 8 |     return v;
                  ^
@@ -1560,7 +1406,6 @@ Line 8, col 12:
 
 exports[`resolveStatements should fail statements for var-scope-foreach-val-shadows-const-map 1`] = `
 "<unknown>:6:17: Variable "m" is trying to shadow an existing constant with the same name
-Line 6, col 17:
   5 | fun test() {
 > 6 |     foreach (k, m in m) {
                       ^
@@ -1570,7 +1415,6 @@ Line 6, col 17:
 
 exports[`resolveStatements should fail statements for var-scope-foreach-val-shadows-key 1`] = `
 "<unknown>:5:17: Variable already exists: "k"
-Line 5, col 17:
   4 |     let m: map<Int, Int> = emptyMap();
 > 5 |     foreach (k, k in m) {
                       ^
@@ -1580,7 +1424,6 @@ Line 5, col 17:
 
 exports[`resolveStatements should fail statements for var-scope-foreach-val-shadows-map 1`] = `
 "<unknown>:5:17: Variable already exists: "m"
-Line 5, col 17:
   4 |     let m: map<Int, Int> = emptyMap();
 > 5 |     foreach (k, m in m) {
                       ^
@@ -1590,7 +1433,6 @@ Line 5, col 17:
 
 exports[`resolveStatements should fail statements for var-scope-foreach-val-shadows-outer-var 1`] = `
 "<unknown>:6:17: Variable already exists: "a"
-Line 6, col 17:
   5 |     let a: Int = 4;
 > 6 |     foreach (k, a in m) {
                       ^
@@ -1600,7 +1442,6 @@ Line 6, col 17:
 
 exports[`resolveStatements should fail statements for var-scope-function-shadows-local-var 1`] = `
 "<unknown>:5:9: Variable already exists: "c"
-Line 5, col 9:
   4 |     let c: Int = 456;
 > 5 |     let c: Int = 10;
               ^
@@ -1610,7 +1451,6 @@ Line 5, col 9:
 
 exports[`resolveStatements should fail statements for var-scope-function-shadows-param 1`] = `
 "<unknown>:4:9: Variable already exists: "b"
-Line 4, col 9:
   3 | fun testFunction(a: Int, b: Int): Int {
 > 4 |     let b: Int = 456;
               ^
@@ -1620,7 +1460,6 @@ Line 4, col 9:
 
 exports[`resolveStatements should fail statements for var-scope-if-else-shadows-outer-const 1`] = `
 "<unknown>:10:13: Variable "A" is trying to shadow an existing constant with the same name
-Line 10, col 13:
    9 |     } else {
 > 10 |         let A: Int = 2;
                    ^
@@ -1630,7 +1469,6 @@ Line 10, col 13:
 
 exports[`resolveStatements should fail statements for var-scope-if-else-shadows-outer-var 1`] = `
 "<unknown>:9:13: Variable already exists: "a"
-Line 9, col 13:
    8 |     } else {
 >  9 |         let a: Int = 2;
                    ^
@@ -1640,7 +1478,6 @@ Line 9, col 13:
 
 exports[`resolveStatements should fail statements for var-scope-if-then-shadows-outer-const 1`] = `
 "<unknown>:8:13: Variable "A" is trying to shadow an existing constant with the same name
-Line 8, col 13:
   7 |     if (true) {
 > 8 |         let A: Int = 2;
                   ^
@@ -1650,7 +1487,6 @@ Line 8, col 13:
 
 exports[`resolveStatements should fail statements for var-scope-if-then-shadows-outer-var 1`] = `
 "<unknown>:7:13: Variable already exists: "a"
-Line 7, col 13:
   6 |     if (true) {
 > 7 |         let a: Int = 2;
                   ^
@@ -1660,7 +1496,6 @@ Line 7, col 13:
 
 exports[`resolveStatements should fail statements for var-scope-local-catch-param-does-not-escape 1`] = `
 "<unknown>:9:12: Unable to resolve id 'e'
-Line 9, col 12:
    8 |     }
 >  9 |     return e;
                   ^
@@ -1670,7 +1505,6 @@ Line 9, col 12:
 
 exports[`resolveStatements should fail statements for var-scope-local-loop-var-does-not-escape 1`] = `
 "<unknown>:9:12: Unable to resolve id 'c'
-Line 9, col 12:
    8 |     }
 >  9 |     return c;
                   ^
@@ -1680,7 +1514,6 @@ Line 9, col 12:
 
 exports[`resolveStatements should fail statements for var-scope-missing-storage-var 1`] = `
 "<unknown>:5:14: Type "Test" does not have a field named "nonExistentField"
-Line 5, col 14:
   4 |     init() {
 > 5 |         self.nonExistentField = 42;
                    ^~~~~~~~~~~~~~~~
@@ -1690,7 +1523,6 @@ Line 5, col 14:
 
 exports[`resolveStatements should fail statements for var-scope-nested-block-statement 1`] = `
 "<unknown>:9:25: Variable already exists: "a"
-Line 9, col 25:
    8 |                 {
 >  9 |                     let a: Int = 456;
                                ^
@@ -1700,7 +1532,6 @@ Line 9, col 25:
 
 exports[`resolveStatements should fail statements for var-scope-no-toString-global-fun1 1`] = `
 "<unknown>:7:9: Static function "toString" does not exist
-Line 7, col 9:
   6 |     init() {
 > 7 |         toString(); // non-existent function
               ^~~~~~~~~~
@@ -1710,7 +1541,6 @@ Line 7, col 9:
 
 exports[`resolveStatements should fail statements for var-scope-no-toString-global-fun2 1`] = `
 "<unknown>:6:12: Static function "toString" does not exist. Perhaps you meant to call ".toString(...)" extension function?
-Line 6, col 12:
   5 | extends fun toString(self: WrappedInt): Int {
 > 6 |     return toString(self.x);
                  ^~~~~~~~~~~~~~~~
@@ -1720,7 +1550,6 @@ Line 6, col 12:
 
 exports[`resolveStatements should fail statements for var-scope-no-valueOf-global-fun 1`] = `
 "<unknown>:4:5: Static function "valueOf" does not exist
-Line 4, col 5:
   3 | fun foo(x: Int) {
 > 4 |     valueOf(x);
           ^~~~~~~~~~
@@ -1730,7 +1559,6 @@ Line 4, col 5:
 
 exports[`resolveStatements should fail statements for var-scope-rec-fun-shadowing-catch 1`] = `
 "<unknown>:6:14: Variable cannot have the same name as its enclosing function: "rec"
-Line 6, col 14:
   5 |         42/0;
 > 6 |     } catch (rec) {  // <-- shadowing
                    ^~~
@@ -1740,7 +1568,6 @@ Line 6, col 14:
 
 exports[`resolveStatements should fail statements for var-scope-rec-fun-shadowing-foreach 1`] = `
 "<unknown>:5:14: Variable cannot have the same name as its enclosing function: "rec"
-Line 5, col 14:
   4 |     let m: map<Int, Int> = null;
 > 5 |     foreach (rec, _ in m) {   // shadowing error
                    ^~~
@@ -1750,7 +1577,6 @@ Line 5, col 14:
 
 exports[`resolveStatements should fail statements for var-scope-rec-fun-shadowing-fun-param 1`] = `
 "<unknown>:3:9: Variable cannot have the same name as its enclosing function: "rec"
-Line 3, col 9:
   2 | 
 > 3 | fun rec(rec: Int): Int { // <-- shadowing
               ^~~
@@ -1760,7 +1586,6 @@ Line 3, col 9:
 
 exports[`resolveStatements should fail statements for var-scope-rec-fun-shadowing-let 1`] = `
 "<unknown>:4:9: Variable cannot have the same name as its enclosing function: "rec"
-Line 4, col 9:
   3 | fun rec(): Int {
 > 4 |     let rec: Int = 42;  // shadowing error
               ^~~
@@ -1770,7 +1595,6 @@ Line 4, col 9:
 
 exports[`resolveStatements should fail statements for var-scope-receiver-shadows-param 1`] = `
 "<unknown>:8:13: Variable already exists: "foo"
-Line 8, col 13:
   7 |     receive (foo: Message) {
 > 8 |         let foo: Int = 0;
                   ^~~
@@ -1780,7 +1604,6 @@ Line 8, col 13:
 
 exports[`resolveStatements should fail statements for var-scope-repeat-shadows-outer-const 1`] = `
 "<unknown>:8:13: Variable "B" is trying to shadow an existing constant with the same name
-Line 8, col 13:
   7 |     repeat (a) {
 > 8 |         let B: Int = a + 3;
                   ^
@@ -1790,7 +1613,6 @@ Line 8, col 13:
 
 exports[`resolveStatements should fail statements for var-scope-repeat-shadows-outer-var 1`] = `
 "<unknown>:7:13: Variable already exists: "b"
-Line 7, col 13:
   6 |     repeat (a) {
 > 7 |         let b: Int = a + 3;
                   ^
@@ -1800,7 +1622,6 @@ Line 7, col 13:
 
 exports[`resolveStatements should fail statements for var-scope-try-does-not-shadow-outer-const 1`] = `
 "<unknown>:8:13: Variable "e" is trying to shadow an existing constant with the same name
-Line 8, col 13:
   7 |     try {
 > 8 |         let e: String = "rty";
                   ^
@@ -1810,7 +1631,6 @@ Line 8, col 13:
 
 exports[`resolveStatements should fail statements for var-scope-try-does-not-shadow-outer-var 1`] = `
 "<unknown>:7:13: Variable already exists: "e"
-Line 7, col 13:
   6 |     try {
 > 7 |         let e: String = "rty";
                   ^
@@ -1820,7 +1640,6 @@ Line 7, col 13:
 
 exports[`resolveStatements should fail statements for var-scope-while-shadows-outer-const 1`] = `
 "<unknown>:8:13: Variable "B" is trying to shadow an existing constant with the same name
-Line 8, col 13:
   7 |     while (true) {
 > 8 |         let B: Int = a + 3;
                   ^
@@ -1830,7 +1649,6 @@ Line 8, col 13:
 
 exports[`resolveStatements should fail statements for var-scope-while-shadows-outer-var 1`] = `
 "<unknown>:7:13: Variable already exists: "b"
-Line 7, col 13:
   6 |     while (true) {
 > 7 |         let b: Int = a + 3;
                   ^
@@ -1840,7 +1658,6 @@ Line 7, col 13:
 
 exports[`resolveStatements should fail statements for var-underscore-name-access 1`] = `
 "<unknown>:6:16: Wildcard variable name '_' cannot be accessed
-Line 6, col 16:
   5 |     foreach (_, _ in m) {
 > 6 |         return _;
                      ^
@@ -1850,7 +1667,6 @@ Line 6, col 16:
 
 exports[`resolveStatements should fail statements for var-underscore-name-access2 1`] = `
 "<unknown>:7:14: Wildcard variable name '_' cannot be accessed
-Line 7, col 14:
   6 |     foreach (_, v in m) {
 > 7 |         x += _;
                    ^
@@ -1860,7 +1676,6 @@ Line 7, col 14:
 
 exports[`resolveStatements should fail statements for var-underscore-name-access3 1`] = `
 "<unknown>:9:12: Wildcard variable name '_' cannot be accessed
-Line 9, col 12:
    8 |     let _: Int = someImpureFunction();
 >  9 |     return _;
                   ^
@@ -1870,7 +1685,6 @@ Line 9, col 12:
 
 exports[`resolveStatements should fail statements for wf-type-let 1`] = `
 "<unknown>:5:16: Invalid map type. Check https://docs.tact-lang.org/book/maps#allowed-types
-Line 5, col 16:
   4 | fun foo() {
 > 5 |     let m: map<String, Int> = null;
                      ^~~~~~


### PR DESCRIPTION
Example error:

```
Error: test/main.tact:5:20: Type "Int1" not found
  4 | contract Master {
> 5 |     get fun foo(): Int1 {
                         ^~~~
  6 |
```

## Issue

Closes #1359.

## Checklist

- [x] I have updated CHANGELOG.md
- [x] I have added tests to demonstrate the contribution is correctly implemented: this usually includes both positive and negative tests, showing the happy path(s) and featuring intentionally broken cases
- [x] I have run all the tests locally and no test failure was reported
- [x] I have run the linter, formatter and spellchecker
- [x] I did not do unrelated and/or undiscussed refactorings
