### PR TITLE
refactor: move and rename `src/prettyPrinter.ts` to `src/ast/ast-printer.ts`

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -176,7 +176,7 @@ Some other codegen tests are as follows:
 
 ### Pretty-printer and AST comparators
 
-The entry point to the Tact AST pretty-printer is [src/prettyPrinter.ts](./src/prettyPrinter.ts). It is going to be used for the Tact source code formatter once the parser keeps comments and other relevant information.
+The entry point to the Tact AST pretty-printer is [src/ast/ast-printer.ts](./src/ast/ast-printer.ts). It is going to be used for the Tact source code formatter once the parser keeps comments and other relevant information.
 
 The AST comparator is defined in [src/ast/compare.ts](./src/ast/compare.ts). This is useful, for instance, for static analysis tools which can re-use the Tact TypeScript API.
 

--- a/knip.json
+++ b/knip.json
@@ -5,7 +5,7 @@
   "ignore": [
     "src/ast/ast.ts",
     "src/config/parseConfig.ts",
-    "src/prettyPrinter.ts",
+    "src/ast/ast-printer.ts",
     "src/error/display-to-json.ts",
     "src/grammar/src-info.ts",
     "src/grammar/next/grammar.ts",

--- a/src/ast/ast-printer.spec.ts
+++ b/src/ast/ast-printer.spec.ts
@@ -1,11 +1,11 @@
 import fs from "fs";
-import { prettyPrint } from "../ast/ast-printer";
+import { prettyPrint } from "./ast-printer";
 import { getParser } from "../grammar";
 import { join } from "path";
-import { trimTrailingCR, CONTRACTS_DIR } from "./util";
+import { trimTrailingCR, CONTRACTS_DIR } from "../test/util";
 import * as assert from "assert";
 import JSONBig from "json-bigint";
-import { getAstFactory } from "../ast/ast";
+import { getAstFactory } from "./ast";
 import { defaultParser } from "../grammar/grammar";
 
 describe("formatter", () => {

--- a/src/ast/ast-printer.ts
+++ b/src/ast/ast-printer.ts
@@ -1,6 +1,6 @@
-import * as A from "./ast/ast";
-import { groupBy, intercalate, isUndefined } from "./utils/array";
-import { makeVisitor } from "./utils/tricks";
+import * as A from "./ast";
+import { groupBy, intercalate, isUndefined } from "../utils/array";
+import { makeVisitor } from "../utils/tricks";
 
 //
 // Types

--- a/src/generator/writers/writeFunction.ts
+++ b/src/generator/writers/writeFunction.ts
@@ -23,7 +23,7 @@ import { resolveFuncTupleType } from "./resolveFuncTupleType";
 import { ops } from "./ops";
 import { freshIdentifier } from "./freshIdentifier";
 import { idTextErr, throwInternalCompilerError } from "../../error/errors";
-import { ppAsmShuffle } from "../../prettyPrinter";
+import { ppAsmShuffle } from "../../ast/ast-printer";
 
 export function writeCastedExpression(
     expression: AstExpression,

--- a/src/test/prettyPrinter.spec.ts
+++ b/src/test/prettyPrinter.spec.ts
@@ -1,5 +1,5 @@
 import fs from "fs";
-import { prettyPrint } from "../prettyPrinter";
+import { prettyPrint } from "../ast/ast-printer";
 import { getParser } from "../grammar";
 import { join } from "path";
 import { trimTrailingCR, CONTRACTS_DIR } from "./util";

--- a/src/test/rename.spec.ts
+++ b/src/test/rename.spec.ts
@@ -1,7 +1,7 @@
 import fs from "fs";
 import { join } from "path";
 import { AstRenamer } from "../ast/rename";
-import { prettyPrint } from "../prettyPrinter";
+import { prettyPrint } from "../ast/ast-printer";
 import { trimTrailingCR, CONTRACTS_DIR } from "./util";
 import * as assert from "assert";
 import { getParser } from "../grammar";

--- a/src/types/resolveExpression.ts
+++ b/src/types/resolveExpression.ts
@@ -39,7 +39,7 @@ import { GlobalFunctions } from "../abi/global";
 import { isAssignable, moreGeneralType } from "./subtyping";
 import { throwInternalCompilerError } from "../error/errors";
 import { StructFunctions } from "../abi/struct";
-import { prettyPrint } from "../prettyPrinter";
+import { prettyPrint } from "../ast/ast-printer";
 
 const store = createContextStore<{
     ast: AstExpression;


### PR DESCRIPTION
## Issue

Closes #1420.

## Checklist

- [x] I have run all the tests locally and no test failure was reported
- [x] I have run the linter, formatter and spellchecker
- [x] I did not do unrelated and/or undiscussed refactorings
