### PR TITLE
fix: use `number` instead of `bigint` in benchmarks for gas

### DIFF
--- a/src/test/benchmarks/__snapshots__/benchmarks.spec.ts.snap
+++ b/src/test/benchmarks/__snapshots__/benchmarks.spec.ts.snap
@@ -6,8 +6,8 @@ exports[`benchmarks benchmark cells creation: gas used emptySlice 1`] = `935n`;
 
 exports[`benchmarks benchmark functions: code size 1`] = `211`;
 
-exports[`benchmarks benchmark functions: gas used 1`] = `2769n`;
+exports[`benchmarks benchmark functions: gas used 1`] = `2769`;
 
 exports[`benchmarks benchmark readFwdFee: code size 1`] = `157`;
 
-exports[`benchmarks benchmark readFwdFee: gas used 1`] = `2799n`;
+exports[`benchmarks benchmark readFwdFee: gas used 1`] = `2799`;

--- a/src/test/benchmarks/benchmarks.spec.ts
+++ b/src/test/benchmarks/benchmarks.spec.ts
@@ -19,11 +19,13 @@ import "@ton/test-utils";
 import { CellsCreation } from "./contracts/output/cells_CellsCreation";
 import { getUsedGas } from "./util";
 
-function measureGas(txs: BlockchainTransaction[]) {
-    return (
-        (txs[1]!.description as TransactionDescriptionGeneric)
-            .computePhase as TransactionComputeVm
-    ).gasUsed;
+function measureGas(txs: BlockchainTransaction[]): number {
+    return Number(
+        (
+            (txs[1]!.description as TransactionDescriptionGeneric)
+                .computePhase as TransactionComputeVm
+        ).gasUsed,
+    );
 }
 
 describe("benchmarks", () => {

--- a/src/test/benchmarks/benchmarks.spec.ts
+++ b/src/test/benchmarks/benchmarks.spec.ts
@@ -76,7 +76,7 @@ describe("benchmarks", () => {
     async function hashStringSmall(
         sha256: SandboxContract<Sha256Small>,
         s: string,
-    ): Promise<bigint> {
+    ): Promise<number> {
         const result = await sha256.send(
             treasure.getSender(),
             { value: toNano(1) },
@@ -89,7 +89,7 @@ describe("benchmarks", () => {
     async function hashStringBig(
         sha256: SandboxContract<Sha256Big>,
         s: string,
-    ): Promise<bigint> {
+    ): Promise<number> {
         const result = await sha256.send(
             treasure.getSender(),
             { value: toNano(1) },
@@ -102,7 +102,7 @@ describe("benchmarks", () => {
     async function hashStringAsSLice(
         sha256: SandboxContract<Sha256AsSlice>,
         s: string,
-    ): Promise<bigint> {
+    ): Promise<number> {
         const result = await sha256.send(
             treasure.getSender(),
             { value: toNano(1) },
@@ -137,33 +137,31 @@ describe("benchmarks", () => {
         await hashStringSmall(sha256Small, "hello world");
         await hashStringAsSLice(sha256AsSlice, "hello world");
 
-        expect(await hashStringBig(sha256Big, "hello world")).toEqual(3039n);
-        expect(await hashStringSmall(sha256Small, "hello world")).toEqual(
-            2516n,
-        );
+        expect(await hashStringBig(sha256Big, "hello world")).toEqual(3039);
+        expect(await hashStringSmall(sha256Small, "hello world")).toEqual(2516);
         expect(await hashStringAsSLice(sha256AsSlice, "hello world")).toEqual(
-            2516n,
+            2516,
         );
 
         expect(await hashStringBig(sha256Big, "hello world".repeat(5))).toEqual(
-            3040n,
+            3040,
         );
         expect(
             await hashStringSmall(sha256Small, "hello world".repeat(5)),
-        ).toEqual(2516n);
+        ).toEqual(2516);
         expect(
             await hashStringAsSLice(sha256AsSlice, "hello world".repeat(5)),
-        ).toEqual(2516n);
+        ).toEqual(2516);
 
         expect(
             await hashStringBig(sha256Big, "hello world".repeat(10)),
-        ).toEqual(3042n);
+        ).toEqual(3042);
         expect(
             await hashStringSmall(sha256Small, "hello world".repeat(10)),
-        ).toEqual(2516n);
+        ).toEqual(2516);
         expect(
             await hashStringAsSLice(sha256AsSlice, "hello world".repeat(10)),
-        ).toEqual(2516n);
+        ).toEqual(2516);
     });
 
     it("benchmark cells creation", async () => {

--- a/src/test/benchmarks/jetton/jetton.spec.ts
+++ b/src/test/benchmarks/jetton/jetton.spec.ts
@@ -311,7 +311,7 @@ describe("Jetton", () => {
         });
 
         const gasUsed = getUsedGas(sendResult);
-        expect(gasUsed).toBe(expectedResult.transfer);
+        expect(gasUsed).toEqual(expectedResult.transfer);
     });
 
     it("burn", async () => {
@@ -344,14 +344,14 @@ describe("Jetton", () => {
             exitCode: 0,
         });
 
-        expect(await getJettonBalance(deployerJettonWallet)).toBe(
+        expect(await getJettonBalance(deployerJettonWallet)).toEqual(
             initialJettonBalance - burnAmount,
         );
         const data = await jettonMinter.getGetJettonData();
-        expect(data.totalSupply).toBe(initialTotalSupply - burnAmount);
+        expect(data.totalSupply).toEqual(initialTotalSupply - burnAmount);
 
         const gasUsed = getUsedGas(burnResult);
-        expect(gasUsed).toBe(expectedResult.burn);
+        expect(gasUsed).toEqual(expectedResult.burn);
     });
 
     it("discovery", async () => {
@@ -370,6 +370,6 @@ describe("Jetton", () => {
         });
 
         const gasUsed = getUsedGas(discoveryResult);
-        expect(gasUsed).toBe(expectedResult.discovery);
+        expect(gasUsed).toEqual(expectedResult.discovery);
     });
 });

--- a/src/test/benchmarks/jetton/jetton.spec.ts
+++ b/src/test/benchmarks/jetton/jetton.spec.ts
@@ -22,23 +22,23 @@ import benchmarkResults from "./results.json";
 
 type BenchmarkResult = {
     label: string;
-    transfer: bigint;
-    burn: bigint;
-    discovery: bigint;
+    transfer: number;
+    burn: number;
+    discovery: number;
 };
 
 const results: BenchmarkResult[] = benchmarkResults.results.map((result) => ({
     label: result.label,
-    transfer: BigInt(result.transfer),
-    burn: BigInt(result.burn),
-    discovery: BigInt(result.discovery),
+    transfer: Number(result.transfer),
+    burn: Number(result.burn),
+    discovery: Number(result.discovery),
 }));
 
 type MetricKey = "transfer" | "burn" | "discovery";
 const METRICS: readonly MetricKey[] = ["transfer", "burn", "discovery"];
 
-function calculateChange(prev: bigint, curr: bigint): string {
-    const change = ((Number(curr - prev) / Number(prev)) * 100).toFixed(2);
+function calculateChange(prev: number, curr: number): string {
+    const change = (((curr - prev) / prev) * 100).toFixed(2);
     const number = parseFloat(change);
     if (number === 0) {
         return chalk.gray(`same`);
@@ -311,7 +311,7 @@ describe("Jetton", () => {
         });
 
         const gasUsed = getUsedGas(sendResult);
-        expect(gasUsed).toEqual(expectedResult.transfer);
+        expect(gasUsed).toBe(expectedResult.transfer);
     });
 
     it("burn", async () => {
@@ -344,14 +344,14 @@ describe("Jetton", () => {
             exitCode: 0,
         });
 
-        expect(await getJettonBalance(deployerJettonWallet)).toEqual(
+        expect(await getJettonBalance(deployerJettonWallet)).toBe(
             initialJettonBalance - burnAmount,
         );
         const data = await jettonMinter.getGetJettonData();
-        expect(data.totalSupply).toEqual(initialTotalSupply - burnAmount);
+        expect(data.totalSupply).toBe(initialTotalSupply - burnAmount);
 
         const gasUsed = getUsedGas(burnResult);
-        expect(gasUsed).toEqual(expectedResult.burn);
+        expect(gasUsed).toBe(expectedResult.burn);
     });
 
     it("discovery", async () => {
@@ -370,6 +370,6 @@ describe("Jetton", () => {
         });
 
         const gasUsed = getUsedGas(discoveryResult);
-        expect(gasUsed).toEqual(expectedResult.discovery);
+        expect(gasUsed).toBe(expectedResult.discovery);
     });
 });

--- a/src/test/benchmarks/util.ts
+++ b/src/test/benchmarks/util.ts
@@ -1,13 +1,13 @@
 import { SendMessageResult } from "@ton/sandbox/dist/blockchain/Blockchain";
 
-export function getUsedGas(sendEnough: SendMessageResult) {
+export function getUsedGas(sendEnough: SendMessageResult): number {
     return sendEnough.transactions
         .slice(1)
         .map((t) =>
             t.description.type === "generic" &&
             t.description.computePhase.type === "vm"
-                ? t.description.computePhase.gasUsed
-                : 0n,
+                ? Number(t.description.computePhase.gasUsed)
+                : 0,
         )
         .reduceRight((prev, cur) => prev + cur);
 }


### PR DESCRIPTION
## Issue

Closes #1803

## Checklist

- [x] I have run all the tests locally and no test failure was reported
- [x] I have run the linter, formatter and spellchecker
- [x] I did not do unrelated and/or undiscussed refactorings
