### PR TITLE
feat: underline only the attribute itself in compilation errors about attributes

### DIFF
--- a/dev-docs/CHANGELOG.md
+++ b/dev-docs/CHANGELOG.md
@@ -36,6 +36,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Allow serialization specifiers for trait fields PR: [#1303](https://github.com/tact-lang/tact/pull/1303)
 - Remove unused typechecker wrapper with the file `check.ts` it is contained in: PR [#1313](https://github.com/tact-lang/tact/pull/1313)
 - Unified `StatementTry` and `StatementTryCatch` AST nodes: PR [#1418](https://github.com/tact-lang/tact/pull/1418)
+- Underline only the attribute itself in compilation errors about attributes: PR [#1524](https://github.com/tact-lang/tact/pull/1524)
 
 ### Fixed
 

--- a/src/grammar/next/__snapshots__/grammar.spec.ts.snap
+++ b/src/grammar/next/__snapshots__/grammar.spec.ts.snap
@@ -22,7 +22,7 @@ exports[`grammar should fail const-override 1`] = `
 "<unknown>:4:1: Module-level constants do not support attributes
   3 | 
 > 4 | override const Foo: Int = 42;
-      ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+      ^~~~~~~~
   5 | 
 "
 `;
@@ -40,7 +40,7 @@ exports[`grammar should fail const-override-virtual 1`] = `
 "<unknown>:4:1: Module-level constants do not support attributes
   3 | 
 > 4 | override virtual const Foo: Int = 42;
-      ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+      ^~~~~~~~
   5 | 
 "
 `;
@@ -49,7 +49,7 @@ exports[`grammar should fail const-virtual 1`] = `
 "<unknown>:4:1: Module-level constants do not support attributes
   3 | 
 > 4 | virtual const Foo: Int = 42;
-      ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
+      ^~~~~~~
   5 | 
 "
 `;
@@ -58,7 +58,7 @@ exports[`grammar should fail const-virtual-override 1`] = `
 "<unknown>:4:1: Module-level constants do not support attributes
   3 | 
 > 4 | virtual override const Foo: Int = 42;
-      ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+      ^~~~~~~
   5 | 
 "
 `;

--- a/src/grammar/next/index.ts
+++ b/src/grammar/next/index.ts
@@ -950,7 +950,7 @@ const parseConstantDefInModule =
                 $: "range",
                 start: firstAttribute.loc.interval.startIdx,
                 end: firstAttribute.loc.interval.endIdx,
-            } as $.Loc);
+            });
             result.attributes = [];
         }
         return result;

--- a/src/grammar/next/index.ts
+++ b/src/grammar/next/index.ts
@@ -946,9 +946,11 @@ const parseConstantDefInModule =
         const result = parseConstantDef(node)(ctx);
         const firstAttribute = result.attributes[0];
         if (typeof firstAttribute !== "undefined") {
-            // FIXME: should be `firstAttribute.loc`
-            // https://github.com/tact-lang/tact/issues/1255
-            ctx.err.topLevelConstantWithAttribute()(node.loc);
+            ctx.err.topLevelConstantWithAttribute()({
+                $: "range",
+                start: firstAttribute.loc.interval.startIdx,
+                end: firstAttribute.loc.interval.endIdx,
+            } as $.Loc);
             result.attributes = [];
         }
         return result;


### PR DESCRIPTION
Not sure if this is a good way to pass location there when we have only `SrcInfo`

## Issue

#1255.

## Checklist

- [x] I have updated CHANGELOG.md
- [x] I have run all the tests locally and no test failure was reported
- [x] I have run the linter, formatter and spellchecker
- [x] I did not do unrelated and/or undiscussed refactorings
