### PR TITLE
refactor(ast): convert union types to const arrays

### DIFF
--- a/knip.json
+++ b/knip.json
@@ -4,6 +4,7 @@
   "project": ["src/**/*.ts"],
   "ignore": [
     "src/ast/ast.ts",
+    "src/ast/ast-constants.ts",
     "src/config/parseConfig.ts",
     "src/ast/ast-printer.ts",
     "src/error/display-to-json.ts",

--- a/src/ast/ast-constants.ts
+++ b/src/ast/ast-constants.ts
@@ -1,20 +1,17 @@
 import { keys } from "../utils/tricks";
+import {
+    AstAugmentedAssignOperation,
+    AstBinaryOperation,
+    AstFunctionAttributeName,
+    AstNumberBase,
+    AstUnaryOperation,
+    ImportType,
+} from "./ast";
 
-type AugmentedAssignOperator =
-    | "+"
-    | "-"
-    | "*"
-    | "/"
-    | "&&"
-    | "||"
-    | "%"
-    | "|"
-    | "<<"
-    | ">>"
-    | "&"
-    | "^";
-
-const augmentedAssignOperationsRecord: Record<AugmentedAssignOperator, true> = {
+const augmentedAssignOperationsRecord: Record<
+    AstAugmentedAssignOperation,
+    true
+> = {
     "+": true,
     "-": true,
     "*": true,
@@ -33,27 +30,7 @@ export const astAugmentedAssignOperations = Object.freeze(
     keys(augmentedAssignOperationsRecord),
 );
 
-type BinaryOperator =
-    | "+"
-    | "-"
-    | "*"
-    | "/"
-    | "!="
-    | ">"
-    | "<"
-    | ">="
-    | "<="
-    | "=="
-    | "&&"
-    | "||"
-    | "%"
-    | "<<"
-    | ">>"
-    | "&"
-    | "|"
-    | "^";
-
-const binaryOperationsRecord: Record<BinaryOperator, true> = {
+const binaryOperationsRecord: Record<AstBinaryOperation, true> = {
     "+": true,
     "-": true,
     "*": true,
@@ -76,9 +53,7 @@ const binaryOperationsRecord: Record<BinaryOperator, true> = {
 
 export const astBinaryOperations = Object.freeze(keys(binaryOperationsRecord));
 
-type UnaryOperator = "+" | "-" | "!" | "!!" | "~";
-
-const unaryOperationsRecord: Record<UnaryOperator, true> = {
+const unaryOperationsRecord: Record<AstUnaryOperation, true> = {
     "+": true,
     "-": true,
     "!": true,
@@ -88,9 +63,7 @@ const unaryOperationsRecord: Record<UnaryOperator, true> = {
 
 export const astUnaryOperations = Object.freeze(keys(unaryOperationsRecord));
 
-type NumberBase = 2 | 8 | 10 | 16;
-
-const numberBasesRecord: Record<NumberBase, true> = {
+const numberBasesRecord: Record<AstNumberBase, true> = {
     2: true,
     8: true,
     10: true,
@@ -99,11 +72,7 @@ const numberBasesRecord: Record<NumberBase, true> = {
 
 export const astNumberBases = Object.freeze(
     keys(numberBasesRecord).map(Number),
-) as readonly number[];
-
-// This is different from ItemOrigin, because relative import
-// from standard library is still import with origin: "stdlib"
-type ImportType = "stdlib" | "relative";
+);
 
 const importTypesRecord: Record<ImportType, true> = {
     stdlib: true,
@@ -124,15 +93,7 @@ export const astConstantAttributeNames = Object.freeze(
     keys(constantAttributeNamesRecord),
 );
 
-type FunctionAttributeName =
-    | "mutates"
-    | "extends"
-    | "virtual"
-    | "abstract"
-    | "override"
-    | "inline";
-
-const functionAttributeNamesRecord: Record<FunctionAttributeName, true> = {
+const functionAttributeNamesRecord: Record<AstFunctionAttributeName, true> = {
     mutates: true,
     extends: true,
     virtual: true,

--- a/src/ast/ast-constants.ts
+++ b/src/ast/ast-constants.ts
@@ -1,0 +1,98 @@
+const augmentedAssignOperationsRecord = {
+    "+": true,
+    "-": true,
+    "*": true,
+    "/": true,
+    "&&": true,
+    "||": true,
+    "%": true,
+    "|": true,
+    "<<": true,
+    ">>": true,
+    "&": true,
+    "^": true,
+};
+
+export const astAugmentedAssignOperations = Object.freeze(
+    Object.keys(augmentedAssignOperationsRecord),
+);
+
+const binaryOperationsRecord = {
+    "+": true,
+    "-": true,
+    "*": true,
+    "/": true,
+    "!=": true,
+    ">": true,
+    "<": true,
+    ">=": true,
+    "<=": true,
+    "==": true,
+    "&&": true,
+    "||": true,
+    "%": true,
+    "<<": true,
+    ">>": true,
+    "&": true,
+    "|": true,
+    "^": true,
+};
+
+export const astBinaryOperations = Object.freeze(
+    Object.keys(binaryOperationsRecord),
+);
+
+const unaryOperationsRecord = {
+    "+": true,
+    "-": true,
+    "!": true,
+    "!!": true,
+    "~": true,
+};
+
+export const astUnaryOperations = Object.freeze(
+    Object.keys(unaryOperationsRecord),
+);
+
+const numberBasesRecord = {
+    2: true,
+    8: true,
+    10: true,
+    16: true,
+};
+
+export const astNumberBases = Object.freeze(
+    Object.keys(numberBasesRecord).map(Number),
+) as readonly number[];
+
+// This is different from ItemOrigin, because relative import
+// from standard library is still import with origin: "stdlib"
+const importTypesRecord = {
+    stdlib: true,
+    relative: true,
+};
+
+export const importTypes = Object.freeze(Object.keys(importTypesRecord));
+
+const constantAttributeNamesRecord = {
+    virtual: true,
+    override: true,
+    abstract: true,
+};
+
+export const astConstantAttributeNames = Object.freeze(
+    Object.keys(constantAttributeNamesRecord),
+);
+
+const functionAttributeNamesRecord = {
+    mutates: true,
+    extends: true,
+    virtual: true,
+    abstract: true,
+    override: true,
+    inline: true,
+};
+
+export const astFunctionAttributeNames = Object.freeze(
+    Object.keys(functionAttributeNamesRecord),
+);

--- a/src/ast/ast-constants.ts
+++ b/src/ast/ast-constants.ts
@@ -1,4 +1,20 @@
-const augmentedAssignOperationsRecord = {
+import { keys } from "../utils/tricks";
+
+type AugmentedAssignOperator =
+    | "+"
+    | "-"
+    | "*"
+    | "/"
+    | "&&"
+    | "||"
+    | "%"
+    | "|"
+    | "<<"
+    | ">>"
+    | "&"
+    | "^";
+
+const augmentedAssignOperationsRecord: Record<AugmentedAssignOperator, true> = {
     "+": true,
     "-": true,
     "*": true,
@@ -14,10 +30,30 @@ const augmentedAssignOperationsRecord = {
 };
 
 export const astAugmentedAssignOperations = Object.freeze(
-    Object.keys(augmentedAssignOperationsRecord),
+    keys(augmentedAssignOperationsRecord),
 );
 
-const binaryOperationsRecord = {
+type BinaryOperator =
+    | "+"
+    | "-"
+    | "*"
+    | "/"
+    | "!="
+    | ">"
+    | "<"
+    | ">="
+    | "<="
+    | "=="
+    | "&&"
+    | "||"
+    | "%"
+    | "<<"
+    | ">>"
+    | "&"
+    | "|"
+    | "^";
+
+const binaryOperationsRecord: Record<BinaryOperator, true> = {
     "+": true,
     "-": true,
     "*": true,
@@ -38,11 +74,11 @@ const binaryOperationsRecord = {
     "^": true,
 };
 
-export const astBinaryOperations = Object.freeze(
-    Object.keys(binaryOperationsRecord),
-);
+export const astBinaryOperations = Object.freeze(keys(binaryOperationsRecord));
 
-const unaryOperationsRecord = {
+type UnaryOperator = "+" | "-" | "!" | "!!" | "~";
+
+const unaryOperationsRecord: Record<UnaryOperator, true> = {
     "+": true,
     "-": true,
     "!": true,
@@ -50,11 +86,11 @@ const unaryOperationsRecord = {
     "~": true,
 };
 
-export const astUnaryOperations = Object.freeze(
-    Object.keys(unaryOperationsRecord),
-);
+export const astUnaryOperations = Object.freeze(keys(unaryOperationsRecord));
 
-const numberBasesRecord = {
+type NumberBase = 2 | 8 | 10 | 16;
+
+const numberBasesRecord: Record<NumberBase, true> = {
     2: true,
     8: true,
     10: true,
@@ -62,29 +98,41 @@ const numberBasesRecord = {
 };
 
 export const astNumberBases = Object.freeze(
-    Object.keys(numberBasesRecord).map(Number),
+    keys(numberBasesRecord).map(Number),
 ) as readonly number[];
 
 // This is different from ItemOrigin, because relative import
 // from standard library is still import with origin: "stdlib"
-const importTypesRecord = {
+type ImportType = "stdlib" | "relative";
+
+const importTypesRecord: Record<ImportType, true> = {
     stdlib: true,
     relative: true,
 };
 
-export const importTypes = Object.freeze(Object.keys(importTypesRecord));
+export const importTypes = Object.freeze(keys(importTypesRecord));
 
-const constantAttributeNamesRecord = {
+type ConstantAttributeName = "virtual" | "override" | "abstract";
+
+const constantAttributeNamesRecord: Record<ConstantAttributeName, true> = {
     virtual: true,
     override: true,
     abstract: true,
 };
 
 export const astConstantAttributeNames = Object.freeze(
-    Object.keys(constantAttributeNamesRecord),
+    keys(constantAttributeNamesRecord),
 );
 
-const functionAttributeNamesRecord = {
+type FunctionAttributeName =
+    | "mutates"
+    | "extends"
+    | "virtual"
+    | "abstract"
+    | "override"
+    | "inline";
+
+const functionAttributeNamesRecord: Record<FunctionAttributeName, true> = {
     mutates: true,
     extends: true,
     virtual: true,
@@ -94,5 +142,5 @@ const functionAttributeNamesRecord = {
 };
 
 export const astFunctionAttributeNames = Object.freeze(
-    Object.keys(functionAttributeNamesRecord),
+    keys(functionAttributeNamesRecord),
 );

--- a/src/ast/ast.ts
+++ b/src/ast/ast.ts
@@ -241,19 +241,23 @@ export type AstStatementAssign = {
     readonly loc: SrcInfo;
 };
 
+export const astAugmentedAssignOperations = [
+    "+",
+    "-",
+    "*",
+    "/",
+    "&&",
+    "||",
+    "%",
+    "|",
+    "<<",
+    ">>",
+    "&",
+    "^",
+] as const;
+
 export type AstAugmentedAssignOperation =
-    | "+"
-    | "-"
-    | "*"
-    | "/"
-    | "&&"
-    | "||"
-    | "%"
-    | "|"
-    | "<<"
-    | ">>"
-    | "&"
-    | "^";
+    (typeof astAugmentedAssignOperations)[number];
 
 export type AstStatementAugmentedAssign = {
     readonly kind: "statement_augmentedassign";
@@ -407,25 +411,28 @@ export type AstLiteral =
     | AstSlice
     | AstStructValue;
 
-export type AstBinaryOperation =
-    | "+"
-    | "-"
-    | "*"
-    | "/"
-    | "!="
-    | ">"
-    | "<"
-    | ">="
-    | "<="
-    | "=="
-    | "&&"
-    | "||"
-    | "%"
-    | "<<"
-    | ">>"
-    | "&"
-    | "|"
-    | "^";
+export const astBinaryOperations = [
+    "+",
+    "-",
+    "*",
+    "/",
+    "!=",
+    ">",
+    "<",
+    ">=",
+    "<=",
+    "==",
+    "&&",
+    "||",
+    "%",
+    "<<",
+    ">>",
+    "&",
+    "|",
+    "^",
+] as const;
+
+export type AstBinaryOperation = (typeof astBinaryOperations)[number];
 
 export type AstOpBinary = {
     readonly kind: "op_binary";
@@ -436,7 +443,9 @@ export type AstOpBinary = {
     readonly loc: SrcInfo;
 };
 
-export type AstUnaryOperation = "+" | "-" | "!" | "!!" | "~";
+export const astUnaryOperations = ["+", "-", "!", "!!", "~"] as const;
+
+export type AstUnaryOperation = (typeof astUnaryOperations)[number];
 
 export type AstOpUnary = {
     readonly kind: "op_unary";
@@ -542,7 +551,9 @@ export type AstNumber = {
     readonly loc: SrcInfo;
 };
 
-export type AstNumberBase = 2 | 8 | 10 | 16;
+export const astNumberBases = [2, 8, 10, 16] as const;
+
+export type AstNumberBase = (typeof astNumberBases)[number];
 
 export type AstBoolean = {
     readonly kind: "boolean";
@@ -560,7 +571,9 @@ export type ImportPath = {
 
 // This is different from ItemOrigin, because relative import
 // from standard library is still import with origin: "stdlib"
-export type ImportType = "stdlib" | "relative";
+export const importTypes = ["stdlib", "relative"] as const;
+
+export type ImportType = (typeof importTypes)[number];
 
 // An AstSimplifiedString is a string in which escaping characters, like '\\' has been simplified, e.g., '\\' simplified to '\'.
 // An AstString is not a literal because it may contain escaping characters that have not been simplified, like '\\'.
@@ -629,7 +642,14 @@ export type AstStructFieldValue = {
     readonly loc: SrcInfo;
 };
 
-export type AstConstantAttributeName = "virtual" | "override" | "abstract";
+export const astConstantAttributeNames = [
+    "virtual",
+    "override",
+    "abstract",
+] as const;
+
+export type AstConstantAttributeName =
+    (typeof astConstantAttributeNames)[number];
 
 export type AstConstantAttribute = {
     readonly type: AstConstantAttributeName;
@@ -649,13 +669,17 @@ export type AstFunctionAttributeGet = {
     readonly loc: SrcInfo;
 };
 
+export const astFunctionAttributeNames = [
+    "mutates",
+    "extends",
+    "virtual",
+    "abstract",
+    "override",
+    "inline",
+] as const;
+
 export type AstFunctionAttributeName =
-    | "mutates"
-    | "extends"
-    | "virtual"
-    | "abstract"
-    | "override"
-    | "inline";
+    (typeof astFunctionAttributeNames)[number];
 
 export type AstFunctionAttributeRest = {
     readonly kind: "function_attribute";

--- a/src/ast/ast.ts
+++ b/src/ast/ast.ts
@@ -2,15 +2,6 @@ import { Address, Cell, Slice } from "@ton/core";
 import { SrcInfo } from "../grammar/src-info";
 import { RelativePath } from "../imports/path";
 import { Language } from "../imports/source";
-import {
-    astAugmentedAssignOperations,
-    astBinaryOperations,
-    astConstantAttributeNames,
-    astFunctionAttributeNames,
-    astNumberBases,
-    astUnaryOperations,
-    importTypes,
-} from "./ast-constants";
 
 export type AstModule = {
     readonly kind: "module";
@@ -251,7 +242,18 @@ export type AstStatementAssign = {
 };
 
 export type AstAugmentedAssignOperation =
-    (typeof astAugmentedAssignOperations)[number];
+    | "+"
+    | "-"
+    | "*"
+    | "/"
+    | "&&"
+    | "||"
+    | "%"
+    | "|"
+    | "<<"
+    | ">>"
+    | "&"
+    | "^";
 
 export type AstStatementAugmentedAssign = {
     readonly kind: "statement_augmentedassign";
@@ -405,7 +407,25 @@ export type AstLiteral =
     | AstSlice
     | AstStructValue;
 
-export type AstBinaryOperation = (typeof astBinaryOperations)[number];
+export type AstBinaryOperation =
+    | "+"
+    | "-"
+    | "*"
+    | "/"
+    | "!="
+    | ">"
+    | "<"
+    | ">="
+    | "<="
+    | "=="
+    | "&&"
+    | "||"
+    | "%"
+    | "<<"
+    | ">>"
+    | "&"
+    | "|"
+    | "^";
 
 export type AstOpBinary = {
     readonly kind: "op_binary";
@@ -416,7 +436,7 @@ export type AstOpBinary = {
     readonly loc: SrcInfo;
 };
 
-export type AstUnaryOperation = (typeof astUnaryOperations)[number];
+export type AstUnaryOperation = "+" | "-" | "!" | "!!" | "~";
 
 export type AstOpUnary = {
     readonly kind: "op_unary";
@@ -522,7 +542,7 @@ export type AstNumber = {
     readonly loc: SrcInfo;
 };
 
-export type AstNumberBase = (typeof astNumberBases)[number];
+export type AstNumberBase = 2 | 8 | 10 | 16;
 
 export type AstBoolean = {
     readonly kind: "boolean";
@@ -538,7 +558,9 @@ export type ImportPath = {
     readonly language: Language;
 };
 
-export type ImportType = (typeof importTypes)[number];
+// This is different from ItemOrigin, because relative import
+// from standard library is still import with origin: "stdlib"
+export type ImportType = "stdlib" | "relative";
 
 // An AstSimplifiedString is a string in which escaping characters, like '\\' has been simplified, e.g., '\\' simplified to '\'.
 // An AstString is not a literal because it may contain escaping characters that have not been simplified, like '\\'.
@@ -607,8 +629,7 @@ export type AstStructFieldValue = {
     readonly loc: SrcInfo;
 };
 
-export type AstConstantAttributeName =
-    (typeof astConstantAttributeNames)[number];
+export type AstConstantAttributeName = "virtual" | "override" | "abstract";
 
 export type AstConstantAttribute = {
     readonly type: AstConstantAttributeName;
@@ -629,7 +650,12 @@ export type AstFunctionAttributeGet = {
 };
 
 export type AstFunctionAttributeName =
-    (typeof astFunctionAttributeNames)[number];
+    | "mutates"
+    | "extends"
+    | "virtual"
+    | "abstract"
+    | "override"
+    | "inline";
 
 export type AstFunctionAttributeRest = {
     readonly kind: "function_attribute";

--- a/src/ast/ast.ts
+++ b/src/ast/ast.ts
@@ -2,6 +2,15 @@ import { Address, Cell, Slice } from "@ton/core";
 import { SrcInfo } from "../grammar/src-info";
 import { RelativePath } from "../imports/path";
 import { Language } from "../imports/source";
+import {
+    astAugmentedAssignOperations,
+    astBinaryOperations,
+    astConstantAttributeNames,
+    astFunctionAttributeNames,
+    astNumberBases,
+    astUnaryOperations,
+    importTypes,
+} from "./ast-constants";
 
 export type AstModule = {
     readonly kind: "module";
@@ -241,21 +250,6 @@ export type AstStatementAssign = {
     readonly loc: SrcInfo;
 };
 
-export const astAugmentedAssignOperations = [
-    "+",
-    "-",
-    "*",
-    "/",
-    "&&",
-    "||",
-    "%",
-    "|",
-    "<<",
-    ">>",
-    "&",
-    "^",
-] as const;
-
 export type AstAugmentedAssignOperation =
     (typeof astAugmentedAssignOperations)[number];
 
@@ -411,27 +405,6 @@ export type AstLiteral =
     | AstSlice
     | AstStructValue;
 
-export const astBinaryOperations = [
-    "+",
-    "-",
-    "*",
-    "/",
-    "!=",
-    ">",
-    "<",
-    ">=",
-    "<=",
-    "==",
-    "&&",
-    "||",
-    "%",
-    "<<",
-    ">>",
-    "&",
-    "|",
-    "^",
-] as const;
-
 export type AstBinaryOperation = (typeof astBinaryOperations)[number];
 
 export type AstOpBinary = {
@@ -442,8 +415,6 @@ export type AstOpBinary = {
     readonly id: number;
     readonly loc: SrcInfo;
 };
-
-export const astUnaryOperations = ["+", "-", "!", "!!", "~"] as const;
 
 export type AstUnaryOperation = (typeof astUnaryOperations)[number];
 
@@ -551,8 +522,6 @@ export type AstNumber = {
     readonly loc: SrcInfo;
 };
 
-export const astNumberBases = [2, 8, 10, 16] as const;
-
 export type AstNumberBase = (typeof astNumberBases)[number];
 
 export type AstBoolean = {
@@ -568,10 +537,6 @@ export type ImportPath = {
     readonly type: ImportType;
     readonly language: Language;
 };
-
-// This is different from ItemOrigin, because relative import
-// from standard library is still import with origin: "stdlib"
-export const importTypes = ["stdlib", "relative"] as const;
 
 export type ImportType = (typeof importTypes)[number];
 
@@ -642,12 +607,6 @@ export type AstStructFieldValue = {
     readonly loc: SrcInfo;
 };
 
-export const astConstantAttributeNames = [
-    "virtual",
-    "override",
-    "abstract",
-] as const;
-
 export type AstConstantAttributeName =
     (typeof astConstantAttributeNames)[number];
 
@@ -668,15 +627,6 @@ export type AstFunctionAttributeGet = {
     readonly methodId: AstExpression | null;
     readonly loc: SrcInfo;
 };
-
-export const astFunctionAttributeNames = [
-    "mutates",
-    "extends",
-    "virtual",
-    "abstract",
-    "override",
-    "inline",
-] as const;
 
 export type AstFunctionAttributeName =
     (typeof astFunctionAttributeNames)[number];

--- a/src/ast/random.infra.ts
+++ b/src/ast/random.infra.ts
@@ -2,6 +2,7 @@ import fc from "fast-check";
 import * as A from "./ast";
 import { dummySrcInfo } from "../grammar/src-info";
 import { diffJson } from "diff";
+import { astBinaryOperations, astUnaryOperations } from "./ast-constants";
 
 /**
  * An array of reserved words that cannot be used as contract or variable names in tests.
@@ -100,7 +101,7 @@ function randomAstOpUnary(
     return dummyAstNode(
         fc.record({
             kind: fc.constant("op_unary"),
-            op: fc.constantFrom("+", "-", "!", "!!", "~"),
+            op: fc.constantFrom(...astUnaryOperations),
             operand: operand,
         }),
     );
@@ -112,26 +113,7 @@ function randomAstOpBinary(
     return dummyAstNode(
         fc.record({
             kind: fc.constant("op_binary"),
-            op: fc.constantFrom(
-                "+",
-                "-",
-                "*",
-                "/",
-                "!=",
-                ">",
-                "<",
-                ">=",
-                "<=",
-                "==",
-                "&&",
-                "||",
-                "%",
-                "<<",
-                ">>",
-                "&",
-                "|",
-                "^",
-            ),
+            op: fc.constantFrom(...astBinaryOperations),
             left: leftExpression,
             right: rightExpression,
         }),

--- a/src/utils/tricks.ts
+++ b/src/utils/tricks.ts
@@ -146,3 +146,5 @@ export const singleton = <K extends string | symbol, V>(key: K, value: V) => {
 export const entries = Object.entries as <O>(
     o: O,
 ) => { [K in keyof O]: [K, O[K]] }[keyof O][];
+
+export const keys = Object.keys as <O>(o: O) => (keyof O)[];


### PR DESCRIPTION
To reuse, for example, in AST generator

## Issue

Closes #1465.

## Checklist

- [x] I have run all the tests locally and no test failure was reported
- [x] I have run the linter, formatter and spellchecker
- [x] I did not do unrelated and/or undiscussed refactorings
