### PR TITLE
fix: check map types for `deepEquals` method

### DIFF
--- a/dev-docs/CHANGELOG.md
+++ b/dev-docs/CHANGELOG.md
@@ -116,6 +116,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Removed the notion of the non-standard TL-B syntax `remainder<X>`: PR [#1599](https://github.com/tact-lang/tact/pull/1599)
 - Added description of `.boc`, `.ts`, `.abi`, `.pkg` files and completed Compilation page: PR [#1676](https://github.com/tact-lang/tact/pull/1676)
 - Marked gas-expensive functions and expressions: PR [#1703](https://github.com/tact-lang/tact/pull/1703)
+- Check map types for `deepEquals` method: PR [#1718](https://github.com/tact-lang/tact/pull/1718)
 
 ### Release contributors
 

--- a/src/abi/map.ts
+++ b/src/abi/map.ts
@@ -495,7 +495,7 @@ export const MapFunctions: ReadonlyMap<string, AbiFunction> = new Map([
 
                 if (!isAssignable(self, other)) {
                     throwCompilationError(
-                        `Type mismatch: "${printTypeRef(self)}" is not assignable to "${printTypeRef(other)}"`,
+                        `Type mismatch: cannot pass argument of type "${printTypeRef(other)}" to parameter of type "${printTypeRef(self)}"`,
                         ref,
                     );
                 }

--- a/src/abi/map.ts
+++ b/src/abi/map.ts
@@ -1,6 +1,6 @@
 import { CompilerContext } from "../context/context";
 import { SrcInfo } from "../grammar";
-import { TypeRef } from "../types/types";
+import { printTypeRef, TypeRef } from "../types/types";
 import { WriterContext } from "../generator/Writer";
 import { ops } from "../generator/writers/ops";
 import { writeExpression } from "../generator/writers/writeExpression";
@@ -8,6 +8,7 @@ import { throwCompilationError } from "../error/errors";
 import { getType } from "../types/resolveDescriptors";
 import { AbiFunction } from "./AbiFunction";
 import { AstExpression } from "../ast/ast";
+import { isAssignable } from "../types/subtyping";
 
 // Helper functions to avoid redundancy
 function checkArgumentsLength(
@@ -491,6 +492,13 @@ export const MapFunctions: ReadonlyMap<string, AbiFunction> = new Map([
                 const [self, other] = args;
                 checkMapType(self, ref);
                 checkMapType(other, ref);
+
+                if (!isAssignable(self, other)) {
+                    throwCompilationError(
+                        `Type mismatch: "${printTypeRef(self)}" is not assignable to "${printTypeRef(other)}"`,
+                        ref,
+                    );
+                }
 
                 return { kind: "ref", name: "Bool", optional: false };
             },

--- a/src/types/__snapshots__/resolveStatements.spec.ts.snap
+++ b/src/types/__snapshots__/resolveStatements.spec.ts.snap
@@ -783,6 +783,24 @@ exports[`resolveStatements should fail statements for init-vars-analysis-with-if
 "
 `;
 
+exports[`resolveStatements should fail statements for map-deepEquals-type-mismatch 1`] = `
+"<unknown>:12:16: Type mismatch: "map<Int, Int>" is not assignable to "map<Address, Int>"
+  11 |         let m2: map<Address, Int> = emptyMap();
+> 12 |         return m1.deepEquals(m2);
+                      ^~~~~~~~~~~~~~~~~
+  13 |     }
+"
+`;
+
+exports[`resolveStatements should fail statements for map-deepEquals-type-mismatch-2 1`] = `
+"<unknown>:12:16: Type mismatch: "map<Address, Int>" is not assignable to "map<Int, Address>"
+  11 |         let m2: map<Int, Address> = emptyMap();
+> 12 |         return m1.deepEquals(m2);
+                      ^~~~~~~~~~~~~~~~~
+  13 |     }
+"
+`;
+
 exports[`resolveStatements should fail statements for return-analysis-catch-if 1`] = `
 "<unknown>:4:1: Function does not always return a result. Adding 'return' statement(s) should fix the issue.
   3 | 

--- a/src/types/__snapshots__/resolveStatements.spec.ts.snap
+++ b/src/types/__snapshots__/resolveStatements.spec.ts.snap
@@ -784,7 +784,7 @@ exports[`resolveStatements should fail statements for init-vars-analysis-with-if
 `;
 
 exports[`resolveStatements should fail statements for map-deepEquals-type-mismatch 1`] = `
-"<unknown>:12:16: Type mismatch: "map<Int, Int>" is not assignable to "map<Address, Int>"
+"<unknown>:12:16: Type mismatch: cannot pass argument of type "map<Address, Int>" to parameter of type "map<Int, Int>"
   11 |         let m2: map<Address, Int> = emptyMap();
 > 12 |         return m1.deepEquals(m2);
                       ^~~~~~~~~~~~~~~~~
@@ -793,7 +793,7 @@ exports[`resolveStatements should fail statements for map-deepEquals-type-mismat
 `;
 
 exports[`resolveStatements should fail statements for map-deepEquals-type-mismatch-2 1`] = `
-"<unknown>:12:16: Type mismatch: "map<Address, Int>" is not assignable to "map<Int, Address>"
+"<unknown>:12:16: Type mismatch: cannot pass argument of type "map<Int, Address>" to parameter of type "map<Address, Int>"
   11 |         let m2: map<Int, Address> = emptyMap();
 > 12 |         return m1.deepEquals(m2);
                       ^~~~~~~~~~~~~~~~~

--- a/src/types/__snapshots__/resolveStatements.spec.ts.snap
+++ b/src/types/__snapshots__/resolveStatements.spec.ts.snap
@@ -793,7 +793,16 @@ exports[`resolveStatements should fail statements for map-deepEquals-type-mismat
 `;
 
 exports[`resolveStatements should fail statements for map-deepEquals-type-mismatch-2 1`] = `
-"<unknown>:12:16: Type mismatch: cannot pass argument of type "map<Int, Address>" to parameter of type "map<Address, Int>"
+"<unknown>:12:16: Type mismatch: cannot pass argument of type "map<Address, Address>" to parameter of type "map<Address, Int>"
+  11 |         let m2: map<Address, Address> = emptyMap();
+> 12 |         return m1.deepEquals(m2);
+                      ^~~~~~~~~~~~~~~~~
+  13 |     }
+"
+`;
+
+exports[`resolveStatements should fail statements for map-deepEquals-type-mismatch-3 1`] = `
+"<unknown>:12:16: Type mismatch: cannot pass argument of type "map<Int, Address>" to parameter of type "map<Int, Bool>"
   11 |         let m2: map<Int, Address> = emptyMap();
 > 12 |         return m1.deepEquals(m2);
                       ^~~~~~~~~~~~~~~~~

--- a/src/types/__snapshots__/resolveStatements.spec.ts.snap
+++ b/src/types/__snapshots__/resolveStatements.spec.ts.snap
@@ -810,6 +810,24 @@ exports[`resolveStatements should fail statements for map-deepEquals-type-mismat
 "
 `;
 
+exports[`resolveStatements should fail statements for map-deepEquals-type-mismatch-4 1`] = `
+"<unknown>:12:16: Type mismatch: cannot pass argument of type "map<Int as uint16, Bool>" to parameter of type "map<Int as uint8, Bool>"
+  11 |         let m2: map<Int as uint16, Bool> = emptyMap();
+> 12 |         return m1.deepEquals(m2);
+                      ^~~~~~~~~~~~~~~~~
+  13 |     }
+"
+`;
+
+exports[`resolveStatements should fail statements for map-deepEquals-type-mismatch-5 1`] = `
+"<unknown>:12:16: Type mismatch: cannot pass argument of type "map<Int, Int>" to parameter of type "map<Int, Int as uint16>"
+  11 |         let m2: map<Int, Int> = emptyMap();
+> 12 |         return m1.deepEquals(m2);
+                      ^~~~~~~~~~~~~~~~~
+  13 |     }
+"
+`;
+
 exports[`resolveStatements should fail statements for return-analysis-catch-if 1`] = `
 "<unknown>:4:1: Function does not always return a result. Adding 'return' statement(s) should fix the issue.
   3 | 

--- a/src/types/stmts-failed/map-deepEquals-type-mismatch-2.tact
+++ b/src/types/stmts-failed/map-deepEquals-type-mismatch-2.tact
@@ -1,0 +1,14 @@
+primitive Bool;
+primitive Int;
+primitive Address;
+
+trait BaseTrait {}
+
+contract Test {
+    get fun foo(): Bool {
+        let m1: map<Address, Int> = emptyMap();
+        m1.set(address(""), 0);
+        let m2: map<Int, Address> = emptyMap();
+        return m1.deepEquals(m2);
+    }
+}

--- a/src/types/stmts-failed/map-deepEquals-type-mismatch-3.tact
+++ b/src/types/stmts-failed/map-deepEquals-type-mismatch-3.tact
@@ -6,9 +6,9 @@ trait BaseTrait {}
 
 contract Test {
     get fun foo(): Bool {
-        let m1: map<Address, Int> = emptyMap();
-        m1.set(address(""), 0);
-        let m2: map<Address, Address> = emptyMap();
+        let m1: map<Int, Bool> = emptyMap();
+        m1.set(0, false);
+        let m2: map<Int, Address> = emptyMap();
         return m1.deepEquals(m2);
     }
 }

--- a/src/types/stmts-failed/map-deepEquals-type-mismatch-4.tact
+++ b/src/types/stmts-failed/map-deepEquals-type-mismatch-4.tact
@@ -1,0 +1,14 @@
+primitive Bool;
+primitive Int;
+primitive Address;
+
+trait BaseTrait {}
+
+contract Test {
+    get fun foo(): Bool {
+        let m1: map<Int as uint8, Bool> = emptyMap();
+        m1.set(0, false);
+        let m2: map<Int as uint16, Bool> = emptyMap();
+        return m1.deepEquals(m2);
+    }
+}

--- a/src/types/stmts-failed/map-deepEquals-type-mismatch-5.tact
+++ b/src/types/stmts-failed/map-deepEquals-type-mismatch-5.tact
@@ -1,0 +1,14 @@
+primitive Bool;
+primitive Int;
+primitive Address;
+
+trait BaseTrait {}
+
+contract Test {
+    get fun foo(): Bool {
+        let m1: map<Int, Int as uint16> = emptyMap();
+        m1.set(0, 10);
+        let m2: map<Int, Int> = emptyMap();
+        return m1.deepEquals(m2);
+    }
+}

--- a/src/types/stmts-failed/map-deepEquals-type-mismatch.tact
+++ b/src/types/stmts-failed/map-deepEquals-type-mismatch.tact
@@ -1,0 +1,14 @@
+primitive Bool;
+primitive Int;
+primitive Address;
+
+trait BaseTrait {}
+
+contract Test {
+    get fun foo(): Bool {
+        let m1: map<Int, Int> = emptyMap();
+        m1.set(42, 0);
+        let m2: map<Address, Int> = emptyMap();
+        return m1.deepEquals(m2);
+    }
+}


### PR DESCRIPTION
## Issue

Closes #1261.

## Checklist

- [x] I have updated CHANGELOG.md
- [x] I have added tests to demonstrate the contribution is correctly implemented: this usually includes both positive and negative tests, showing the happy path(s) and featuring intentionally broken cases
- [x] I have run all the tests locally and no test failure was reported
- [x] I have run the linter, formatter and spellchecker
- [x] I did not do unrelated and/or undiscussed refactorings
