### PR TITLE
fix: better error messages for empty `bounced()` and `bounced("string")`

### DIFF
--- a/dev-docs/CHANGELOG.md
+++ b/dev-docs/CHANGELOG.md
@@ -108,6 +108,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Bump used `@tact-lang/opcode` version to `0.2` which fixes many issues in CI runs: PR [#1922](https://github.com/tact-lang/tact/pull/1922)
 - Generation of the fallback receiver for external messages: PR [#1926](https://github.com/tact-lang/tact/pull/1926)
 - Runtime calls to `sha256()` now work for arbitrary slices with length >= 128: PR [#1936](https://github.com/tact-lang/tact/pull/1936)
+- Better error messages for empty `bounced()` and `bounced("string")`: PR [#1998](https://github.com/tact-lang/tact/pull/1998)
 
 ### Docs
 

--- a/src/grammar/next/__snapshots__/grammar.spec.ts.snap
+++ b/src/grammar/next/__snapshots__/grammar.spec.ts.snap
@@ -178,6 +178,15 @@ exports[`grammar should fail destructuring-duplicate-source-id 1`] = `
 "
 `;
 
+exports[`grammar should fail empty-bounced-receiver 1`] = `
+"<unknown>:2:5: bounced() receiver should accept one of Message, bounced<Message> or Slice
+  1 | contract Test {
+> 2 |     bounced() {}
+          ^~~~~~~~~~~~
+  3 | }
+"
+`;
+
 exports[`grammar should fail expr-fun-call-trailing-comma-no-args 1`] = `
 "<unknown>:6:14: Expected "!", "(", ")", "+", "-", "0", "\\"", "codeOf", "false", "initOf", "null", "true", "~", capitalized identifier, digit, or identifier
   5 | fun b(): Int {
@@ -612,6 +621,15 @@ exports[`grammar should fail literal-underscore-after-leading-zero 1`] = `
   1 | fun test_fun(): Int {
 > 2 |     return 0_123;
                  ^~~~~
+  3 | }
+"
+`;
+
+exports[`grammar should fail string-bounced-receiver 1`] = `
+"<unknown>:2:5: bounced() receiver can only accept Message, bounced<Message> or Slice
+  1 | contract Test {
+> 2 |     bounced("hello") {}
+          ^~~~~~~~~~~~~~~~~~~
   3 | }
 "
 `;

--- a/src/grammar/next/__snapshots__/grammar.spec.ts.snap
+++ b/src/grammar/next/__snapshots__/grammar.spec.ts.snap
@@ -179,7 +179,7 @@ exports[`grammar should fail destructuring-duplicate-source-id 1`] = `
 `;
 
 exports[`grammar should fail empty-bounced-receiver 1`] = `
-"<unknown>:2:5: bounced() receiver should accept one of Message, bounced<Message> or Slice
+"<unknown>:2:5: bounced() receiver should accept a Message, bounced<Message> or Slice
   1 | contract Test {
 > 2 |     bounced() {}
           ^~~~~~~~~~~~
@@ -626,7 +626,7 @@ exports[`grammar should fail literal-underscore-after-leading-zero 1`] = `
 `;
 
 exports[`grammar should fail string-bounced-receiver 1`] = `
-"<unknown>:2:5: bounced() receiver can only accept Message, bounced<Message> or Slice
+"<unknown>:2:5: bounced() receiver can only accept a Message, bounced<Message> or Slice
   1 | contract Test {
 > 2 |     bounced("hello") {}
           ^~~~~~~~~~~~~~~~~~~

--- a/src/grammar/parser-error.ts
+++ b/src/grammar/parser-error.ts
@@ -75,12 +75,12 @@ export const syntaxErrorSchema = <T, U>(
         },
         noBouncedWithoutArg: () => {
             return handle(
-                sub`bounced() receiver should accept one of Message, bounced<Message> or Slice`,
+                sub`bounced() receiver should accept a Message, bounced<Message> or Slice`,
             );
         },
         noBouncedWithString: () => {
             return handle(
-                sub`bounced() receiver can only accept Message, bounced<Message> or Slice`,
+                sub`bounced() receiver can only accept a Message, bounced<Message> or Slice`,
             );
         },
         noConstantDecl: () => {

--- a/src/grammar/parser-error.ts
+++ b/src/grammar/parser-error.ts
@@ -74,11 +74,13 @@ export const syntaxErrorSchema = <T, U>(
             return handle(sub`Expression is not callable`);
         },
         noBouncedWithoutArg: () => {
-            return handle(sub`bounced() cannot be used as fallback`);
+            return handle(
+                sub`bounced() receiver should accept one of Message, bounced<Message> or Slice`,
+            );
         },
         noBouncedWithString: () => {
             return handle(
-                sub`bounced() cannot be used with a string literal name`,
+                sub`bounced() receiver can only accept Message, bounced<Message> or Slice`,
             );
         },
         noConstantDecl: () => {

--- a/src/grammar/prev/__snapshots__/grammar.spec.ts.snap
+++ b/src/grammar/prev/__snapshots__/grammar.spec.ts.snap
@@ -183,6 +183,16 @@ exports[`grammar should fail destructuring-duplicate-source-id 1`] = `
 "
 `;
 
+exports[`grammar should fail empty-bounced-receiver 1`] = `
+"<unknown>:2:13: Expected "_", "A".."Z", or "a".."z"
+
+  1 | contract Test {
+> 2 |     bounced() {}
+                  ^
+  3 | }
+"
+`;
+
 exports[`grammar should fail expr-fun-call-trailing-comma-no-args 1`] = `
 "<unknown>:6:14: Empty parameter list should not have a dangling comma
   5 | fun b(): Int {
@@ -656,6 +666,16 @@ exports[`grammar should fail literal-underscore-after-leading-zero 1`] = `
 
   1 | fun test_fun(): Int {
 > 2 |     return 0_123;
+                  ^
+  3 | }
+"
+`;
+
+exports[`grammar should fail string-bounced-receiver 1`] = `
+"<unknown>:2:13: Expected "_", "A".."Z", or "a".."z"
+
+  1 | contract Test {
+> 2 |     bounced("hello") {}
                   ^
   3 | }
 "

--- a/src/grammar/test-failed/empty-bounced-receiver.tact
+++ b/src/grammar/test-failed/empty-bounced-receiver.tact
@@ -1,0 +1,3 @@
+contract Test {
+    bounced() {}
+}

--- a/src/grammar/test-failed/string-bounced-receiver.tact
+++ b/src/grammar/test-failed/string-bounced-receiver.tact
@@ -1,0 +1,3 @@
+contract Test {
+    bounced("hello") {}
+}


### PR DESCRIPTION
## Issue

Closes #1984.

## Checklist

- [x] I have updated CHANGELOG.md
- [x] I have added tests to demonstrate the contribution is correctly implemented: this usually includes both positive and negative tests, showing the happy path(s) and featuring intentionally broken cases
- [x] I have run all the tests locally and no test failure was reported
- [x] I have run the linter, formatter and spellchecker
- [x] I did not do unrelated and/or undiscussed refactorings
