### PR TITLE
refactor: move bigint utils to `src/optimizer/util.ts`

### DIFF
--- a/src/ast/util.ts
+++ b/src/ast/util.ts
@@ -191,31 +191,3 @@ export function checkIsName(ast: A.AstExpression): boolean {
 export function checkIsBoolean(ast: A.AstExpression, b: boolean): boolean {
     return ast.kind === "boolean" ? ast.value == b : false;
 }
-
-// bigint arithmetic
-
-// precondition: the divisor is not zero
-// rounds the division result towards negative infinity
-export function divFloor(a: bigint, b: bigint): bigint {
-    const almostSameSign = a > 0n === b > 0n;
-    if (almostSameSign) {
-        return a / b;
-    }
-    return a / b + (a % b === 0n ? 0n : -1n);
-}
-
-export function abs(a: bigint): bigint {
-    return a < 0n ? -a : a;
-}
-
-export function sign(a: bigint): bigint {
-    if (a === 0n) return 0n;
-    else return a < 0n ? -1n : 1n;
-}
-
-// precondition: the divisor is not zero
-// rounds the result towards negative infinity
-// Uses the fact that a / b * b + a % b == a, for all b != 0.
-export function modFloor(a: bigint, b: bigint): bigint {
-    return a - divFloor(a, b) * b;
-}

--- a/src/optimizer/associative.ts
+++ b/src/optimizer/associative.ts
@@ -5,13 +5,12 @@ import * as A from "../ast/ast";
 import * as iM from "./interpreter";
 import { ExpressionTransformer, Rule } from "./types";
 import {
-    abs,
     checkIsBinaryOpNode,
     checkIsBinaryOp_With_RightValue,
     checkIsBinaryOp_With_LeftValue,
-    sign,
     AstUtil,
 } from "../ast/util";
+import { abs, sign } from "./util";
 
 type TransformData = {
     simplifiedExpression: A.AstExpression;

--- a/src/optimizer/interpreter.ts
+++ b/src/optimizer/interpreter.ts
@@ -11,7 +11,7 @@ import {
     throwConstEvalError,
     throwInternalCompilerError,
 } from "../error/errors";
-import { AstUtil, divFloor, getAstUtil, modFloor } from "../ast/util";
+import { AstUtil, getAstUtil } from "../ast/util";
 import {
     getStaticConstant,
     getStaticFunction,
@@ -24,6 +24,7 @@ import { TypeRef, showValue } from "../types/types";
 import { sha256_sync } from "@ton/crypto";
 import { defaultParser, getParser, Parser } from "../grammar/grammar";
 import { dummySrcInfo, SrcInfo } from "../grammar";
+import { divFloor, modFloor } from "./util";
 
 // TVM integers are signed 257-bit integers
 const minTvmInt: bigint = -(2n ** 256n);

--- a/src/optimizer/util.ts
+++ b/src/optimizer/util.ts
@@ -1,0 +1,25 @@
+// precondition: the divisor is not zero
+// rounds the division result towards negative infinity
+export function divFloor(a: bigint, b: bigint): bigint {
+    const almostSameSign = a > 0n === b > 0n;
+    if (almostSameSign) {
+        return a / b;
+    }
+    return a / b + (a % b === 0n ? 0n : -1n);
+}
+
+export function abs(a: bigint): bigint {
+    return a < 0n ? -a : a;
+}
+
+export function sign(a: bigint): bigint {
+    if (a === 0n) return 0n;
+    else return a < 0n ? -1n : 1n;
+}
+
+// precondition: the divisor is not zero
+// rounds the result towards negative infinity
+// Uses the fact that a / b * b + a % b == a, for all b != 0.
+export function modFloor(a: bigint, b: bigint): bigint {
+    return a - divFloor(a, b) * b;
+}


### PR DESCRIPTION
## Issue

#1421.

## Checklist

- [x] I have run all the tests locally and no test failure was reported
- [x] I have run the linter, formatter and spellchecker
- [x] I did not do unrelated and/or undiscussed refactorings
