### PR TITLE
refactor: change long imports for AST to  `* as A` imports

### DIFF
--- a/src/context/store.ts
+++ b/src/context/store.ts
@@ -1,11 +1,4 @@
-import {
-    AstModule,
-    AstConstantDef,
-    AstFunctionDef,
-    AstNativeFunctionDecl,
-    AstTypeDecl,
-    AstAsmFunctionDef,
-} from "../ast/ast";
+import * as A from "../ast/ast";
 import { throwInternalCompilerError } from "../error/errors";
 import { CompilerContext, createContextStore } from "./context";
 import { ItemOrigin } from "../grammar/src-info";
@@ -26,9 +19,13 @@ export type TactSource = { code: string; path: string; origin: ItemOrigin };
 export type AstStore = {
     sources: TactSource[];
     funcSources: { code: string; path: string }[];
-    functions: (AstFunctionDef | AstNativeFunctionDecl | AstAsmFunctionDef)[];
-    constants: AstConstantDef[];
-    types: AstTypeDecl[];
+    functions: (
+        | A.AstFunctionDef
+        | A.AstNativeFunctionDecl
+        | A.AstAsmFunctionDef
+    )[];
+    constants: A.AstConstantDef[];
+    types: A.AstTypeDecl[];
 };
 
 const store = createContextStore<AstStore>();
@@ -55,7 +52,7 @@ export function getRawAST(ctx: CompilerContext): AstStore {
 export function parseModules(
     sources: TactSource[],
     parser: Parser,
-): AstModule[] {
+): A.AstModule[] {
     return sources.map((source) =>
         parser.parse(source.code, source.path, source.origin),
     );
@@ -73,18 +70,18 @@ export function openContext(
     sources: TactSource[],
     funcSources: { code: string; path: string }[],
     parser: Parser,
-    parsedModules?: AstModule[],
+    parsedModules?: A.AstModule[],
 ): CompilerContext {
     const modules = parsedModules
         ? parsedModules
         : parseModules(sources, parser);
-    const types: AstTypeDecl[] = [];
+    const types: A.AstTypeDecl[] = [];
     const functions: (
-        | AstNativeFunctionDecl
-        | AstFunctionDef
-        | AstAsmFunctionDef
+        | A.AstNativeFunctionDecl
+        | A.AstFunctionDef
+        | A.AstAsmFunctionDef
     )[] = [];
-    const constants: AstConstantDef[] = [];
+    const constants: A.AstConstantDef[] = [];
     for (const module of modules) {
         for (const item of module.items) {
             switch (item.kind) {

--- a/src/grammar/grammar.ts
+++ b/src/grammar/grammar.ts
@@ -1,23 +1,26 @@
 import { getParser as getParserNext } from "./next";
 
-import { AstExpression, AstImport, AstModule, FactoryAst } from "../ast/ast";
+import * as A from "../ast/ast";
 
 import { getParser as getParserPrev } from "./prev/grammar";
 import { ItemOrigin } from "./src-info";
 
 export type Parser = {
-    parse: (src: string, path: string, origin: ItemOrigin) => AstModule;
-    parseExpression: (sourceCode: string) => AstExpression;
+    parse: (src: string, path: string, origin: ItemOrigin) => A.AstModule;
+    parseExpression: (sourceCode: string) => A.AstExpression;
     parseImports: (
         src: string,
         path: string,
         origin: ItemOrigin,
-    ) => AstImport[];
+    ) => A.AstImport[];
 };
 
 export const defaultParser = "new";
 
-export const getParser = (ast: FactoryAst, version: "old" | "new"): Parser => {
+export const getParser = (
+    ast: A.FactoryAst,
+    version: "old" | "new",
+): Parser => {
     if (version === "new") {
         return getParserNext(ast);
     } else {

--- a/src/optimizer/algebraic.ts
+++ b/src/optimizer/algebraic.ts
@@ -1,11 +1,4 @@
-import {
-    AstBinaryOperation,
-    AstExpression,
-    AstOpBinary,
-    AstOpUnary,
-    eqExpressions,
-    isLiteral,
-} from "../ast/ast";
+import * as A from "../ast/ast";
 import { ExpressionTransformer, Rule } from "./types";
 import {
     checkIsBinaryOpNode,
@@ -16,17 +9,17 @@ import {
 } from "../ast/util";
 
 export class AddZero extends Rule {
-    private additiveOperators: AstBinaryOperation[] = ["+", "-"];
+    private additiveOperators: A.AstBinaryOperation[] = ["+", "-"];
 
     public applyRule(
-        ast: AstExpression,
+        ast: A.AstExpression,
         { util }: ExpressionTransformer,
-    ): AstExpression {
+    ): A.AstExpression {
         if (checkIsBinaryOpNode(ast)) {
-            const topLevelNode = ast as AstOpBinary;
+            const topLevelNode = ast as A.AstOpBinary;
             if (this.additiveOperators.includes(topLevelNode.op)) {
                 if (
-                    !isLiteral(topLevelNode.left) &&
+                    !A.isLiteral(topLevelNode.left) &&
                     checkIsNumber(topLevelNode.right, 0n)
                 ) {
                     // The tree has this form:
@@ -37,7 +30,7 @@ export class AddZero extends Rule {
                     return x;
                 } else if (
                     checkIsNumber(topLevelNode.left, 0n) &&
-                    !isLiteral(topLevelNode.right)
+                    !A.isLiteral(topLevelNode.right)
                 ) {
                     // The tree has this form:
                     // 0 op x
@@ -62,11 +55,11 @@ export class AddZero extends Rule {
 
 export class MultiplyZero extends Rule {
     public applyRule(
-        ast: AstExpression,
+        ast: A.AstExpression,
         { util }: ExpressionTransformer,
-    ): AstExpression {
+    ): A.AstExpression {
         if (checkIsBinaryOpNode(ast)) {
-            const topLevelNode = ast as AstOpBinary;
+            const topLevelNode = ast as A.AstOpBinary;
             if (topLevelNode.op === "*") {
                 if (
                     checkIsName(topLevelNode.left) &&
@@ -96,14 +89,14 @@ export class MultiplyZero extends Rule {
 
 export class MultiplyOne extends Rule {
     public applyRule(
-        ast: AstExpression,
+        ast: A.AstExpression,
         _optimizer: ExpressionTransformer,
-    ): AstExpression {
+    ): A.AstExpression {
         if (checkIsBinaryOpNode(ast)) {
-            const topLevelNode = ast as AstOpBinary;
+            const topLevelNode = ast as A.AstOpBinary;
             if (topLevelNode.op === "*") {
                 if (
-                    !isLiteral(topLevelNode.left) &&
+                    !A.isLiteral(topLevelNode.left) &&
                     checkIsNumber(topLevelNode.right, 1n)
                 ) {
                     // The tree has this form:
@@ -114,7 +107,7 @@ export class MultiplyOne extends Rule {
                     return x;
                 } else if (
                     checkIsNumber(topLevelNode.left, 1n) &&
-                    !isLiteral(topLevelNode.right)
+                    !A.isLiteral(topLevelNode.right)
                 ) {
                     // The tree has this form:
                     // 1 * x
@@ -134,11 +127,11 @@ export class MultiplyOne extends Rule {
 
 export class SubtractSelf extends Rule {
     public applyRule(
-        ast: AstExpression,
+        ast: A.AstExpression,
         { util }: ExpressionTransformer,
-    ): AstExpression {
+    ): A.AstExpression {
         if (checkIsBinaryOpNode(ast)) {
-            const topLevelNode = ast as AstOpBinary;
+            const topLevelNode = ast as A.AstOpBinary;
             if (topLevelNode.op === "-") {
                 if (
                     checkIsName(topLevelNode.left) &&
@@ -151,7 +144,7 @@ export class SubtractSelf extends Rule {
                     const x = topLevelNode.left;
                     const y = topLevelNode.right;
 
-                    if (eqExpressions(x, y)) {
+                    if (A.eqExpressions(x, y)) {
                         return util.makeNumberLiteral(0n, ast.loc);
                     }
                 }
@@ -166,15 +159,15 @@ export class SubtractSelf extends Rule {
 
 export class AddSelf extends Rule {
     public applyRule(
-        ast: AstExpression,
+        ast: A.AstExpression,
         { applyRules, util }: ExpressionTransformer,
-    ): AstExpression {
+    ): A.AstExpression {
         if (checkIsBinaryOpNode(ast)) {
-            const topLevelNode = ast as AstOpBinary;
+            const topLevelNode = ast as A.AstOpBinary;
             if (topLevelNode.op === "+") {
                 if (
-                    !isLiteral(topLevelNode.left) &&
-                    !isLiteral(topLevelNode.right)
+                    !A.isLiteral(topLevelNode.left) &&
+                    !A.isLiteral(topLevelNode.right)
                 ) {
                     // The tree has this form:
                     // x + y
@@ -183,7 +176,7 @@ export class AddSelf extends Rule {
                     const x = topLevelNode.left;
                     const y = topLevelNode.right;
 
-                    if (eqExpressions(x, y)) {
+                    if (A.eqExpressions(x, y)) {
                         const res = util.makeBinaryExpression(
                             "*",
                             x,
@@ -205,15 +198,15 @@ export class AddSelf extends Rule {
 
 export class OrTrue extends Rule {
     public applyRule(
-        ast: AstExpression,
+        ast: A.AstExpression,
         { util }: ExpressionTransformer,
-    ): AstExpression {
+    ): A.AstExpression {
         if (checkIsBinaryOpNode(ast)) {
-            const topLevelNode = ast as AstOpBinary;
+            const topLevelNode = ast as A.AstOpBinary;
             if (topLevelNode.op === "||") {
                 if (
                     (checkIsName(topLevelNode.left) ||
-                        isLiteral(topLevelNode.left)) &&
+                        A.isLiteral(topLevelNode.left)) &&
                     checkIsBoolean(topLevelNode.right, true)
                 ) {
                     // The tree has this form:
@@ -237,15 +230,15 @@ export class OrTrue extends Rule {
 
 export class AndFalse extends Rule {
     public applyRule(
-        ast: AstExpression,
+        ast: A.AstExpression,
         { util }: ExpressionTransformer,
-    ): AstExpression {
+    ): A.AstExpression {
         if (checkIsBinaryOpNode(ast)) {
-            const topLevelNode = ast as AstOpBinary;
+            const topLevelNode = ast as A.AstOpBinary;
             if (topLevelNode.op === "&&") {
                 if (
                     (checkIsName(topLevelNode.left) ||
-                        isLiteral(topLevelNode.left)) &&
+                        A.isLiteral(topLevelNode.left)) &&
                     checkIsBoolean(topLevelNode.right, false)
                 ) {
                     // The tree has this form:
@@ -269,11 +262,11 @@ export class AndFalse extends Rule {
 
 export class OrFalse extends Rule {
     public applyRule(
-        ast: AstExpression,
+        ast: A.AstExpression,
         _optimizer: ExpressionTransformer,
-    ): AstExpression {
+    ): A.AstExpression {
         if (checkIsBinaryOpNode(ast)) {
-            const topLevelNode = ast as AstOpBinary;
+            const topLevelNode = ast as A.AstOpBinary;
             if (topLevelNode.op === "||") {
                 if (checkIsBoolean(topLevelNode.right, false)) {
                     // The tree has this form:
@@ -301,11 +294,11 @@ export class OrFalse extends Rule {
 
 export class AndTrue extends Rule {
     public applyRule(
-        ast: AstExpression,
+        ast: A.AstExpression,
         _optimizer: ExpressionTransformer,
-    ): AstExpression {
+    ): A.AstExpression {
         if (checkIsBinaryOpNode(ast)) {
-            const topLevelNode = ast as AstOpBinary;
+            const topLevelNode = ast as A.AstOpBinary;
             if (topLevelNode.op === "&&") {
                 if (checkIsBoolean(topLevelNode.right, true)) {
                     // The tree has this form:
@@ -333,11 +326,11 @@ export class AndTrue extends Rule {
 
 export class OrSelf extends Rule {
     public applyRule(
-        ast: AstExpression,
+        ast: A.AstExpression,
         _optimizer: ExpressionTransformer,
-    ): AstExpression {
+    ): A.AstExpression {
         if (checkIsBinaryOpNode(ast)) {
-            const topLevelNode = ast as AstOpBinary;
+            const topLevelNode = ast as A.AstOpBinary;
             if (topLevelNode.op === "||") {
                 // The tree has this form:
                 // x || y
@@ -346,7 +339,7 @@ export class OrSelf extends Rule {
                 const x = topLevelNode.left;
                 const y = topLevelNode.right;
 
-                if (eqExpressions(x, y)) {
+                if (A.eqExpressions(x, y)) {
                     return x;
                 }
             }
@@ -360,11 +353,11 @@ export class OrSelf extends Rule {
 
 export class AndSelf extends Rule {
     public applyRule(
-        ast: AstExpression,
+        ast: A.AstExpression,
         _optimizer: ExpressionTransformer,
-    ): AstExpression {
+    ): A.AstExpression {
         if (checkIsBinaryOpNode(ast)) {
-            const topLevelNode = ast as AstOpBinary;
+            const topLevelNode = ast as A.AstOpBinary;
             if (topLevelNode.op === "&&") {
                 // The tree has this form:
                 // x && y
@@ -373,7 +366,7 @@ export class AndSelf extends Rule {
                 const x = topLevelNode.left;
                 const y = topLevelNode.right;
 
-                if (eqExpressions(x, y)) {
+                if (A.eqExpressions(x, y)) {
                     return x;
                 }
             }
@@ -387,14 +380,14 @@ export class AndSelf extends Rule {
 
 export class ExcludedMiddle extends Rule {
     public applyRule(
-        ast: AstExpression,
+        ast: A.AstExpression,
         { util }: ExpressionTransformer,
-    ): AstExpression {
+    ): A.AstExpression {
         if (checkIsBinaryOpNode(ast)) {
-            const topLevelNode = ast as AstOpBinary;
+            const topLevelNode = ast as A.AstOpBinary;
             if (topLevelNode.op === "||") {
                 if (checkIsUnaryOpNode(topLevelNode.right)) {
-                    const rightNode = topLevelNode.right as AstOpUnary;
+                    const rightNode = topLevelNode.right as A.AstOpUnary;
                     if (rightNode.op === "!") {
                         // The tree has this form:
                         // x || !y
@@ -405,14 +398,14 @@ export class ExcludedMiddle extends Rule {
                         const y = rightNode.operand;
 
                         if (
-                            (checkIsName(x) || isLiteral(x)) &&
-                            eqExpressions(x, y)
+                            (checkIsName(x) || A.isLiteral(x)) &&
+                            A.eqExpressions(x, y)
                         ) {
                             return util.makeBooleanLiteral(true, ast.loc);
                         }
                     }
                 } else if (checkIsUnaryOpNode(topLevelNode.left)) {
-                    const leftNode = topLevelNode.left as AstOpUnary;
+                    const leftNode = topLevelNode.left as A.AstOpUnary;
                     if (leftNode.op === "!") {
                         // The tree has this form:
                         // !x || y
@@ -423,8 +416,8 @@ export class ExcludedMiddle extends Rule {
                         const y = topLevelNode.right;
 
                         if (
-                            (checkIsName(x) || isLiteral(x)) &&
-                            eqExpressions(x, y)
+                            (checkIsName(x) || A.isLiteral(x)) &&
+                            A.eqExpressions(x, y)
                         ) {
                             return util.makeBooleanLiteral(true, ast.loc);
                         }
@@ -441,14 +434,14 @@ export class ExcludedMiddle extends Rule {
 
 export class Contradiction extends Rule {
     public applyRule(
-        ast: AstExpression,
+        ast: A.AstExpression,
         { util }: ExpressionTransformer,
-    ): AstExpression {
+    ): A.AstExpression {
         if (checkIsBinaryOpNode(ast)) {
-            const topLevelNode = ast as AstOpBinary;
+            const topLevelNode = ast as A.AstOpBinary;
             if (topLevelNode.op === "&&") {
                 if (checkIsUnaryOpNode(topLevelNode.right)) {
-                    const rightNode = topLevelNode.right as AstOpUnary;
+                    const rightNode = topLevelNode.right as A.AstOpUnary;
                     if (rightNode.op === "!") {
                         // The tree has this form:
                         // x && !y
@@ -459,14 +452,14 @@ export class Contradiction extends Rule {
                         const y = rightNode.operand;
 
                         if (
-                            (checkIsName(x) || isLiteral(x)) &&
-                            eqExpressions(x, y)
+                            (checkIsName(x) || A.isLiteral(x)) &&
+                            A.eqExpressions(x, y)
                         ) {
                             return util.makeBooleanLiteral(false, ast.loc);
                         }
                     }
                 } else if (checkIsUnaryOpNode(topLevelNode.left)) {
-                    const leftNode = topLevelNode.left as AstOpUnary;
+                    const leftNode = topLevelNode.left as A.AstOpUnary;
                     if (leftNode.op === "!") {
                         // The tree has this form:
                         // !x && y
@@ -477,8 +470,8 @@ export class Contradiction extends Rule {
                         const y = topLevelNode.right;
 
                         if (
-                            (checkIsName(x) || isLiteral(x)) &&
-                            eqExpressions(x, y)
+                            (checkIsName(x) || A.isLiteral(x)) &&
+                            A.eqExpressions(x, y)
                         ) {
                             return util.makeBooleanLiteral(false, ast.loc);
                         }
@@ -495,14 +488,14 @@ export class Contradiction extends Rule {
 
 export class DoubleNegation extends Rule {
     public applyRule(
-        ast: AstExpression,
+        ast: A.AstExpression,
         _optimizer: ExpressionTransformer,
-    ): AstExpression {
+    ): A.AstExpression {
         if (checkIsUnaryOpNode(ast)) {
-            const topLevelNode = ast as AstOpUnary;
+            const topLevelNode = ast as A.AstOpUnary;
             if (topLevelNode.op === "!") {
                 if (checkIsUnaryOpNode(topLevelNode.operand)) {
-                    const innerNode = topLevelNode.operand as AstOpUnary;
+                    const innerNode = topLevelNode.operand as A.AstOpUnary;
                     if (innerNode.op === "!") {
                         // The tree has this form:
                         // !!x
@@ -523,11 +516,11 @@ export class DoubleNegation extends Rule {
 
 export class NegateTrue extends Rule {
     public applyRule(
-        ast: AstExpression,
+        ast: A.AstExpression,
         { util }: ExpressionTransformer,
-    ): AstExpression {
+    ): A.AstExpression {
         if (checkIsUnaryOpNode(ast)) {
-            const topLevelNode = ast as AstOpUnary;
+            const topLevelNode = ast as A.AstOpUnary;
             if (topLevelNode.op === "!") {
                 if (checkIsBoolean(topLevelNode.operand, true)) {
                     // The tree has this form
@@ -546,11 +539,11 @@ export class NegateTrue extends Rule {
 
 export class NegateFalse extends Rule {
     public applyRule(
-        ast: AstExpression,
+        ast: A.AstExpression,
         { util }: ExpressionTransformer,
-    ): AstExpression {
+    ): A.AstExpression {
         if (checkIsUnaryOpNode(ast)) {
-            const topLevelNode = ast as AstOpUnary;
+            const topLevelNode = ast as A.AstOpUnary;
             if (topLevelNode.op === "!") {
                 if (checkIsBoolean(topLevelNode.operand, false)) {
                     // The tree has this form

--- a/src/optimizer/constEval.ts
+++ b/src/optimizer/constEval.ts
@@ -1,11 +1,5 @@
 import { CompilerContext } from "../context/context";
-import {
-    AstBinaryOperation,
-    AstExpression,
-    AstUnaryOperation,
-    isLiteral,
-    AstLiteral,
-} from "../ast/ast";
+import * as A from "../ast/ast";
 import {
     TactConstEvalError,
     throwInternalCompilerError,
@@ -26,9 +20,9 @@ import { SrcInfo } from "../grammar";
 // Utility Exception class to interrupt the execution
 // of functions that cannot evaluate a tree fully into a value.
 class PartiallyEvaluatedTree extends Error {
-    public tree: AstExpression;
+    public tree: A.AstExpression;
 
-    constructor(tree: AstExpression) {
+    constructor(tree: A.AstExpression) {
         super();
         this.tree = tree;
     }
@@ -40,11 +34,11 @@ export const getOptimizer = (util: AstUtil) => {
     const optimizer: ExpressionTransformer = new StandardOptimizer(util);
 
     function partiallyEvalUnaryOp(
-        op: AstUnaryOperation,
-        operand: AstExpression,
+        op: A.AstUnaryOperation,
+        operand: A.AstExpression,
         source: SrcInfo,
         ctx: CompilerContext,
-    ): AstExpression {
+    ): A.AstExpression {
         if (operand.kind === "number" && op === "-") {
             // emulating negative integer literals
             return ensureInt(util.makeNumberLiteral(-operand.value, source));
@@ -52,7 +46,7 @@ export const getOptimizer = (util: AstUtil) => {
 
         const simplOperand = partiallyEvalExpression(operand, ctx);
 
-        if (isLiteral(simplOperand)) {
+        if (A.isLiteral(simplOperand)) {
             const result = evalUnaryOp(op, simplOperand, source, util);
             return result;
         } else {
@@ -62,15 +56,15 @@ export const getOptimizer = (util: AstUtil) => {
     }
 
     function partiallyEvalBinaryOp(
-        op: AstBinaryOperation,
-        left: AstExpression,
-        right: AstExpression,
+        op: A.AstBinaryOperation,
+        left: A.AstExpression,
+        right: A.AstExpression,
         source: SrcInfo,
         ctx: CompilerContext,
-    ): AstExpression {
+    ): A.AstExpression {
         const leftOperand = partiallyEvalExpression(left, ctx);
 
-        if (isLiteral(leftOperand)) {
+        if (A.isLiteral(leftOperand)) {
             // Because of short-circuiting, we must delay evaluation of the right operand
             try {
                 const result = evalBinaryOp(
@@ -82,7 +76,7 @@ export const getOptimizer = (util: AstUtil) => {
                             right,
                             ctx,
                         );
-                        if (isLiteral(rightOperand)) {
+                        if (A.isLiteral(rightOperand)) {
                             // If the right operand reduced to a value, then we can let the function
                             // evalBinaryOp finish its normal execution by returning the
                             // right operand.
@@ -130,10 +124,10 @@ export const getOptimizer = (util: AstUtil) => {
     }
 
     function partiallyEvalExpression(
-        ast: AstExpression,
+        ast: A.AstExpression,
         ctx: CompilerContext,
         interpreterConfig?: InterpreterConfig,
-    ): AstExpression {
+    ): A.AstExpression {
         const interpreter = new Interpreter(util, ctx, interpreterConfig);
         switch (ast.kind) {
             case "id":
@@ -212,11 +206,11 @@ export const getOptimizer = (util: AstUtil) => {
 };
 
 export function evalConstantExpression(
-    ast: AstExpression,
+    ast: A.AstExpression,
     ctx: CompilerContext,
     util: AstUtil,
     interpreterConfig?: InterpreterConfig,
-): AstLiteral {
+): A.AstLiteral {
     const interpreter = new Interpreter(util, ctx, interpreterConfig);
     const result = interpreter.interpretExpression(ast);
     return result;

--- a/src/types/resolveDescriptors.ts
+++ b/src/types/resolveDescriptors.ts
@@ -1,24 +1,4 @@
-import {
-    AstAsmFunctionDef,
-    AstConstantDecl,
-    AstConstantDef,
-    AstContractInit,
-    AstExpression,
-    AstFieldDecl,
-    AstFunctionDecl,
-    AstFunctionDef,
-    AstId,
-    AstMapType,
-    AstNativeFunctionDecl,
-    AstNode,
-    AstType,
-    AstTypeId,
-    eqNames,
-    FactoryAst,
-    idText,
-    isSelfId,
-    isSlice,
-} from "../ast/ast";
+import * as A from "../ast/ast";
 import { traverse } from "../ast/iterators";
 import {
     idTextErr,
@@ -65,14 +45,14 @@ const staticConstantsStore = createContextStore<ConstantDescription>();
 
 // this function does not handle the case of structs
 function verifyMapAsAnnotationsForPrimitiveTypes(
-    type: AstTypeId,
-    asAnnotation: AstId | null,
+    type: A.AstTypeId,
+    asAnnotation: A.AstId | null,
     kind: "keyType" | "valType",
 ): void {
-    switch (idText(type)) {
+    switch (A.idText(type)) {
         case "Int": {
             if (asAnnotation === null) return;
-            const ann = idText(asAnnotation);
+            const ann = A.idText(asAnnotation);
             switch (kind) {
                 case "keyType":
                     if (!Object.keys(intMapKeyFormats).includes(ann)) {
@@ -110,12 +90,12 @@ function verifyMapAsAnnotationsForPrimitiveTypes(
 }
 
 function verifyMapTypes(
-    typeId: AstTypeId,
-    asAnnotation: AstId | null,
+    typeId: A.AstTypeId,
+    asAnnotation: A.AstId | null,
     allowedTypeNames: string[],
     kind: "keyType" | "valType",
 ): void {
-    if (!allowedTypeNames.includes(idText(typeId))) {
+    if (!allowedTypeNames.includes(A.idText(typeId))) {
         throwCompilationError(
             "Invalid map type. Check https://docs.tact-lang.org/book/maps#allowed-types",
             typeId.loc,
@@ -124,7 +104,7 @@ function verifyMapTypes(
     verifyMapAsAnnotationsForPrimitiveTypes(typeId, asAnnotation, kind);
 }
 
-function verifyMapType(mapTy: AstMapType, isValTypeStruct: boolean) {
+function verifyMapType(mapTy: A.AstMapType, isValTypeStruct: boolean) {
     // optional and other compound key and value types are disallowed at the level of grammar
 
     // check allowed key types
@@ -150,10 +130,10 @@ function verifyMapType(mapTy: AstMapType, isValTypeStruct: boolean) {
 
 export const toBounced = (type: string) => `${type}%%BOUNCED%%`;
 
-export function resolveTypeRef(ctx: CompilerContext, type: AstType): TypeRef {
+export function resolveTypeRef(ctx: CompilerContext, type: A.AstType): TypeRef {
     switch (type.kind) {
         case "type_id": {
-            const t = getType(ctx, idText(type));
+            const t = getType(ctx, A.idText(type));
             return {
                 kind: "ref",
                 name: t.name,
@@ -167,7 +147,7 @@ export function resolveTypeRef(ctx: CompilerContext, type: AstType): TypeRef {
                     type.typeArg.loc,
                 );
             }
-            const t = getType(ctx, idText(type.typeArg));
+            const t = getType(ctx, A.idText(type.typeArg));
             return {
                 kind: "ref",
                 name: t.name,
@@ -175,25 +155,25 @@ export function resolveTypeRef(ctx: CompilerContext, type: AstType): TypeRef {
             };
         }
         case "map_type": {
-            const keyTy = getType(ctx, idText(type.keyType));
-            const valTy = getType(ctx, idText(type.valueType));
+            const keyTy = getType(ctx, A.idText(type.keyType));
+            const valTy = getType(ctx, A.idText(type.valueType));
             verifyMapType(type, valTy.kind === "struct");
             return {
                 kind: "map",
                 key: keyTy.name,
                 keyAs:
                     type.keyStorageType !== null
-                        ? idText(type.keyStorageType)
+                        ? A.idText(type.keyStorageType)
                         : null,
                 value: valTy.name,
                 valueAs:
                     type.valueStorageType !== null
-                        ? idText(type.valueStorageType)
+                        ? A.idText(type.valueStorageType)
                         : null,
             };
         }
         case "bounced_message_type": {
-            const t = getType(ctx, idText(type.messageType));
+            const t = getType(ctx, A.idText(type.messageType));
             return {
                 kind: "ref_bounced",
                 name: t.name,
@@ -203,12 +183,12 @@ export function resolveTypeRef(ctx: CompilerContext, type: AstType): TypeRef {
 }
 
 function buildTypeRef(
-    type: AstType,
+    type: A.AstType,
     types: Map<string, TypeDescription>,
 ): TypeRef {
     switch (type.kind) {
         case "type_id": {
-            if (!types.has(idText(type))) {
+            if (!types.has(A.idText(type))) {
                 throwCompilationError(
                     `Type ${idTextErr(type)} not found`,
                     type.loc,
@@ -216,7 +196,7 @@ function buildTypeRef(
             }
             return {
                 kind: "ref",
-                name: idText(type),
+                name: A.idText(type),
                 optional: false,
             };
         }
@@ -227,7 +207,7 @@ function buildTypeRef(
                     type.typeArg.loc,
                 );
             }
-            if (!types.has(idText(type.typeArg))) {
+            if (!types.has(A.idText(type.typeArg))) {
                 throwCompilationError(
                     `Type ${idTextErr(type.typeArg)} not found`,
                     type.loc,
@@ -235,43 +215,43 @@ function buildTypeRef(
             }
             return {
                 kind: "ref",
-                name: idText(type.typeArg),
+                name: A.idText(type.typeArg),
                 optional: true,
             };
         }
         case "map_type": {
-            if (!types.has(idText(type.keyType))) {
+            if (!types.has(A.idText(type.keyType))) {
                 throwCompilationError(
                     `Type ${idTextErr(type.keyType)} not found`,
                     type.loc,
                 );
             }
-            if (!types.has(idText(type.valueType))) {
+            if (!types.has(A.idText(type.valueType))) {
                 throwCompilationError(
                     `Type ${idTextErr(type.valueType)} not found`,
                     type.loc,
                 );
             }
-            const valTy = types.get(idText(type.valueType))!;
+            const valTy = types.get(A.idText(type.valueType))!;
             verifyMapType(type, valTy.kind === "struct");
             return {
                 kind: "map",
-                key: idText(type.keyType),
+                key: A.idText(type.keyType),
                 keyAs:
                     type.keyStorageType !== null
-                        ? idText(type.keyStorageType)
+                        ? A.idText(type.keyStorageType)
                         : null,
-                value: idText(type.valueType),
+                value: A.idText(type.valueType),
                 valueAs:
                     type.valueStorageType !== null
-                        ? idText(type.valueStorageType)
+                        ? A.idText(type.valueStorageType)
                         : null,
             };
         }
         case "bounced_message_type": {
             return {
                 kind: "ref_bounced",
-                name: idText(type.messageType),
+                name: A.idText(type.messageType),
             };
         }
     }
@@ -286,7 +266,7 @@ function uidForName(name: string, types: Map<string, TypeDescription>) {
     return uid;
 }
 
-export function resolveDescriptors(ctx: CompilerContext, Ast: FactoryAst) {
+export function resolveDescriptors(ctx: CompilerContext, Ast: A.FactoryAst) {
     const types: Map<string, TypeDescription> = new Map();
     const staticFunctions: Map<string, FunctionDescription> = new Map();
     const staticConstants: Map<string, ConstantDescription> = new Map();
@@ -298,22 +278,22 @@ export function resolveDescriptors(ctx: CompilerContext, Ast: FactoryAst) {
     //
 
     for (const a of ast.types) {
-        if (types.has(idText(a.name))) {
+        if (types.has(A.idText(a.name))) {
             throwCompilationError(
-                `Type "${idText(a.name)}" already exists`,
+                `Type "${A.idText(a.name)}" already exists`,
                 a.loc,
             );
         }
 
-        const uid = uidForName(idText(a.name), types);
+        const uid = uidForName(A.idText(a.name), types);
 
         switch (a.kind) {
             case "primitive_type_decl":
                 {
-                    types.set(idText(a.name), {
+                    types.set(A.idText(a.name), {
                         kind: "primitive_type_decl",
                         origin: a.loc.origin,
-                        name: idText(a.name),
+                        name: A.idText(a.name),
                         uid,
                         fields: [],
                         traits: [],
@@ -333,10 +313,10 @@ export function resolveDescriptors(ctx: CompilerContext, Ast: FactoryAst) {
                 break;
             case "contract":
                 {
-                    types.set(idText(a.name), {
+                    types.set(A.idText(a.name), {
                         kind: "contract",
                         origin: a.loc.origin,
-                        name: idText(a.name),
+                        name: A.idText(a.name),
                         uid,
                         header: null,
                         tlb: null,
@@ -357,10 +337,10 @@ export function resolveDescriptors(ctx: CompilerContext, Ast: FactoryAst) {
             case "struct_decl":
             case "message_decl":
                 {
-                    types.set(idText(a.name), {
+                    types.set(A.idText(a.name), {
                         kind: "struct",
                         origin: a.loc.origin,
-                        name: idText(a.name),
+                        name: A.idText(a.name),
                         uid,
                         header: null,
                         tlb: null,
@@ -379,10 +359,10 @@ export function resolveDescriptors(ctx: CompilerContext, Ast: FactoryAst) {
                 }
                 break;
             case "trait": {
-                types.set(idText(a.name), {
+                types.set(A.idText(a.name), {
                     kind: "trait",
                     origin: a.loc.origin,
-                    name: idText(a.name),
+                    name: A.idText(a.name),
                     uid,
                     header: null,
                     tlb: null,
@@ -407,7 +387,7 @@ export function resolveDescriptors(ctx: CompilerContext, Ast: FactoryAst) {
     //
 
     function buildFieldDescription(
-        src: AstFieldDecl,
+        src: A.AstFieldDecl,
         index: number,
     ): FieldDescription {
         const fieldTy = buildTypeRef(src.type, types);
@@ -425,23 +405,23 @@ export function resolveDescriptors(ctx: CompilerContext, Ast: FactoryAst) {
         const type = resolveABIType(src);
 
         return {
-            name: idText(src.name),
+            name: A.idText(src.name),
             type: fieldTy,
             index,
-            as: src.as !== null ? idText(src.as) : null,
+            as: src.as !== null ? A.idText(src.as) : null,
             default: undefined, // initializer will be evaluated after typechecking
             loc: src.loc,
             ast: src,
-            abi: { name: idText(src.name), type },
+            abi: { name: A.idText(src.name), type },
         };
     }
 
     function buildConstantDescription(
-        src: AstConstantDef | AstConstantDecl,
+        src: A.AstConstantDef | A.AstConstantDecl,
     ): ConstantDescription {
         const constDeclTy = buildTypeRef(src.type, types);
         return {
-            name: idText(src.name),
+            name: A.idText(src.name),
             type: constDeclTy,
             value: undefined, // initializer will be evaluated after typechecking
             loc: src.loc,
@@ -456,8 +436,8 @@ export function resolveDescriptors(ctx: CompilerContext, Ast: FactoryAst) {
                 if (f.kind === "field_decl") {
                     if (
                         types
-                            .get(idText(a.name))!
-                            .fields.find((v) => eqNames(v.name, f.name))
+                            .get(A.idText(a.name))!
+                            .fields.find((v) => A.eqNames(v.name, f.name))
                     ) {
                         throwCompilationError(
                             `Field ${idTextErr(f.name)} already exists`,
@@ -466,27 +446,27 @@ export function resolveDescriptors(ctx: CompilerContext, Ast: FactoryAst) {
                     }
                     if (
                         types
-                            .get(idText(a.name))!
-                            .constants.find((v) => eqNames(v.name, f.name))
+                            .get(A.idText(a.name))!
+                            .constants.find((v) => A.eqNames(v.name, f.name))
                     ) {
                         throwCompilationError(
-                            `Constant ${idText(f.name)} already exists`,
+                            `Constant ${A.idText(f.name)} already exists`,
                             f.loc,
                         );
                     }
                     types
-                        .get(idText(a.name))!
+                        .get(A.idText(a.name))!
                         .fields.push(
                             buildFieldDescription(
                                 f,
-                                types.get(idText(a.name))!.fields.length,
+                                types.get(A.idText(a.name))!.fields.length,
                             ),
                         );
                 } else if (f.kind === "constant_def") {
                     if (
                         types
-                            .get(idText(a.name))!
-                            .fields.find((v) => eqNames(v.name, f.name))
+                            .get(A.idText(a.name))!
+                            .fields.find((v) => A.eqNames(v.name, f.name))
                     ) {
                         throwCompilationError(
                             `Field ${idTextErr(f.name)} already exists`,
@@ -495,8 +475,8 @@ export function resolveDescriptors(ctx: CompilerContext, Ast: FactoryAst) {
                     }
                     if (
                         types
-                            .get(idText(a.name))!
-                            .constants.find((v) => eqNames(v.name, f.name))
+                            .get(A.idText(a.name))!
+                            .constants.find((v) => A.eqNames(v.name, f.name))
                     ) {
                         throwCompilationError(
                             `Constant ${idTextErr(f.name)} already exists`,
@@ -510,7 +490,7 @@ export function resolveDescriptors(ctx: CompilerContext, Ast: FactoryAst) {
                         );
                     }
                     types
-                        .get(idText(a.name))!
+                        .get(A.idText(a.name))!
                         .constants.push(buildConstantDescription(f));
                 }
             }
@@ -521,8 +501,8 @@ export function resolveDescriptors(ctx: CompilerContext, Ast: FactoryAst) {
             for (const f of a.fields) {
                 if (
                     types
-                        .get(idText(a.name))!
-                        .fields.find((v) => eqNames(v.name, f.name))
+                        .get(A.idText(a.name))!
+                        .fields.find((v) => A.eqNames(v.name, f.name))
                 ) {
                     throwCompilationError(
                         `Field ${idTextErr(f.name)} already exists`,
@@ -530,11 +510,11 @@ export function resolveDescriptors(ctx: CompilerContext, Ast: FactoryAst) {
                     );
                 }
                 types
-                    .get(idText(a.name))!
+                    .get(A.idText(a.name))!
                     .fields.push(
                         buildFieldDescription(
                             f,
-                            types.get(idText(a.name))!.fields.length,
+                            types.get(A.idText(a.name))!.fields.length,
                         ),
                     );
             }
@@ -552,8 +532,10 @@ export function resolveDescriptors(ctx: CompilerContext, Ast: FactoryAst) {
                 if (traitDecl.kind === "field_decl") {
                     if (
                         types
-                            .get(idText(a.name))!
-                            .fields.find((v) => eqNames(v.name, traitDecl.name))
+                            .get(A.idText(a.name))!
+                            .fields.find((v) =>
+                                A.eqNames(v.name, traitDecl.name),
+                            )
                     ) {
                         throwCompilationError(
                             `Field ${idTextErr(traitDecl.name)} already exists`,
@@ -567,11 +549,11 @@ export function resolveDescriptors(ctx: CompilerContext, Ast: FactoryAst) {
                         );
                     }
                     types
-                        .get(idText(a.name))!
+                        .get(A.idText(a.name))!
                         .fields.push(
                             buildFieldDescription(
                                 traitDecl,
-                                types.get(idText(a.name))!.fields.length,
+                                types.get(A.idText(a.name))!.fields.length,
                             ),
                         );
                 } else if (
@@ -580,8 +562,10 @@ export function resolveDescriptors(ctx: CompilerContext, Ast: FactoryAst) {
                 ) {
                     if (
                         types
-                            .get(idText(a.name))!
-                            .fields.find((v) => eqNames(v.name, traitDecl.name))
+                            .get(A.idText(a.name))!
+                            .fields.find((v) =>
+                                A.eqNames(v.name, traitDecl.name),
+                            )
                     ) {
                         throwCompilationError(
                             `Field ${idTextErr(traitDecl.name)} already exists`,
@@ -590,9 +574,9 @@ export function resolveDescriptors(ctx: CompilerContext, Ast: FactoryAst) {
                     }
                     if (
                         types
-                            .get(idText(a.name))!
+                            .get(A.idText(a.name))!
                             .constants.find((v) =>
-                                eqNames(v.name, traitDecl.name),
+                                A.eqNames(v.name, traitDecl.name),
                             )
                     ) {
                         throwCompilationError(
@@ -609,7 +593,7 @@ export function resolveDescriptors(ctx: CompilerContext, Ast: FactoryAst) {
                         );
                     }
                     types
-                        .get(idText(a.name))!
+                        .get(A.idText(a.name))!
                         .constants.push(buildConstantDescription(traitDecl));
                 }
             }
@@ -631,10 +615,10 @@ export function resolveDescriptors(ctx: CompilerContext, Ast: FactoryAst) {
     function resolveFunctionDescriptor(
         optSelf: TypeRef | null,
         a:
-            | AstFunctionDef
-            | AstNativeFunctionDecl
-            | AstFunctionDecl
-            | AstAsmFunctionDef,
+            | A.AstFunctionDef
+            | A.AstNativeFunctionDecl
+            | A.AstFunctionDecl
+            | A.AstAsmFunctionDef,
         origin: ItemOrigin,
     ): FunctionDescription {
         let self = optSelf;
@@ -827,7 +811,7 @@ export function resolveDescriptors(ctx: CompilerContext, Ast: FactoryAst) {
                 );
             }
             const firstParam = params[0]!;
-            if (!isSelfId(firstParam.name)) {
+            if (!A.isSelfId(firstParam.name)) {
                 throwCompilationError(
                     'Extend function must have first parameter named "self"',
                     firstParam.loc,
@@ -862,19 +846,19 @@ export function resolveDescriptors(ctx: CompilerContext, Ast: FactoryAst) {
         // Check parameter names
         const exNames: Set<string> = new Set();
         for (const param of params) {
-            if (isSelfId(param.name)) {
+            if (A.isSelfId(param.name)) {
                 throwCompilationError(
                     'Parameter name "self" is reserved',
                     param.loc,
                 );
             }
-            if (exNames.has(idText(param.name))) {
+            if (exNames.has(A.idText(param.name))) {
                 throwCompilationError(
                     `Parameter name ${idTextErr(param.name)} is already used`,
                     param.loc,
                 );
             }
-            exNames.add(idText(param.name));
+            exNames.add(A.idText(param.name));
         }
 
         // Check for runtime types in getters
@@ -902,7 +886,7 @@ export function resolveDescriptors(ctx: CompilerContext, Ast: FactoryAst) {
             // check arguments shuffle
             if (a.shuffle.args.length !== 0) {
                 const shuffleArgSet = new Set(
-                    a.shuffle.args.map((id) => idText(id)),
+                    a.shuffle.args.map((id) => A.idText(id)),
                 );
                 if (shuffleArgSet.size !== a.shuffle.args.length) {
                     throwCompilationError(
@@ -911,7 +895,7 @@ export function resolveDescriptors(ctx: CompilerContext, Ast: FactoryAst) {
                     );
                 }
                 const paramSet = new Set(
-                    a.params.map((typedId) => idText(typedId.name)),
+                    a.params.map((typedId) => A.idText(typedId.name)),
                 );
                 if (!isSubsetOf(paramSet, shuffleArgSet)) {
                     throwCompilationError(
@@ -994,7 +978,7 @@ export function resolveDescriptors(ctx: CompilerContext, Ast: FactoryAst) {
 
         // Register function
         return {
-            name: idText(a.name),
+            name: A.idText(a.name),
             self: self,
             origin,
             params,
@@ -1010,7 +994,7 @@ export function resolveDescriptors(ctx: CompilerContext, Ast: FactoryAst) {
         };
     }
 
-    function resolveInitFunction(ast: AstContractInit): InitDescription {
+    function resolveInitFunction(ast: A.AstContractInit): InitDescription {
         const params: InitParameter[] = [];
         for (const r of ast.params) {
             params.push({
@@ -1040,7 +1024,7 @@ export function resolveDescriptors(ctx: CompilerContext, Ast: FactoryAst) {
 
     for (const a of ast.types) {
         if (a.kind === "contract" || a.kind === "trait") {
-            const s = types.get(idText(a.name))!;
+            const s = types.get(A.idText(a.name))!;
             for (const d of a.declarations) {
                 if (
                     d.kind === "function_def" ||
@@ -1104,7 +1088,7 @@ export function resolveDescriptors(ctx: CompilerContext, Ast: FactoryAst) {
                                         d.loc,
                                     );
                                 }
-                                const t = types.get(idText(param.type));
+                                const t = types.get(A.idText(param.type));
                                 if (!t) {
                                     throwCompilationError(
                                         `Type ${idTextErr(param.type)} not found`,
@@ -1190,7 +1174,7 @@ export function resolveDescriptors(ctx: CompilerContext, Ast: FactoryAst) {
                                     }
 
                                     // Check for duplicate
-                                    const n = idText(param.type);
+                                    const n = A.idText(param.type);
                                     if (
                                         s.receivers.find(
                                             (v) =>
@@ -1198,7 +1182,7 @@ export function resolveDescriptors(ctx: CompilerContext, Ast: FactoryAst) {
                                                     (internal
                                                         ? "internal-binary"
                                                         : "external-binary") &&
-                                                eqNames(v.selector.type, n),
+                                                A.eqNames(v.selector.type, n),
                                         )
                                     ) {
                                         throwCompilationError(
@@ -1214,7 +1198,7 @@ export function resolveDescriptors(ctx: CompilerContext, Ast: FactoryAst) {
                                                 ? "internal-binary"
                                                 : "external-binary",
                                             name: param.name,
-                                            type: idText(param.type),
+                                            type: A.idText(param.type),
                                         },
                                         ast: d,
                                     });
@@ -1293,7 +1277,7 @@ export function resolveDescriptors(ctx: CompilerContext, Ast: FactoryAst) {
                             const param = d.selector.param;
 
                             if (param.type.kind === "type_id") {
-                                if (isSlice(param.type)) {
+                                if (A.isSlice(param.type)) {
                                     if (
                                         s.receivers.find(
                                             (v) =>
@@ -1315,7 +1299,9 @@ export function resolveDescriptors(ctx: CompilerContext, Ast: FactoryAst) {
                                         ast: d,
                                     });
                                 } else {
-                                    const type = types.get(idText(param.type));
+                                    const type = types.get(
+                                        A.idText(param.type),
+                                    );
                                     if (type === undefined) {
                                         throwCompilationError(
                                             `Unknown bounced receiver parameter type: ${idTextErr(param.type)}`,
@@ -1354,7 +1340,7 @@ export function resolveDescriptors(ctx: CompilerContext, Ast: FactoryAst) {
                                         selector: {
                                             kind: "bounce-binary",
                                             name: param.name,
-                                            type: idText(param.type),
+                                            type: A.idText(param.type),
                                             bounced: false,
                                         },
                                         ast: d,
@@ -1369,7 +1355,7 @@ export function resolveDescriptors(ctx: CompilerContext, Ast: FactoryAst) {
                                 param.type.kind === "bounced_message_type"
                             ) {
                                 const t = types.get(
-                                    idText(param.type.messageType),
+                                    A.idText(param.type.messageType),
                                 );
                                 if (t === undefined) {
                                     throwCompilationError(
@@ -1412,7 +1398,7 @@ export function resolveDescriptors(ctx: CompilerContext, Ast: FactoryAst) {
                                     selector: {
                                         kind: "bounce-binary",
                                         name: param.name,
-                                        type: idText(param.type.messageType),
+                                        type: A.idText(param.type.messageType),
                                         bounced: true,
                                     },
                                     ast: d,
@@ -1444,7 +1430,7 @@ export function resolveDescriptors(ctx: CompilerContext, Ast: FactoryAst) {
                         params: [],
                         statements: [],
                         loc: t.ast.loc,
-                    }) as AstContractInit,
+                    }) as A.AstContractInit,
                 };
             }
         }
@@ -1457,7 +1443,7 @@ export function resolveDescriptors(ctx: CompilerContext, Ast: FactoryAst) {
     for (const t of types.values()) {
         if (t.ast.kind === "trait" || t.ast.kind === "contract") {
             // Check there are no duplicates in the _immediately_ inherited traits
-            const traitSet: Set<string> = new Set(t.ast.traits.map(idText));
+            const traitSet: Set<string> = new Set(t.ast.traits.map(A.idText));
             if (traitSet.size !== t.ast.traits.length) {
                 const aggregateType =
                     t.ast.kind === "contract" ? "contract" : "trait";
@@ -1486,7 +1472,7 @@ export function resolveDescriptors(ctx: CompilerContext, Ast: FactoryAst) {
                 traits.push(tt);
                 if (tt.ast.kind === "trait") {
                     for (const s of tt.ast.traits) {
-                        visit(idText(s));
+                        visit(A.idText(s));
                     }
                     for (const f of tt.traits) {
                         visit(f.name);
@@ -1500,7 +1486,7 @@ export function resolveDescriptors(ctx: CompilerContext, Ast: FactoryAst) {
             }
             visit("BaseTrait");
             for (const s of t.ast.traits) {
-                visit(idText(s));
+                visit(A.idText(s));
             }
 
             // Assign traits
@@ -1876,15 +1862,15 @@ export function resolveDescriptors(ctx: CompilerContext, Ast: FactoryAst) {
 
     for (const [k, t] of types) {
         const dependsOn: Set<string> = new Set();
-        const handler = (src: AstNode) => {
+        const handler = (src: A.AstNode) => {
             if (src.kind === "init_of") {
-                if (!types.has(idText(src.contract))) {
+                if (!types.has(A.idText(src.contract))) {
                     throwCompilationError(
                         `Type ${idTextErr(src.contract)} not found`,
                         src.loc,
                     );
                 }
-                dependsOn.add(idText(src.contract));
+                dependsOn.add(A.idText(src.contract));
             }
         };
 
@@ -1972,22 +1958,22 @@ export function resolveDescriptors(ctx: CompilerContext, Ast: FactoryAst) {
     //
 
     for (const a of ast.constants) {
-        if (staticConstants.has(idText(a.name))) {
+        if (staticConstants.has(A.idText(a.name))) {
             throwCompilationError(
                 `Static constant ${idTextErr(a.name)} already exists`,
                 a.loc,
             );
         }
         if (
-            staticFunctions.has(idText(a.name)) ||
-            GlobalFunctions.has(idText(a.name))
+            staticFunctions.has(A.idText(a.name)) ||
+            GlobalFunctions.has(A.idText(a.name))
         ) {
             throwCompilationError(
                 `Static function ${idTextErr(a.name)} already exists`,
                 a.loc,
             );
         }
-        staticConstants.set(idText(a.name), buildConstantDescription(a));
+        staticConstants.set(A.idText(a.name), buildConstantDescription(a));
     }
 
     //
@@ -2015,9 +2001,9 @@ export function resolveDescriptors(ctx: CompilerContext, Ast: FactoryAst) {
 
 export function getType(
     ctx: CompilerContext,
-    ident: AstId | AstTypeId | string,
+    ident: A.AstId | A.AstTypeId | string,
 ): TypeDescription {
-    const name = typeof ident === "string" ? ident : idText(ident);
+    const name = typeof ident === "string" ? ident : A.idText(ident);
     const r = store.get(ctx, name);
     if (!r) {
         throwInternalCompilerError(`Type ${name} not found`);
@@ -2135,7 +2121,7 @@ function checkInitializerType(
     name: string,
     kind: "Constant" | "Struct field",
     declTy: TypeRef,
-    initializer: AstExpression,
+    initializer: A.AstExpression,
     ctx: CompilerContext,
 ): CompilerContext {
     const stmtCtx = emptyContext(initializer.loc, null, declTy);
@@ -2238,7 +2224,7 @@ function checkRecursiveTypes(ctx: CompilerContext): void {
         (aggregate) => aggregate.kind === "struct",
     );
     let index = 0;
-    const stack: AstId[] = [];
+    const stack: A.AstId[] = [];
     // `string` here means "struct name"
     const indices: Map<string, number> = new Map();
     const lowLinks: Map<string, number> = new Map();
@@ -2318,11 +2304,11 @@ function checkRecursiveTypes(ctx: CompilerContext): void {
         }
 
         if (lowLinks.get(struct.name) === indices.get(struct.name)) {
-            const cycle: AstId[] = [];
+            const cycle: A.AstId[] = [];
             let e = "";
             do {
                 const last = stack.pop()!;
-                e = idText(last);
+                e = A.idText(last);
                 onStack.delete(e);
                 cycle.push(last);
             } while (e !== struct.name);

--- a/src/types/resolveExpression.ts
+++ b/src/types/resolveExpression.ts
@@ -1,28 +1,4 @@
-import {
-    AstBoolean,
-    AstExpression,
-    AstInitOf,
-    AstNull,
-    AstNumber,
-    AstOpBinary,
-    AstMethodCall,
-    AstStaticCall,
-    AstFieldAccess,
-    AstStructInstance,
-    AstOpUnary,
-    AstString,
-    AstConditional,
-    eqNames,
-    idText,
-    isWildcard,
-    AstAddress,
-    AstCell,
-    AstSlice,
-    AstSimplifiedString,
-    AstCommentValue,
-    AstStructValue,
-    getAstFactory,
-} from "../ast/ast";
+import * as A from "../ast/ast";
 import {
     idTextErr,
     TactConstEvalError,
@@ -50,11 +26,11 @@ import { evalConstantExpression } from "../optimizer/constEval";
 import { getAstUtil } from "../ast/util";
 
 const store = createContextStore<{
-    ast: AstExpression;
+    ast: A.AstExpression;
     description: TypeRef;
 }>();
 
-export function getExpType(ctx: CompilerContext, exp: AstExpression) {
+export function getExpType(ctx: CompilerContext, exp: A.AstExpression) {
     const t = store.get(ctx, exp.id);
     if (!t) {
         throwInternalCompilerError(`Expression ${exp.id} not found`);
@@ -64,7 +40,7 @@ export function getExpType(ctx: CompilerContext, exp: AstExpression) {
 
 function registerExpType(
     ctx: CompilerContext,
-    exp: AstExpression,
+    exp: A.AstExpression,
     description: TypeRef,
 ): CompilerContext {
     const ex = store.get(ctx, exp.id);
@@ -81,7 +57,7 @@ function registerExpType(
 }
 
 function resolveBooleanLiteral(
-    exp: AstBoolean,
+    exp: A.AstBoolean,
     sctx: StatementContext,
     ctx: CompilerContext,
 ): CompilerContext {
@@ -93,7 +69,7 @@ function resolveBooleanLiteral(
 }
 
 function resolveIntLiteral(
-    exp: AstNumber,
+    exp: A.AstNumber,
     sctx: StatementContext,
     ctx: CompilerContext,
 ): CompilerContext {
@@ -105,7 +81,7 @@ function resolveIntLiteral(
 }
 
 function resolveNullLiteral(
-    exp: AstNull,
+    exp: A.AstNull,
     sctx: StatementContext,
     ctx: CompilerContext,
 ): CompilerContext {
@@ -113,7 +89,7 @@ function resolveNullLiteral(
 }
 
 function resolveAddressLiteral(
-    exp: AstAddress,
+    exp: A.AstAddress,
     sctx: StatementContext,
     ctx: CompilerContext,
 ): CompilerContext {
@@ -125,7 +101,7 @@ function resolveAddressLiteral(
 }
 
 function resolveCellLiteral(
-    exp: AstCell,
+    exp: A.AstCell,
     sctx: StatementContext,
     ctx: CompilerContext,
 ): CompilerContext {
@@ -137,7 +113,7 @@ function resolveCellLiteral(
 }
 
 function resolveSliceLiteral(
-    exp: AstSlice,
+    exp: A.AstSlice,
     sctx: StatementContext,
     ctx: CompilerContext,
 ): CompilerContext {
@@ -149,7 +125,7 @@ function resolveSliceLiteral(
 }
 
 function resolveStringLiteral(
-    exp: AstString | AstSimplifiedString | AstCommentValue,
+    exp: A.AstString | A.AstSimplifiedString | A.AstCommentValue,
     sctx: StatementContext,
     ctx: CompilerContext,
 ): CompilerContext {
@@ -161,7 +137,7 @@ function resolveStringLiteral(
 }
 
 function resolveStructNew(
-    exp: AstStructInstance | AstStructValue,
+    exp: A.AstStructInstance | A.AstStructValue,
     sctx: StatementContext,
     ctx: CompilerContext,
 ): CompilerContext {
@@ -179,16 +155,16 @@ function resolveStructNew(
     const processed: Set<string> = new Set();
     for (const e of exp.args) {
         // Check duplicates
-        if (processed.has(idText(e.field))) {
+        if (processed.has(A.idText(e.field))) {
             throwCompilationError(
                 `Duplicate fields ${idTextErr(e.field)}`,
                 e.loc,
             );
         }
-        processed.add(idText(e.field));
+        processed.add(A.idText(e.field));
 
         // Check existing
-        const f = tp.fields.find((v) => eqNames(v.name, e.field));
+        const f = tp.fields.find((v) => A.eqNames(v.name, e.field));
         if (!f) {
             throwCompilationError(
                 `Unknown fields ${idTextErr(e.field)} in type ${idTextErr(tp.name)}`,
@@ -232,7 +208,7 @@ function resolveStructNew(
 }
 
 function resolveBinaryOp(
-    exp: AstOpBinary,
+    exp: A.AstOpBinary,
     sctx: StatementContext,
     ctx: CompilerContext,
 ): CompilerContext {
@@ -278,7 +254,7 @@ function resolveBinaryOp(
                             evalConstantExpression(
                                 exp.right,
                                 ctx,
-                                getAstUtil(getAstFactory()),
+                                getAstUtil(A.getAstFactory()),
                             ),
                         );
                         if (0n > valBits.value || valBits.value > 256n) {
@@ -398,7 +374,7 @@ function isEqualityType(ctx: CompilerContext, ty: TypeRef): boolean {
 }
 
 function resolveUnaryOp(
-    exp: AstOpUnary,
+    exp: A.AstOpUnary,
     sctx: StatementContext,
     ctx: CompilerContext,
 ): CompilerContext {
@@ -458,7 +434,7 @@ function resolveUnaryOp(
 }
 
 function resolveFieldAccess(
-    exp: AstFieldAccess,
+    exp: A.AstFieldAccess,
     sctx: StatementContext,
     ctx: CompilerContext,
 ): CompilerContext {
@@ -481,7 +457,7 @@ function resolveFieldAccess(
         exp.aggregate.kind === "id" &&
         exp.aggregate.text === "self"
     ) {
-        if (sctx.requiredFields.find((v) => eqNames(v, exp.field))) {
+        if (sctx.requiredFields.find((v) => A.eqNames(v, exp.field))) {
             throwCompilationError(
                 `Field ${idTextErr(exp.field)} is not initialized`,
                 exp.field.loc,
@@ -492,7 +468,9 @@ function resolveFieldAccess(
     // Find field
     const srcT = getType(ctx, src.name);
 
-    const fieldIndex = srcT.fields.findIndex((v) => eqNames(v.name, exp.field));
+    const fieldIndex = srcT.fields.findIndex((v) =>
+        A.eqNames(v.name, exp.field),
+    );
     const field = fieldIndex !== -1 ? srcT.fields[fieldIndex] : undefined;
 
     // If we found a field of bounced<T>, check if the field doesn't fit in 224 bytes and cannot be accessed
@@ -514,7 +492,7 @@ function resolveFieldAccess(
         );
     }
 
-    const cst = srcT.constants.find((v) => eqNames(v.name, exp.field));
+    const cst = srcT.constants.find((v) => A.eqNames(v.name, exp.field));
     if (!field && !cst) {
         const typeStr =
             src.kind === "ref_bounced"
@@ -525,8 +503,8 @@ function resolveFieldAccess(
             // Check for struct methods
             if (
                 (srcT.kind === "struct" &&
-                    StructFunctions.has(idText(exp.field))) ||
-                srcT.functions.has(idText(exp.field))
+                    StructFunctions.has(A.idText(exp.field))) ||
+                srcT.functions.has(A.idText(exp.field))
             ) {
                 throwCompilationError(
                     `Type ${typeStr} does not have a field named "${exp.field.text}", did you mean "${exp.field.text}()" instead?`,
@@ -550,13 +528,13 @@ function resolveFieldAccess(
 }
 
 function resolveStaticCall(
-    exp: AstStaticCall,
+    exp: A.AstStaticCall,
     sctx: StatementContext,
     ctx: CompilerContext,
 ): CompilerContext {
     // Check if abi global function
-    if (GlobalFunctions.has(idText(exp.function))) {
-        const f = GlobalFunctions.get(idText(exp.function))!;
+    if (GlobalFunctions.has(A.idText(exp.function))) {
+        const f = GlobalFunctions.get(A.idText(exp.function))!;
 
         // Resolve arguments
         for (const e of exp.args) {
@@ -575,15 +553,15 @@ function resolveStaticCall(
     }
 
     // Check if function exists
-    if (!hasStaticFunction(ctx, idText(exp.function))) {
+    if (!hasStaticFunction(ctx, A.idText(exp.function))) {
         // check if there is a method with the same name
         if (
             getAllTypes(ctx).find(
-                (ty) => ty.functions.get(idText(exp.function)) !== undefined,
+                (ty) => ty.functions.get(A.idText(exp.function)) !== undefined,
             ) !== undefined
         ) {
             throwCompilationError(
-                `Static function ${idTextErr(exp.function)} does not exist. Perhaps you meant to call ".${idText(exp.function)}(...)" extension function?`,
+                `Static function ${idTextErr(exp.function)} does not exist. Perhaps you meant to call ".${A.idText(exp.function)}(...)" extension function?`,
                 exp.loc,
             );
         }
@@ -595,7 +573,7 @@ function resolveStaticCall(
     }
 
     // Get static function
-    const f = getStaticFunction(ctx, idText(exp.function));
+    const f = getStaticFunction(ctx, A.idText(exp.function));
 
     // Resolve call arguments
     for (const e of exp.args) {
@@ -625,7 +603,7 @@ function resolveStaticCall(
 }
 
 function resolveCall(
-    exp: AstMethodCall,
+    exp: A.AstMethodCall,
     sctx: StatementContext,
     ctx: CompilerContext,
 ): CompilerContext {
@@ -656,8 +634,8 @@ function resolveCall(
 
         // Check struct ABI
         if (srcT.kind === "struct") {
-            if (StructFunctions.has(idText(exp.method))) {
-                const abi = StructFunctions.get(idText(exp.method))!;
+            if (StructFunctions.has(A.idText(exp.method))) {
+                const abi = StructFunctions.get(A.idText(exp.method))!;
                 const resolved = abi.resolve(
                     ctx,
                     [src, ...exp.args.map((v) => getExpType(ctx, v))],
@@ -667,7 +645,7 @@ function resolveCall(
             }
         }
 
-        const f = srcT.functions.get(idText(exp.method));
+        const f = srcT.functions.get(A.idText(exp.method));
         if (f) {
             // Check arguments
             if (f.params.length !== exp.args.length) {
@@ -691,7 +669,7 @@ function resolveCall(
         }
 
         // Check if a field with the same name exists
-        const field = srcT.fields.find((v) => eqNames(v.name, exp.method));
+        const field = srcT.fields.find((v) => A.eqNames(v.name, exp.method));
         if (field) {
             throwCompilationError(
                 `Type "${src.name}" does not have a function named "${exp.method.text}()", did you mean field "${exp.method.text}" instead?`,
@@ -707,13 +685,13 @@ function resolveCall(
 
     // Handle map
     if (src.kind === "map") {
-        if (!MapFunctions.has(idText(exp.method))) {
+        if (!MapFunctions.has(A.idText(exp.method))) {
             throwCompilationError(
                 `Map function ${idTextErr(exp.method)} not found`,
                 exp.loc,
             );
         }
-        const abf = MapFunctions.get(idText(exp.method))!;
+        const abf = MapFunctions.get(A.idText(exp.method))!;
         const resolved = abf.resolve(
             ctx,
             [src, ...exp.args.map((v) => getExpType(ctx, v))],
@@ -733,7 +711,7 @@ function resolveCall(
 }
 
 function resolveInitOf(
-    ast: AstInitOf,
+    ast: A.AstInitOf,
     sctx: StatementContext,
     ctx: CompilerContext,
 ): CompilerContext {
@@ -784,7 +762,7 @@ function resolveInitOf(
 }
 
 function resolveConditional(
-    ast: AstConditional,
+    ast: A.AstConditional,
     sctx: StatementContext,
     ctx: CompilerContext,
 ): CompilerContext {
@@ -824,7 +802,7 @@ function resolveConditional(
 }
 
 export function resolveExpression(
-    exp: AstExpression,
+    exp: A.AstExpression,
     sctx: StatementContext,
     ctx: CompilerContext,
 ) {
@@ -876,7 +854,7 @@ export function resolveExpression(
             const v = sctx.vars.get(exp.text);
             if (!v) {
                 if (!hasStaticConstant(ctx, exp.text)) {
-                    if (isWildcard(exp)) {
+                    if (A.isWildcard(exp)) {
                         throwCompilationError(
                             "Wildcard variable name '_' cannot be accessed",
                             exp.loc,

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -1,21 +1,6 @@
 import { ABIField } from "@ton/core";
 import { throwInternalCompilerError } from "../error/errors";
-import {
-    AstConstantDef,
-    AstFunctionDef,
-    AstContractInit,
-    AstNativeFunctionDecl,
-    AstReceiver,
-    AstTypeDecl,
-    AstId,
-    AstFunctionDecl,
-    AstConstantDecl,
-    AstFieldDecl,
-    AstAsmFunctionDef,
-    AstNumber,
-    AstLiteral,
-    idText,
-} from "../ast/ast";
+import * as A from "../ast/ast";
 import { ItemOrigin, SrcInfo } from "../grammar";
 
 export type TypeDescription = {
@@ -23,7 +8,7 @@ export type TypeDescription = {
     origin: ItemOrigin;
     name: string;
     uid: number;
-    header: AstNumber | null;
+    header: A.AstNumber | null;
     tlb: string | null;
     signature: string | null;
     fields: FieldDescription[];
@@ -32,7 +17,7 @@ export type TypeDescription = {
     functions: Map<string, FunctionDescription>;
     receivers: ReceiverDescription[];
     init: InitDescription | null;
-    ast: AstTypeDecl;
+    ast: A.AstTypeDecl;
     dependsOn: TypeDescription[];
     interfaces: string[];
     constants: ConstantDescription[];
@@ -66,7 +51,7 @@ export type TypeRef =
 // https://github.com/microsoft/TypeScript/pull/57293
 // eslint-disable-next-line @typescript-eslint/consistent-indexed-object-style
 
-export function showValue(val: AstLiteral): string {
+export function showValue(val: A.AstLiteral): string {
     switch (val.kind) {
         case "number":
             return val.value.toString(val.base);
@@ -85,7 +70,7 @@ export function showValue(val: AstLiteral): string {
         case "struct_value": {
             const assocList = val.args.map(
                 (field) =>
-                    `${idText(field.field)}: ${showValue(field.initializer)}`,
+                    `${A.idText(field.field)}: ${showValue(field.initializer)}`,
             );
             return `{${assocList.join(",")}}`;
         }
@@ -99,28 +84,28 @@ export type FieldDescription = {
     index: number;
     type: TypeRef;
     as: string | null;
-    default: AstLiteral | undefined;
+    default: A.AstLiteral | undefined;
     loc: SrcInfo;
-    ast: AstFieldDecl;
+    ast: A.AstFieldDecl;
     abi: ABIField;
 };
 
 export type ConstantDescription = {
     name: string;
     type: TypeRef;
-    value: AstLiteral | undefined;
+    value: A.AstLiteral | undefined;
     loc: SrcInfo;
-    ast: AstConstantDef | AstConstantDecl;
+    ast: A.AstConstantDef | A.AstConstantDecl;
 };
 
 export type FunctionParameter = {
-    name: AstId;
+    name: A.AstId;
     type: TypeRef;
     loc: SrcInfo;
 };
 
 export type InitParameter = {
-    name: AstId;
+    name: A.AstId;
     type: TypeRef;
     as: string | null;
     loc: SrcInfo;
@@ -140,28 +125,28 @@ export type FunctionDescription = {
     returns: TypeRef;
     params: FunctionParameter[];
     ast:
-        | AstFunctionDef
-        | AstNativeFunctionDecl
-        | AstFunctionDecl
-        | AstAsmFunctionDef;
+        | A.AstFunctionDef
+        | A.AstNativeFunctionDecl
+        | A.AstFunctionDecl
+        | A.AstAsmFunctionDef;
 };
 
 export type BinaryReceiverSelector =
     | {
           kind: "internal-binary";
           type: string;
-          name: AstId;
+          name: A.AstId;
       }
     | {
           kind: "bounce-binary";
-          name: AstId;
+          name: A.AstId;
           type: string;
           bounced: boolean;
       }
     | {
           kind: "external-binary";
           type: string;
-          name: AstId;
+          name: A.AstId;
       };
 
 export type CommentReceiverSelector =
@@ -185,23 +170,23 @@ type EmptyReceiverSelector =
 type FallbackReceiverSelector =
     | {
           kind: "internal-comment-fallback";
-          name: AstId;
+          name: A.AstId;
       }
     | {
           kind: "internal-fallback";
-          name: AstId;
+          name: A.AstId;
       }
     | {
           kind: "bounce-fallback";
-          name: AstId;
+          name: A.AstId;
       }
     | {
           kind: "external-comment-fallback";
-          name: AstId;
+          name: A.AstId;
       }
     | {
           kind: "external-fallback";
-          name: AstId;
+          name: A.AstId;
       };
 
 export type ReceiverSelector =
@@ -235,12 +220,12 @@ export function receiverSelectorName(selector: ReceiverSelector): string {
 
 export type ReceiverDescription = {
     selector: ReceiverSelector;
-    ast: AstReceiver;
+    ast: A.AstReceiver;
 };
 
 export type InitDescription = {
     params: InitParameter[];
-    ast: AstContractInit;
+    ast: A.AstContractInit;
 };
 
 export function printTypeRef(src: TypeRef): string {


### PR DESCRIPTION
## Issue

Closes #1407.

## Checklist

- [x] I have run all the tests locally and no test failure was reported
- [x] I have run the linter, formatter and spellchecker
- [x] I did not do unrelated and/or undiscussed refactorings
