### PR TITLE
make `msg_bounced` last parameter of `*_contract_router_internal`

### DIFF
--- a/dev-docs/CHANGELOG.md
+++ b/dev-docs/CHANGELOG.md
@@ -36,6 +36,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Allow serialization specifiers for trait fields PR: [#1303](https://github.com/tact-lang/tact/pull/1303)
 - Remove unused typechecker wrapper with the file `check.ts` it is contained in: PR [#1313](https://github.com/tact-lang/tact/pull/1313)
 - Unified `StatementTry` and `StatementTryCatch` AST nodes: PR [#1418](https://github.com/tact-lang/tact/pull/1418)
+- Make `msg_bounced` last parameter of `*_contract_router_internal` for better code generation: PR [#1585](https://github.com/tact-lang/tact/pull/1585)
 
 ### Fixed
 

--- a/src/generator/writers/writeContract.ts
+++ b/src/generator/writers/writeContract.ts
@@ -342,7 +342,7 @@ export function writeMainContract(
             // Process operation
             ctx.append(`;; Handle operation`);
             ctx.append(
-                `int handled = self~${ops.contractRouter(type.name, "internal")}(msg_bounced, in_msg);`,
+                `int handled = self~${ops.contractRouter(type.name, "internal")}(in_msg, msg_bounced);`,
             );
             ctx.append();
 

--- a/src/generator/writers/writeRouter.ts
+++ b/src/generator/writers/writeRouter.ts
@@ -26,7 +26,7 @@ export function writeRouter(
     const internal = kind === "internal";
     if (internal) {
         ctx.append(
-            `(${resolveFuncType(type, ctx)}, int) ${ops.contractRouter(type.name, kind)}(${resolveFuncType(type, ctx)} self, int msg_bounced, slice in_msg) impure inline_ref {`,
+            `(${resolveFuncType(type, ctx)}, int) ${ops.contractRouter(type.name, kind)}(${resolveFuncType(type, ctx)} self, slice in_msg, int msg_bounced) impure inline_ref {`,
         );
     } else {
         ctx.append(

--- a/src/test/benchmarks/benchmarks.spec.ts
+++ b/src/test/benchmarks/benchmarks.spec.ts
@@ -33,11 +33,11 @@ describe("benchmarks", () => {
                     .description as TransactionDescriptionGeneric
             ).computePhase as TransactionComputeVm
         ).gasUsed;
-        expect(gasUsed).toMatchInlineSnapshot(`3018n`);
+        expect(gasUsed).toMatchInlineSnapshot(`3000n`);
 
         // Verify code size
         const codeSize = functions.init!.code.toBoc().length;
-        expect(codeSize).toMatchInlineSnapshot(`233`);
+        expect(codeSize).toMatchInlineSnapshot(`232`);
     });
 
     it("benchmark functions (inline)", async () => {
@@ -57,10 +57,10 @@ describe("benchmarks", () => {
                     .description as TransactionDescriptionGeneric
             ).computePhase as TransactionComputeVm
         ).gasUsed;
-        expect(gasUsed).toMatchInlineSnapshot(`2887n`);
+        expect(gasUsed).toMatchInlineSnapshot(`2869n`);
 
         // Verify code size
         const codeSize = functionsInline.init!.code.toBoc().length;
-        expect(codeSize).toMatchInlineSnapshot(`226`);
+        expect(codeSize).toMatchInlineSnapshot(`225`);
     });
 });


### PR DESCRIPTION
## Issue

Closes #1572.

## Checklist

- [x] I have updated CHANGELOG.md
- [x] I have run all the tests locally and no test failure was reported
- [x] I have run the linter, formatter and spellchecker
- [x] I did not do unrelated and/or undiscussed refactorings
