### PR TITLE
fix: bit shift FunC compilation errors for incorrect bit widths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Show stacktrace of a compiler error only in verbose mode: PR [#1375](https://github.com/tact-lang/tact/pull/1375)
 - Flag name in help (`--project` to `--projects`): PR [#1419](https://github.com/tact-lang/tact/pull/1419)
 - Allow importing FunC files with `.func` extension: PR [#1451](https://github.com/tact-lang/tact/pull/1451)
+- Bit shift FunC compilation errors for incorrect bit widths: PR [#1453](https://github.com/tact-lang/tact/pull/1453)
 
 ### Docs
 

--- a/src/test/compilation-failed/const-eval-failed.spec.ts
+++ b/src/test/compilation-failed/const-eval-failed.spec.ts
@@ -91,12 +91,12 @@ describe("fail-const-eval", () => {
     itShouldNotCompile({
         testName: "const-eval-shl-invalid-bits1",
         errorMessage:
-            "Cannot evaluate expression to a constant: the number of bits shifted ('257') must be within [0..256] range",
+            "the number of bits shifted ('257') must be within [0..256] range",
     });
     itShouldNotCompile({
         testName: "const-eval-shl-invalid-bits2",
         errorMessage:
-            "Cannot evaluate expression to a constant: the number of bits shifted ('-1') must be within [0..256] range",
+            "the number of bits shifted ('-1') must be within [0..256] range",
     });
     itShouldNotCompile({
         testName: "const-eval-unboxing-null",

--- a/src/types/__snapshots__/resolveDescriptors.spec.ts.snap
+++ b/src/types/__snapshots__/resolveDescriptors.spec.ts.snap
@@ -73,7 +73,7 @@ exports[`resolveDescriptors should fail descriptors for const-decl-default-field
 `;
 
 exports[`resolveDescriptors should fail descriptors for const-eval-overflow 1`] = `
-"<unknown>:8:26: Cannot evaluate expression to a constant: the number of bits shifted ('-1073741824') must be within [0..256] range
+"<unknown>:8:26: the number of bits shifted ('-1073741824') must be within [0..256] range
   7 | 
 > 8 | const a: Int = 1 + (1 >> -1073741824);
                                ^~~~~~~~~~~

--- a/src/types/__snapshots__/resolveStatements.spec.ts.snap
+++ b/src/types/__snapshots__/resolveStatements.spec.ts.snap
@@ -438,6 +438,69 @@ exports[`resolveStatements should fail statements for expr-module-fun-call-bool-
 "
 `;
 
+exports[`resolveStatements should fail statements for expr-shift-left-bits-out-of-bounds-1 1`] = `
+"<unknown>:6:22: the number of bits shifted ('39279986343') must be within [0..256] range
+  5 |     get fun shift(x: Int): Int {
+> 6 |         return x << (34605176784551 & 0xFFFFFFFFF);
+                           ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  7 |     }
+"
+`;
+
+exports[`resolveStatements should fail statements for expr-shift-left-bits-out-of-bounds-2 1`] = `
+"<unknown>:6:22: the number of bits shifted ('-1') must be within [0..256] range
+  5 |     get fun shift(x: Int): Int {
+> 6 |         return x << (42 - 43);
+                           ^~~~~~~
+  7 |     }
+"
+`;
+
+exports[`resolveStatements should fail statements for expr-shift-left-bits-out-of-bounds-3 1`] = `
+"<unknown>:8:21: the number of bits shifted ('1000') must be within [0..256] range
+  7 |     get fun shift(x: Int): Int {
+> 8 |         return x << SHIFT_VAL;
+                          ^~~~~~~~~
+  9 |     }
+"
+`;
+
+exports[`resolveStatements should fail statements for expr-shift-left-bits-out-of-bounds-4 1`] = `
+"<unknown>:14:21: the number of bits shifted ('500') must be within [0..256] range
+  13 |     get fun shift(x: Int): Int {
+> 14 |         return x << foo();
+                           ^~~~~
+  15 |     }
+"
+`;
+
+exports[`resolveStatements should fail statements for expr-shift-right-bits-out-of-bounds-1 1`] = `
+"<unknown>:6:22: the number of bits shifted ('39279986343') must be within [0..256] range
+  5 |     get fun shift(x: Int): Int {
+> 6 |         return x >> (34605176784551 & 0xFFFFFFFFF);
+                           ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  7 |     }
+"
+`;
+
+exports[`resolveStatements should fail statements for expr-shift-right-bits-out-of-bounds-2 1`] = `
+"<unknown>:6:22: the number of bits shifted ('-1') must be within [0..256] range
+  5 |     get fun shift(x: Int): Int {
+> 6 |         return x >> (42 - 43);
+                           ^~~~~~~
+  7 |     }
+"
+`;
+
+exports[`resolveStatements should fail statements for expr-shift-right-bits-out-of-bounds-3 1`] = `
+"<unknown>:8:21: the number of bits shifted ('1000') must be within [0..256] range
+  7 |     get fun shift(x: Int): Int {
+> 8 |         return x >> SHIFT_VAL;
+                          ^~~~~~~~~
+  9 |     }
+"
+`;
+
 exports[`resolveStatements should fail statements for expr-struct-duplicate-field 1`] = `
 "<unknown>:17:9: Duplicate fields "a"
   16 |         a: 1,

--- a/src/types/__snapshots__/resolveStatements.spec.ts.snap
+++ b/src/types/__snapshots__/resolveStatements.spec.ts.snap
@@ -501,6 +501,15 @@ exports[`resolveStatements should fail statements for expr-shift-right-bits-out-
 "
 `;
 
+exports[`resolveStatements should fail statements for expr-shift-right-bits-out-of-bounds-4 1`] = `
+"<unknown>:14:21: the number of bits shifted ('500') must be within [0..256] range
+  13 |     get fun shift(x: Int): Int {
+> 14 |         return x >> foo();
+                           ^~~~~
+  15 |     }
+"
+`;
+
 exports[`resolveStatements should fail statements for expr-struct-duplicate-field 1`] = `
 "<unknown>:17:9: Duplicate fields "a"
   16 |         a: 1,

--- a/src/types/stmts-failed/expr-shift-left-bits-out-of-bounds-1.tact
+++ b/src/types/stmts-failed/expr-shift-left-bits-out-of-bounds-1.tact
@@ -1,0 +1,8 @@
+primitive Int;
+trait BaseTrait { }
+
+contract Test {
+    get fun shift(x: Int): Int {
+        return x << (34605176784551 & 0xFFFFFFFFF);
+    }
+}

--- a/src/types/stmts-failed/expr-shift-left-bits-out-of-bounds-2.tact
+++ b/src/types/stmts-failed/expr-shift-left-bits-out-of-bounds-2.tact
@@ -1,0 +1,8 @@
+primitive Int;
+trait BaseTrait { }
+
+contract Test {
+    get fun shift(x: Int): Int {
+        return x << (42 - 43);
+    }
+}

--- a/src/types/stmts-failed/expr-shift-left-bits-out-of-bounds-3.tact
+++ b/src/types/stmts-failed/expr-shift-left-bits-out-of-bounds-3.tact
@@ -1,0 +1,10 @@
+primitive Int;
+trait BaseTrait { }
+
+const SHIFT_VAL: Int = 1000;
+
+contract Test {
+    get fun shift(x: Int): Int {
+        return x << SHIFT_VAL;
+    }
+}

--- a/src/types/stmts-failed/expr-shift-left-bits-out-of-bounds-4.tact
+++ b/src/types/stmts-failed/expr-shift-left-bits-out-of-bounds-4.tact
@@ -1,0 +1,16 @@
+primitive Int;
+trait BaseTrait { }
+
+fun foo(): Int {
+    let a = 0;
+    repeat(100) {
+        a += 5;
+    }
+    return a;
+}
+
+contract Test {
+    get fun shift(x: Int): Int {
+        return x << foo();
+    }
+}

--- a/src/types/stmts-failed/expr-shift-right-bits-out-of-bounds-1.tact
+++ b/src/types/stmts-failed/expr-shift-right-bits-out-of-bounds-1.tact
@@ -1,0 +1,8 @@
+primitive Int;
+trait BaseTrait { }
+
+contract Test {
+    get fun shift(x: Int): Int {
+        return x >> (34605176784551 & 0xFFFFFFFFF);
+    }
+}

--- a/src/types/stmts-failed/expr-shift-right-bits-out-of-bounds-2.tact
+++ b/src/types/stmts-failed/expr-shift-right-bits-out-of-bounds-2.tact
@@ -1,0 +1,8 @@
+primitive Int;
+trait BaseTrait { }
+
+contract Test {
+    get fun shift(x: Int): Int {
+        return x >> (42 - 43);
+    }
+}

--- a/src/types/stmts-failed/expr-shift-right-bits-out-of-bounds-3.tact
+++ b/src/types/stmts-failed/expr-shift-right-bits-out-of-bounds-3.tact
@@ -1,0 +1,10 @@
+primitive Int;
+trait BaseTrait { }
+
+const SHIFT_VAL: Int = 1000;
+
+contract Test {
+    get fun shift(x: Int): Int {
+        return x >> SHIFT_VAL;
+    }
+}

--- a/src/types/stmts-failed/expr-shift-right-bits-out-of-bounds-4.tact
+++ b/src/types/stmts-failed/expr-shift-right-bits-out-of-bounds-4.tact
@@ -1,0 +1,16 @@
+primitive Int;
+trait BaseTrait { }
+
+fun foo(): Int {
+    let a = 0;
+    repeat(100) {
+        a += 5;
+    }
+    return a;
+}
+
+contract Test {
+    get fun shift(x: Int): Int {
+        return x >> foo();
+    }
+}


### PR DESCRIPTION
This will only work for the simple cases as in the audit report, i.e. when the bit widths are immediate (in-place) constant expressions. We are going to implement a proper constant propagation static analysis in the next Tact release.

Initial commit: 32dbaa8d84d200903c2c3321cc168707b7b832b7

Added extra tests with constant and function evaluation.

Fixes #1383

## Issue

Closes #1383.

## Checklist

- [x] I have updated CHANGELOG.md
- [x] I have added tests to demonstrate the contribution is correctly implemented: this usually includes both positive and negative tests, showing the happy path(s) and featuring intentionally broken cases
- [x] I have run all the tests locally and no test failure was reported
- [x] I have run the linter, formatter and spellchecker
- [x] I did not do unrelated and/or undiscussed refactorings
