### PR TITLE
tests: parseStdAddress and newAddress are inverses of each other

### DIFF
--- a/src/test/e2e-emulated/contracts/semantics.tact
+++ b/src/test/e2e-emulated/contracts/semantics.tact
@@ -1934,6 +1934,28 @@ contract SemanticsTester {
         return result;
     }
 
+    get fun testInversesParseStdAddressAndNewAddress(): Bool {
+        let addr = myAddress();
+
+        // Using parseStdAddress followed by newAddress produce the same results
+        let parsedAddr: StdAddress = parseStdAddress(addr.asSlice());
+        let addr2: Address = newAddress(parsedAddr.workchain, parsedAddr.address);
+
+        let result = addr == addr2;
+
+        // Using newAddress followed by parseStdAddress produce the same results
+
+        // The two components of our address
+        let chainId = 0;
+        let accountId = (initOf SemanticsTester()).toCell().hash();
+
+        let addr3: Address = newAddress(chainId, accountId);
+        let parsedAddr2: StdAddress = parseStdAddress(addr3.asSlice());
+
+        result &&= chainId == parsedAddr2.workchain && accountId == parsedAddr2.address;
+
+        return result;
+    }
 
     /*************** Slices ********************/
 

--- a/src/test/e2e-emulated/semantics.spec.ts
+++ b/src/test/e2e-emulated/semantics.spec.ts
@@ -116,6 +116,9 @@ describe("semantics", () => {
 
         // Testing equality on addresses
         expect(await contract.getTestAddressEquality()).toEqual(true);
+        expect(
+            await contract.getTestInversesParseStdAddressAndNewAddress(),
+        ).toEqual(true);
 
         // Testing equality on slices
         expect(await contract.getTestSliceEquality1()).toEqual(true);


### PR DESCRIPTION
<!--
IMPORTANT:
If your PR doesn't close a particular issue, please, create the issue first and describe the whole context: what you're adding/changing and why you're doing so. And only then open the Pull Request, which would close that issue!
-->

## Issue

Closes #1727.

## Checklist

- [ ] I have updated CHANGELOG.md
- [X] I have run all the tests locally and no test failure was reported
- [X] I have run the linter, formatter and spellchecker
- [X] I did not do unrelated and/or undiscussed refactorings
