### PR TITLE
docs: mark gas-expensive functions and expressions

### DIFF
--- a/dev-docs/CHANGELOG.md
+++ b/dev-docs/CHANGELOG.md
@@ -111,6 +111,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Improved Chinese localization of the documentation: PR [#1642](https://github.com/tact-lang/tact/pull/1642)
 - Removed the notion of the non-standard TL-B syntax `remainder<X>`: PR [#1599](https://github.com/tact-lang/tact/pull/1599)
 - Added description of `.boc`, `.ts`, `.abi`, `.pkg` files and completed Compilation page: PR [#1676](https://github.com/tact-lang/tact/pull/1676)
+- Marked gas-expensive functions and expressions: PR [#1703](https://github.com/tact-lang/tact/pull/1703)
 
 ### Release contributors
 

--- a/docs/src/content/docs/book/expressions.mdx
+++ b/docs/src/content/docs/book/expressions.mdx
@@ -3,6 +3,8 @@ title: Expressions
 description: "This page lists all the expressions in Tact"
 ---
 
+import { Badge } from '@astrojs/starlight/components';
+
 Every operator in Tact forms an expression, but there's much more to uncover as Tact offers a wide range of expressive options to choose from.
 
 :::note
@@ -251,6 +253,8 @@ contract ExampleContract {
 ```
 
 ## `initOf`
+
+<Badge text="Gas-expensive" title="Uses 500 gas units or more" variant="danger" size="medium"/><p/>
 
 Expression `initOf{:tact}` computes initial state, i.e. `StateInit{:tact}` of a [contract](/book/contracts):
 

--- a/docs/src/content/docs/book/maps.mdx
+++ b/docs/src/content/docs/book/maps.mdx
@@ -359,6 +359,7 @@ if (fizz == null) {
 
 ### Compare with `.deepEquals()` {#deepequals}
 
+<Badge text="Gas-expensive" title="Uses 500 gas units or more" variant="danger" size="medium"/>
 <Badge text="Available since Tact 1.5" variant="tip" size="medium"/><p/>
 
 ```tact

--- a/docs/src/content/docs/ref/core-advanced.mdx
+++ b/docs/src/content/docs/ref/core-advanced.mdx
@@ -444,6 +444,7 @@ Attempts to queue more than $255$ messages throw an exception with an [exit code
 
 ## nativeSendMessageReturnForwardFee
 
+<Badge text="Gas-expensive" title="Uses 500 gas units or more" variant="danger" size="medium"/>
 <Badge text="Available since Tact 1.5" variant="tip" size="medium"/><p/>
 
 ```tact

--- a/docs/src/content/docs/ref/core-cells.mdx
+++ b/docs/src/content/docs/ref/core-cells.mdx
@@ -35,6 +35,8 @@ let fizz: Builder = beginCell();
 
 ## emptyCell
 
+<Badge text="Gas-expensive" title="Uses 500 gas units or more" variant="danger" size="medium"/><p/>
+
 ```tact
 fun emptyCell(): Cell;
 ```
@@ -51,6 +53,8 @@ fizz == buzz; // true
 ```
 
 ## emptySlice
+
+<Badge text="Gas-expensive" title="Uses 500 gas units or more" variant="danger" size="medium"/><p/>
 
 ```tact
 fun emptySlice(): Slice;
@@ -127,6 +131,8 @@ let fizz: Slice = c.asSlice();
 A section to group all extension and extension mutation functions for the [`Builder{:tact}`][builder] type.
 
 ### Builder.endCell
+
+<Badge text="Gas-expensive" title="Uses 500 gas units or more" variant="danger" size="medium"/><p/>
 
 ```tact
 extends fun endCell(self: Builder): Cell;
@@ -1035,6 +1041,8 @@ try {
 
 ### Slice.hash
 
+<Badge text="Gas-expensive" title="Uses 500 gas units or more" variant="danger" size="medium"/><p/>
+
 ```tact
 extends fun hash(self: Slice): Int;
 ```
@@ -1051,6 +1059,8 @@ let fizz: Int = s.hash();
 ```
 
 ### Slice.asCell
+
+<Badge text="Gas-expensive" title="Uses 500 gas units or more" variant="danger" size="medium"/><p/>
 
 ```tact
 extends fun asCell(self: Slice): Cell;

--- a/docs/src/content/docs/ref/core-common.mdx
+++ b/docs/src/content/docs/ref/core-common.mdx
@@ -3,6 +3,8 @@ title: Common
 description: "Commonly used global static functions from the Core library of Tact"
 ---
 
+import { Badge } from '@astrojs/starlight/components';
+
 List of the most commonly used built-in [global static functions](/book/functions#global-static-functions).
 
 ## Contextual
@@ -117,6 +119,8 @@ require(ctx.value != 68 + 1, "Invalid amount of nanoToncoins, bye!");
 
 ### newAddress
 
+<Badge text="Gas-expensive" title="Uses 500 gas units or more" variant="danger" size="medium"/><p/>
+
 ```tact
 fun newAddress(chain: Int, hash: Int): Address;
 ```
@@ -152,6 +156,8 @@ let oldTonFoundationAddr: Address =
 
 ### contractAddress
 
+<Badge text="Gas-expensive" title="Uses 500 gas units or more" variant="danger" size="medium"/><p/>
+
 ```tact
 fun contractAddress(s: StateInit): Address;
 ```
@@ -165,6 +171,8 @@ let foundMeSome: Address = contractAddress(initOf SomeContract());
 ```
 
 ### contractAddressExt
+
+<Badge text="Gas-expensive" title="Uses 500 gas units or more" variant="danger" size="medium"/><p/>
 
 ```tact
 fun contractAddressExt(chain: Int, code: Cell, data: Cell): Address;
@@ -196,6 +204,8 @@ let hereBeDragons: Address = contractAddressExt(0, initPkg.code, initPkg.data);
 
 ### send
 
+<Badge text="Gas-expensive" title="Uses 500 gas units or more" variant="danger" size="medium"/><p/>
+
 ```tact
 fun send(params: SendParameters);
 ```
@@ -223,6 +233,8 @@ send(SendParameters{
 :::
 
 ### emit
+
+<Badge text="Gas-expensive" title="Uses 500 gas units or more" variant="danger" size="medium"/><p/>
 
 ```tact
 fun emit(body: Cell);

--- a/docs/src/content/docs/ref/core-debug.mdx
+++ b/docs/src/content/docs/ref/core-debug.mdx
@@ -3,6 +3,8 @@ title: Debug
 description: "Various debugging functions from the Core library of Tact"
 ---
 
+import { Badge } from '@astrojs/starlight/components';
+
 List of functions commonly used for debugging smart contracts in Tact.
 
 Read more about debugging on the dedicated page: [Debugging](/book/debug).
@@ -39,6 +41,8 @@ try {
 ```
 
 ## dump
+
+<Badge text="Gas-expensive" title="Uses 500 gas units or more" variant="danger" size="medium"/><p/>
 
 ```tact
 fun dump(arg);
@@ -101,6 +105,8 @@ dump(emit("msg".asComment())); // As emit() function doesn't return a value, dum
 :::
 
 ## dumpStack
+
+<Badge text="Gas-expensive" title="Uses 500 gas units or more" variant="danger" size="medium"/><p/>
 
 ```tact
 fun dumpStack();

--- a/docs/src/content/docs/ref/core-math.mdx
+++ b/docs/src/content/docs/ref/core-math.mdx
@@ -3,6 +3,8 @@ title: Math
 description: "Various math helper functions from the Core library of Tact"
 ---
 
+import { Badge } from '@astrojs/starlight/components';
+
 Various math helper functions.
 
 ## min
@@ -191,6 +193,8 @@ contract Example {
 
 ## checkSignature
 
+<Badge text="Gas-expensive" title="Uses 500 gas units or more" variant="danger" size="medium"/><p/>
+
 ```tact
 fun checkSignature(hash: Int, signature: Slice, public_key: Int): Bool;
 ```
@@ -231,6 +235,8 @@ contract Showcase {
 ```
 
 ## checkDataSignature
+
+<Badge text="Gas-expensive" title="Uses 500 gas units or more" variant="danger" size="medium"/><p/>
 
 ```tact
 fun checkDataSignature(data: Slice, signature: Slice, public_key: Int): Bool;

--- a/docs/src/content/docs/ref/core-strings.mdx
+++ b/docs/src/content/docs/ref/core-strings.mdx
@@ -3,6 +3,8 @@ title: Strings and StringBuilders
 description: "Various String and StringBuilder functions from the Core library of Tact"
 ---
 
+import { Badge } from '@astrojs/starlight/components';
+
 Strings are immutable sequences of characters, which means that once a [`String{:tact}`][p] is created, it cannot be changed. Strings are useful to store text, and so they can be converted to [`Cell{:tact}`][cell] type to be used as message bodies.
 
 To be able to concatenate strings in a gas-efficient way, use a [`StringBuilder{:tact}`][p].
@@ -105,6 +107,8 @@ let fizz: StringBuilder = beginString()
 
 ## StringBuilder.toString
 
+<Badge text="Gas-expensive" title="Uses 500 gas units or more" variant="danger" size="medium"/><p/>
+
 ```tact
 extends fun toString(self: StringBuilder): String;
 ```
@@ -122,6 +126,8 @@ let buzz: String = fizz.toString();
 
 ## StringBuilder.toCell
 
+<Badge text="Gas-expensive" title="Uses 500 gas units or more" variant="danger" size="medium"/><p/>
+
 ```tact
 extends fun toCell(self: StringBuilder): Cell;
 ```
@@ -138,6 +144,8 @@ let buzz: Cell = fizz.toCell();
 ```
 
 ## StringBuilder.toSlice
+
+<Badge text="Gas-expensive" title="Uses 500 gas units or more" variant="danger" size="medium"/><p/>
 
 ```tact
 extends fun toSlice(self: StringBuilder): Slice;
@@ -186,6 +194,8 @@ fizz == buzz; // true, but be careful as it's not always the case
 :::
 
 ## String.asComment
+
+<Badge text="Gas-expensive" title="Uses 500 gas units or more" variant="danger" size="medium"/><p/>
 
 ```tact
 extends fun asComment(self: String): Cell;
@@ -277,6 +287,8 @@ let fizz: Slice = s.fromBase64();
 
 ## Int.toString
 
+<Badge text="Gas-expensive" title="Uses 500 gas units or more" variant="danger" size="medium"/><p/>
+
 ```tact
 extends fun toString(self: Int): String;
 ```
@@ -292,6 +304,8 @@ let fizz: String = (84 - 42).toString();
 ```
 
 ## Int.toFloatString
+
+<Badge text="Gas-expensive" title="Uses 500 gas units or more" variant="danger" size="medium"/><p/>
 
 ```tact
 extends fun toFloatString(self: Int, digits: Int): String;
@@ -310,6 +324,8 @@ let fizz: String = (42).toFloatString(9); // "0.000000042"
 ```
 
 ## Int.toCoinsString
+
+<Badge text="Gas-expensive" title="Uses 500 gas units or more" variant="danger" size="medium"/><p/>
 
 ```tact
 extends fun toCoinsString(self: Int): String;
@@ -332,6 +348,8 @@ fizz == buzz; // true, both store "0.000000042"
 ```
 
 ## Address.toString
+
+<Badge text="Gas-expensive" title="Uses 500 gas units or more" variant="danger" size="medium"/><p/>
 
 ```tact
 extends fun toString(self: Address): String;


### PR DESCRIPTION
The "gas-expensive" threshold is 500 gas units — to display this bit of info I've added the [`title`](https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/title) attribute, which shows the tooltip when hovering over the badge.

Also marked the `emptyCell()` and `emptySlice()` a bit different, since they'll become less expensive soon: #1696

If necessary, we can also add such remarks to the code comments for the affected functions & `initOf`, but I don't know yet if that's a good idea.

<!--
IMPORTANT:
If your PR doesn't close a particular issue, please, create the issue first and describe the whole context: what you're adding/changing and why you're doing so. And only then open the Pull Request, which would close that issue!
-->

## Issue

Closes #1246.

## Checklist

- [x] I have updated CHANGELOG.md
- [x] I have run the linter, formatter and spellchecker
- [x] I did not do unrelated and/or undiscussed refactorings
