### PR TITLE
forbid via `eslint` to use the `Buffer` class in the code

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -15,6 +15,13 @@ module.exports = {
     es2021: true,
   },
   rules: {
+    "no-restricted-syntax": [
+      "error",
+      {
+        selector: "MemberExpression[object.name='Buffer']",
+        message: "lol",
+      },
+    ],
     "@typescript-eslint/no-unused-vars": [
       "error",
       {


### PR DESCRIPTION
<!--
IMPORTANT:
If your PR doesn't close a particular issue, please, create the issue first and describe the whole context: what you're adding/changing and why you're doing so. And only then open the Pull Request, which would close that issue!

IMPORTANT:
In general, the Tact team does not accept refactorings from external contributors unless those were previously discussed and you've got the green light to change things without adding new functionality or to fix something broken. Language features, bugfixes, doc improvements are more than welcome!
-->

In a comment https://github.com/tact-lang/tact/pull/1565#discussion_r1929544444 @verytactical wrote:
> `Buffer` is Node's non-standard API for binary data, while there is platform-agnostic `Blob`. When we build browser version of `@tact-lang/compiler`, we have to include a polyfill for `Buffer`.
> 
> While there are other places that use `Buffer`, we're working hard to remove them. I'd consider removing `Buffer` support here too.

So my suggestion is to disallow it via an `eslint` rule. This is a concept, if you like it I will add ignore existing errors.

## Checklist

- [ ] I have updated CHANGELOG.md
- [ ] I have run all the tests locally and no test failure was reported
- [ ] I have run the linter, formatter and spellchecker
- [ ] I did not do unrelated and/or undiscussed refactorings
