### PR TITLE
refactor: streamline `renameModuleItems` function

### DIFF
--- a/src/ast/rename.ts
+++ b/src/ast/rename.ts
@@ -114,15 +114,12 @@ export class AstRenamer {
 
     public renameModuleItems(items: AstModuleItem[]): AstModuleItem[] {
         // Give new names to module-level elements.
-        let renamedItems = items.map((item) => this.changeItemName(item));
-
-        if (this.sort) {
-            renamedItems.map((item) => this.sortAttributes(item));
-        }
-
-        // Apply renaming to the contents of these elements.
-        renamedItems = renamedItems.map((item) =>
-            this.renameModuleItemContents(item),
+        const renamedItems = items.map((item) =>
+            this.renameModuleItemContents(
+                this.sort
+                    ? this.sortAttributes(this.changeItemName(item))
+                    : this.changeItemName(item),
+            ),
         );
 
         return this.sort ? this.sortModuleItems(renamedItems) : renamedItems;

--- a/src/ast/rename.ts
+++ b/src/ast/rename.ts
@@ -121,7 +121,6 @@ export class AstRenamer {
                     : this.changeItemName(item),
             ),
         );
-
         return this.sort ? this.sortModuleItems(renamedItems) : renamedItems;
     }
 


### PR DESCRIPTION
It also removes the unused `map` result.

This fixes issue #6 of Trail of Bits security audit (2024)

Initial commit: 00bf680218ae37f05a6f019ca2529a7a43642953

## Issue

Closes #1382.

## Checklist

- [x] I have run all the tests locally and no test failure was reported
- [x] I have run the linter, formatter and spellchecker
- [x] I did not do unrelated and/or undiscussed refactorings
