### PR TITLE
put the linter launch in a separate job

### DIFF
--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -28,7 +28,10 @@ jobs:
 
       - name: Prepare linter
         run: |
-          yarn gen
+          gen:grammar
+          gen:stdlib
+          gen:func-js
+          gen:contracts:test
 
       - name: Check there are no errors to be fixed in package.json and no uncommitted changes
         run: |

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -28,9 +28,7 @@ jobs:
 
       - name: Prepare linter
         run: |
-          yarn gen:grammar
-          yarn gen:stdlib
-          yarn gen:func-js
+          yarn gen
 
       - name: Check there are no errors to be fixed in package.json and no uncommitted changes
         run: |

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -45,3 +45,11 @@ jobs:
       - name: Check there are no unused dependencies
         run: |
           yarn knip
+
+      - name: Check broken file references in internal documentation
+        uses: lycheeverse/lychee-action@v2
+        with:
+          args: "-n -s file --exclude-path node_modules --exclude-path docs './**/*.md'"
+          output: "/dev/stdout"
+          fail: true
+          failIfEmpty: false

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -1,0 +1,47 @@
+name: Linter check
+
+env:
+  HUSKY: 0
+
+on:
+  pull_request:
+    branches: ["**"]
+  workflow_dispatch:
+
+jobs:
+  linter:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js 22
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: "yarn"
+
+      - name: Install dependencies
+        run: |
+          corepack enable
+          yarn install
+
+      - name: Check there are no errors to be fixed in package.json and no uncommitted changes
+        run: |
+          npm pkg fix && git diff --exit-code
+
+      - name: Check there are no errors reported by ESLint
+        run: |
+          yarn lint
+
+      - name: Check formatting with Prettier
+        run: |
+          yarn fmt:check
+
+      - name: Spellcheck code base
+        run: |
+          yarn spell
+
+      - name: Check there are no unused dependencies
+        run: |
+          yarn knip

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -26,6 +26,12 @@ jobs:
           corepack enable
           yarn install
 
+      - name: Prepare linter
+        run: |
+          yarn gen:grammar
+          yarn gen:stdlib
+          yarn gen:func-js
+
       - name: Check there are no errors to be fixed in package.json and no uncommitted changes
         run: |
           npm pkg fix && git diff --exit-code

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -28,10 +28,10 @@ jobs:
 
       - name: Prepare linter
         run: |
-          gen:grammar
-          gen:stdlib
-          gen:func-js
-          gen:contracts:test
+          yarn gen:grammar
+          yarn gen:stdlib
+          yarn gen:func-js
+          yarn gen:contracts:test
 
       - name: Check there are no errors to be fixed in package.json and no uncommitted changes
         run: |

--- a/.github/workflows/tact.yml
+++ b/.github/workflows/tact.yml
@@ -107,29 +107,9 @@ jobs:
           yarn gen
           yarn build
 
-      - name: Check there are no errors to be fixed in package.json and no uncommitted changes
-        run: |
-          npm pkg fix && git diff --exit-code
-
       - name: Test Tact compiler
         run: |
           yarn coverage
-
-      - name: Check there are no errors reported by ESLint
-        run: |
-          yarn lint
-
-      - name: Check formatting with Prettier
-        run: |
-          yarn fmt:check
-
-      - name: Spellcheck code base
-        run: |
-          yarn spell
-
-      - name: Check there are no unused dependencies
-        run: |
-          yarn knip
 
       - name: Check broken file references in internal documentation
         if: runner.os == 'Linux'

--- a/.github/workflows/tact.yml
+++ b/.github/workflows/tact.yml
@@ -111,15 +111,6 @@ jobs:
         run: |
           yarn coverage
 
-      - name: Check broken file references in internal documentation
-        if: runner.os == 'Linux'
-        uses: lycheeverse/lychee-action@v2
-        with:
-          args: "-n -s file --exclude-path node_modules --exclude-path docs './**/*.md'"
-          output: "/dev/stdout"
-          fail: true
-          failIfEmpty: false
-
       - name: Show an example .pkg file on Windows
         if: runner.os == 'Windows'
         run: |


### PR DESCRIPTION
<!--
IMPORTANT:
If your PR doesn't close a particular issue, please, create the issue first and describe the whole context: what you're adding/changing and why you're doing so. And only then open the Pull Request, which would close that issue!
-->

Closes #1575.

Made the `tact` assembly split and run all the linters.
This will help to find problems with the code in advance, even before the compiler is built. Also, it is not necessary to run them on all platforms.

Yes, there will be errors now, if this idea is directed to you, I will add running the generator to the CI step for linters.

## Checklist

- [ ] I have updated CHANGELOG.md
- [ ] I have run the linter, formatter and spellchecker
- [ ] I did not do unrelated and/or undiscussed refactorings
