### PR TITLE
fix(imports): allow importing FunC files with .func extension

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Support `AstTypedParameter` AST node in pretty printer: PR [#1347](https://github.com/tact-lang/tact/pull/1347)
 - Show stacktrace of a compiler error only in verbose mode: PR [#1375](https://github.com/tact-lang/tact/pull/1375)
 - Flag name in help (`--project` to `--projects`): PR [#1419](https://github.com/tact-lang/tact/pull/1419)
+- Allow importing FunC files with `.func` extension: PR [#1451](https://github.com/tact-lang/tact/pull/1451)
 
 ### Docs
 

--- a/src/imports/resolveLibrary.ts
+++ b/src/imports/resolveLibrary.ts
@@ -53,11 +53,14 @@ export function resolveLibrary(args: ResolveLibraryArgs): ResolveLibraryResult {
     const workingDirectory = args.path.slice(vfs.root.length);
 
     // Resolving relative file
-    let importName = args.name;
-    const kind: "tact" | "func" = importName.endsWith(".fc") ? "func" : "tact";
-    if (!importName.endsWith(".tact") && !importName.endsWith(".fc")) {
-        importName = importName + ".tact";
-    }
+    const kind =
+        args.name.endsWith(".fc") || args.name.endsWith(".func")
+            ? "func"
+            : "tact";
+    const importName =
+        kind === "func" || args.name.endsWith(".tact")
+            ? args.name
+            : `${args.name}.tact`;
 
     // Resolve import
     const parsedImport = parseImportPath(importName);

--- a/src/test/codegen/all-contracts.tact
+++ b/src/test/codegen/all-contracts.tact
@@ -8,3 +8,4 @@ import "./mutating-method-on-non-lvalues";
 import "./var-scope-global-fun-shadowing-allowed";
 import "./map-uint-bool-get";
 import "./emptyMap-in-equality";
+import "./func.func";

--- a/src/test/codegen/func.func
+++ b/src/test/codegen/func.func
@@ -1,0 +1,1 @@
+;; an empty FunC file to test imports of files with .func extension


### PR DESCRIPTION
This fixes issue 1 of Trail of Bits security audit (2024)

Original commit: https://github.com/tact-lang/tact/commit/abe8746d26aa968c7d9d19e30f3e49524d508f1d

## Issue

Closes #1379.

## Checklist

- [x] I have updated CHANGELOG.md
- [x] I have added tests to demonstrate the contribution is correctly implemented: this usually includes both positive and negative tests, showing the happy path(s) and featuring intentionally broken cases
- [x] I have run all the tests locally and no test failure was reported
- [x] I have run the linter, formatter and spellchecker
- [x] I did not do unrelated and/or undiscussed refactorings
