### PR TITLE
fix(traits): error on circular trait dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Support `AstTypedParameter` AST node in pretty printer: PR [#1347](https://github.com/tact-lang/tact/pull/1347)
 - Show stacktrace of a compiler error only in verbose mode: PR [#1375](https://github.com/tact-lang/tact/pull/1375)
 - Flag name in help (`--project` to `--projects`): PR [#1419](https://github.com/tact-lang/tact/pull/1419)
+- Error on circular trait dependencies: PR [#1452](https://github.com/tact-lang/tact/pull/1452)
 
 ### Docs
 

--- a/src/types/__snapshots__/resolveDescriptors.spec.ts.snap
+++ b/src/types/__snapshots__/resolveDescriptors.spec.ts.snap
@@ -699,6 +699,24 @@ exports[`resolveDescriptors should fail descriptors for struct-decl-self-referen
 "
 `;
 
+exports[`resolveDescriptors should fail descriptors for trait-circular-deps 1`] = `
+"<unknown>:3:1: Circular dependency detected for type "A"
+  2 | 
+> 3 | trait A with B {}
+      ^~~~~~~~~~~~~~~~~
+  4 | trait B with A {}
+"
+`;
+
+exports[`resolveDescriptors should fail descriptors for trait-circular-deps-with-deep-inheritance 1`] = `
+"<unknown>:3:1: Circular dependency detected for type "A"
+  2 | 
+> 3 | trait A with B {}
+      ^~~~~~~~~~~~~~~~~
+  4 | trait B with C {}
+"
+`;
+
 exports[`resolveDescriptors should fail descriptors for trait-duplicates-in-trait-list 1`] = `
 "<unknown>:7:1: The list of inherited traits for trait "Test" has duplicates
   6 | 

--- a/src/types/resolveDescriptors.ts
+++ b/src/types/resolveDescriptors.ts
@@ -1849,7 +1849,7 @@ export function resolveDescriptors(ctx: CompilerContext, Ast: FactoryAst) {
                 types.get(name)!.ast.loc,
             );
         }
-        processing.has(name);
+        processing.add(name);
 
         // Process dependencies first
         const dependencies = Array.from(types.values()).filter((v) =>

--- a/src/types/test-failed/trait-circular-deps-with-deep-inheritance.tact
+++ b/src/types/test-failed/trait-circular-deps-with-deep-inheritance.tact
@@ -1,0 +1,8 @@
+trait BaseTrait {}
+
+trait A with B {}
+trait B with C {}
+trait C with D {}
+trait D with A {}
+
+contract Test with A {}

--- a/src/types/test-failed/trait-circular-deps.tact
+++ b/src/types/test-failed/trait-circular-deps.tact
@@ -1,0 +1,6 @@
+trait BaseTrait {}
+
+trait A with B {}
+trait B with A {}
+
+contract Test with A {}


### PR DESCRIPTION
This fixes issue 2 of Trail of Bits security audit (2024)

Original commit: https://github.com/tact-lang/tact/commit/d12cf9427b5e96a4c14604c058b59e9f610e33e8

Added additional test with deep inheritance.

## Issue

Closes #1380.

## Checklist

- [x] I have updated CHANGELOG.md
- [x] I have added tests to demonstrate the contribution is correctly implemented: this usually includes both positive and negative tests, showing the happy path(s) and featuring intentionally broken cases
- [x] I have run all the tests locally and no test failure was reported
- [x] I have run the linter, formatter and spellchecker
- [x] I did not do unrelated and/or undiscussed refactorings
