### PR TITLE
refactor: rename `AstCondition` to `AstStatementCondition` to match other names

### DIFF
--- a/src/ast/ast-printer.ts
+++ b/src/ast/ast-printer.ts
@@ -241,7 +241,9 @@ export const ppAstOpBinary: ExprPrinter<A.AstOpBinary> =
         return brace(position, `${leftCode} ${op} ${rightCode}`);
     };
 
-export const ppAstConditional: ExprPrinter<A.AstConditional> =
+export const ppAstStatementConditional: ExprPrinter<
+    A.AstStatementConditional
+> =
     ({ condition, thenBranch, elseBranch }) =>
     (position) => {
         const { brace, self, child } = conditionalPrecedence;
@@ -274,7 +276,7 @@ export const ppAstExpressionNested = makeVisitor<A.AstExpression>()({
 
     op_binary: ppAstOpBinary,
 
-    conditional: ppAstConditional,
+    conditional: ppAstStatementConditional,
 });
 
 export const ppAstExpression = (expr: A.AstExpression): string => {
@@ -736,7 +738,7 @@ export const ppAstStatementAugmentedAssign: Printer<
             `${ppAstExpression(path)} ${op}= ${ppAstExpression(expression)};`,
         );
 
-export const ppAstCondition: Printer<A.AstCondition> =
+export const ppAstStatementCondition: Printer<A.AstStatementCondition> =
     ({ condition, trueStatements, falseStatements }) =>
     (c) => {
         if (falseStatements) {
@@ -842,7 +844,7 @@ export const ppAstStatement: Printer<A.AstStatement> =
         statement_expression: ppAstStatementExpression,
         statement_assign: ppAstStatementAssign,
         statement_augmentedassign: ppAstStatementAugmentedAssign,
-        statement_condition: ppAstCondition,
+        statement_condition: ppAstStatementCondition,
         statement_while: ppAstStatementWhile,
         statement_until: ppAstStatementUntil,
         statement_repeat: ppAstStatementRepeat,
@@ -910,7 +912,7 @@ export const ppAstNode: Printer<A.AstNode> = makeVisitor<A.AstNode>()({
     statement_expression: ppAstStatementExpression,
     statement_assign: ppAstStatementAssign,
     statement_augmentedassign: ppAstStatementAugmentedAssign,
-    statement_condition: ppAstCondition,
+    statement_condition: ppAstStatementCondition,
     statement_while: ppAstStatementWhile,
     statement_until: ppAstStatementUntil,
     statement_repeat: ppAstStatementRepeat,

--- a/src/ast/ast.ts
+++ b/src/ast/ast.ts
@@ -200,7 +200,7 @@ export type AstStatement =
     | AstStatementExpression
     | AstStatementAssign
     | AstStatementAugmentedAssign
-    | AstCondition
+    | AstStatementCondition
     | AstStatementWhile
     | AstStatementUntil
     | AstStatementRepeat
@@ -263,12 +263,12 @@ export type AstStatementAugmentedAssign = {
     loc: SrcInfo;
 };
 
-export type AstCondition = {
+export type AstStatementCondition = {
     kind: "statement_condition";
     condition: AstExpression;
     trueStatements: AstStatement[];
     falseStatements: AstStatement[] | null;
-    elseif: AstCondition | null;
+    elseif: AstStatementCondition | null;
     id: number;
     loc: SrcInfo;
 };
@@ -384,7 +384,7 @@ export type AstBouncedMessageType = {
 export type AstExpression =
     | AstOpBinary
     | AstOpUnary
-    | AstConditional
+    | AstStatementConditional
     | AstMethodCall
     | AstFieldAccess
     | AstStaticCall
@@ -494,7 +494,7 @@ export type AstInitOf = {
     loc: SrcInfo;
 };
 
-export type AstConditional = {
+export type AstStatementConditional = {
     kind: "conditional";
     condition: AstExpression;
     thenBranch: AstExpression;
@@ -925,15 +925,15 @@ export function eqExpressions(
             return (
                 eqExpressions(
                     ast1.condition,
-                    (ast2 as AstConditional).condition,
+                    (ast2 as AstStatementConditional).condition,
                 ) &&
                 eqExpressions(
                     ast1.thenBranch,
-                    (ast2 as AstConditional).thenBranch,
+                    (ast2 as AstStatementConditional).thenBranch,
                 ) &&
                 eqExpressions(
                     ast1.elseBranch,
-                    (ast2 as AstConditional).elseBranch,
+                    (ast2 as AstStatementConditional).elseBranch,
                 )
             );
         case "struct_instance":

--- a/src/ast/compare.ts
+++ b/src/ast/compare.ts
@@ -395,13 +395,13 @@ export class AstComparator {
                     trueStatements: true1,
                     falseStatements: false1,
                     elseif: condElseIf1,
-                } = node1 as A.AstCondition;
+                } = node1 as A.AstStatementCondition;
                 const {
                     condition: cond2,
                     trueStatements: true2,
                     falseStatements: false2,
                     elseif: condElseIf2,
-                } = node2 as A.AstCondition;
+                } = node2 as A.AstStatementCondition;
                 return (
                     this.compare(cond1, cond2) &&
                     this.compareArray(true1, true2) &&
@@ -715,12 +715,12 @@ export class AstComparator {
                     condition: cond1,
                     thenBranch: then1,
                     elseBranch: else1,
-                } = node1 as A.AstConditional;
+                } = node1 as A.AstStatementConditional;
                 const {
                     condition: cond2,
                     thenBranch: then2,
                     elseBranch: else2,
-                } = node2 as A.AstConditional;
+                } = node2 as A.AstStatementConditional;
                 return (
                     this.compare(cond1, cond2) &&
                     this.compare(then1, then2) &&

--- a/src/ast/getAstSchema.ts
+++ b/src/ast/getAstSchema.ts
@@ -295,10 +295,10 @@ export const getAstSchema = (
             condition: A.AstExpression,
             trueStatements: A.AstStatement[],
             falseStatements: A.AstStatement[] | null,
-            elseif: A.AstCondition | null,
+            elseif: A.AstStatementCondition | null,
             loc: Loc,
-        ): A.AstCondition =>
-            createNode<A.AstCondition>({
+        ): A.AstStatementCondition =>
+            createNode<A.AstStatementCondition>({
                 kind: "statement_condition",
                 condition,
                 trueStatements,
@@ -510,8 +510,8 @@ export const getAstSchema = (
             thenBranch: A.AstExpression,
             elseBranch: A.AstExpression,
             loc: Loc,
-        ): A.AstConditional =>
-            createNode<A.AstConditional>({
+        ): A.AstStatementConditional =>
+            createNode<A.AstStatementConditional>({
                 kind: "conditional",
                 condition,
                 thenBranch,

--- a/src/ast/rename.ts
+++ b/src/ast/rename.ts
@@ -370,7 +370,9 @@ export class AstRenamer {
                         ? this.renameStatements(stmt.falseStatements)
                         : null,
                     elseif: stmt.elseif
-                        ? (this.renameStatement(stmt.elseif) as A.AstCondition)
+                        ? (this.renameStatement(
+                              stmt.elseif,
+                          ) as A.AstStatementCondition)
                         : null,
                 };
             case "statement_while":

--- a/src/generator/writers/writeFunction.ts
+++ b/src/generator/writers/writeFunction.ts
@@ -493,7 +493,7 @@ export function writeStatement(
 }
 
 function writeCondition(
-    f: A.AstCondition,
+    f: A.AstStatementCondition,
     self: string | null,
     elseif: boolean,
     returns: TypeRef | null,

--- a/src/grammar/next/index.ts
+++ b/src/grammar/next/index.ts
@@ -495,7 +495,7 @@ const parseStatementCondition =
         trueBranch,
         falseBranch,
         loc,
-    }: $ast.StatementCondition): Handler<A.AstCondition> =>
+    }: $ast.StatementCondition): Handler<A.AstStatementCondition> =>
     (ctx) => {
         if (typeof falseBranch === "undefined") {
             return ctx.ast.Condition(

--- a/src/optimizer/interpreter.ts
+++ b/src/optimizer/interpreter.ts
@@ -974,7 +974,7 @@ export class Interpreter {
         );
     }
 
-    public interpretConditional(ast: A.AstConditional): A.AstLiteral {
+    public interpretConditional(ast: A.AstStatementConditional): A.AstLiteral {
         // here we rely on the typechecker that both branches have the same type
         const valCond = ensureBoolean(this.interpretExpression(ast.condition));
         if (valCond.value) {
@@ -1639,7 +1639,7 @@ export class Interpreter {
         }
     }
 
-    public interpretConditionStatement(ast: A.AstCondition) {
+    public interpretConditionStatement(ast: A.AstStatementCondition) {
         const condition = ensureBoolean(
             this.interpretExpression(ast.condition),
         );

--- a/src/types/resolveExpression.ts
+++ b/src/types/resolveExpression.ts
@@ -762,7 +762,7 @@ function resolveInitOf(
 }
 
 function resolveConditional(
-    ast: A.AstConditional,
+    ast: A.AstStatementConditional,
     sctx: StatementContext,
     ctx: CompilerContext,
 ): CompilerContext {

--- a/src/types/resolveStatements.ts
+++ b/src/types/resolveStatements.ts
@@ -123,7 +123,7 @@ function addVariable(
 }
 
 function processCondition(
-    condition: A.AstCondition,
+    condition: A.AstStatementCondition,
     sctx: StatementContext,
     ctx: CompilerContext,
 ): {


### PR DESCRIPTION
## Issue

Towards #1408

## Checklist

- [x] I have run all the tests locally and no test failure was reported
- [x] I have run the linter, formatter and spellchecker
- [x] I did not do unrelated and/or undiscussed refactorings
