### PR TITLE
feat(stdlib): add `getPrecompiledGas` function

### DIFF
--- a/src/stdlib/stdlib/std/internal/contract.tact
+++ b/src/stdlib/stdlib/std/internal/contract.tact
@@ -346,7 +346,6 @@ asm fun myCode(): Cell { MYCODE }
 /// fucntion available in the TVM update 
 asm fun getPrecompiledGas(): Int { GETPRECOMPILEDGAS }
 
-asm fun getFeeConfigs(): Tuple {UNPACKEDCONFIGTUPLE}
 
 
 

--- a/src/stdlib/stdlib/std/internal/contract.tact
+++ b/src/stdlib/stdlib/std/internal/contract.tact
@@ -343,3 +343,13 @@ asm fun setSeed(seed: Int) { SETRAND }
 /// See: https://docs.tact-lang.org/ref/core-advanced#mycode
 ///
 asm fun myCode(): Cell { MYCODE }
+/// fucntion available in the TVM update 
+asm fun getPrecompiledGas(): Int { GETPRECOMPILEDGAS }
+
+asm fun getFeeConfigs(): Tuple {UNPACKEDCONFIGTUPLE}
+
+
+
+
+
+


### PR DESCRIPTION
Missing GETPRECOMPILEDGAS TVM fucntion necessary for contract like USDT contract :
https://docs.ton.org/v3/documentation/tvm/changelog/tvm-upgrade-2024-04#opcodes-to-process-config-parameters
And new TVM fucntion UNPACKEDCONFIGTUPLE missing too:
https://docs.ton.org/v3/documentation/tvm/changelog/tvm-upgrade-2024-04#opcodes-to-work-with-new-c7-values
