### PR TITLE
fix(test): allow generate deep (really huge) Ast Expressions with custom weighted AST childrens in nodes

### DIFF
--- a/src/ast/fuzz.spec.ts
+++ b/src/ast/fuzz.spec.ts
@@ -5,7 +5,7 @@ import { diffAstObjects, randomAstExpression } from "./random.infra";
 import { prettyPrint } from "./ast-printer";
 
 describe("Pretty Print Expressions", () => {
-    const maxDepth = 4;
+    const maxDepth: fc.DepthSize = "+1"; // Small (default value) +1
     const parser = getParser(getAstFactory(), "new");
 
     it(`should parse AstExpression`, () => {
@@ -28,7 +28,7 @@ describe("Pretty Print Expressions", () => {
                 }
                 expect(actual).toBe(true);
             }),
-            { seed: 1, numRuns: 5000 },
+            { seed: 1, numRuns: 1000, ignoreEqualValues: true },
         );
     });
 });

--- a/src/ast/random-ast.ts
+++ b/src/ast/random-ast.ts
@@ -15,7 +15,7 @@ if (isNaN(count) || count <= 0) {
     process.exit(1);
 }
 
-fc.sample(randomAstExpression(4), count).forEach((expression, index) => {
+fc.sample(randomAstExpression("+1"), count).forEach((expression, index) => {
     console.log(`Expression ${index + 1}:`);
     console.log(prettyPrint(expression));
     console.log("-".repeat(80));


### PR DESCRIPTION
AST expressions will be generated with deeper AST trees, however this has a direct impact on performance, which is the reason I reduced the `numRun` value in test.

Some fixes:
- duplicate AST are no longer generated
- added a small chance of generating huge numbers (**256), but still prioritize readable numbers (this gave a small performance boost 🚀 )
- Reworked depth and implemented `fc.letrec` instead `fc.memo`. Changed depth [size](https://fast-check.dev/docs/configuration/larger-entries-by-default/#depth-size-explained) of AST expression by default to +1 (which be 3 - between small and medium). It's optimal to run in CI right now
- Fixed a major glitch with entering infinity recursion 
- Every AST expression child now have some weight. We can provide custom weights to change fuzzer rules.

But we sacrificed typification in some places...

## Issue

Closes #1662 

## Checklist

- [ ] I have updated CHANGELOG.md
- [x] I have run all the tests locally and no test failure was reported
- [x] I have run the linter, formatter and spellchecker
- [x] I did not do unrelated and/or undiscussed refactorings
