### PR TITLE
fix: show better error for fields with a contract type

### DIFF
--- a/dev-docs/CHANGELOG.md
+++ b/dev-docs/CHANGELOG.md
@@ -112,6 +112,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Better error messages for empty `bounced()` and `bounced("string")`: PR [#1998](https://github.com/tact-lang/tact/pull/1998)
 - Contract data types in compilation reports are now generated correctly: PR [#2004](https://github.com/tact-lang/tact/pull/2004)
 - Updated contracts in `./examples`: PR [#2008](https://github.com/tact-lang/tact/pull/2008)
+- Show better error for fields with a contract type: PR [#2011](https://github.com/tact-lang/tact/pull/2011)
 
 ### Docs
 

--- a/src/types/__snapshots__/resolveDescriptors.spec.ts.snap
+++ b/src/types/__snapshots__/resolveDescriptors.spec.ts.snap
@@ -410,6 +410,24 @@ exports[`resolveDescriptors should fail descriptors for message-decl-remainder-i
 "
 `;
 
+exports[`resolveDescriptors should fail descriptors for message-field-with-contract-type 1`] = `
+"<unknown>:6:5: Fields with a contract type are not supported yet
+  5 | message TakeEscrowData {
+> 6 |     escrowData: Escrow;
+          ^~~~~~~~~~~~~~~~~~
+  7 | }
+"
+`;
+
+exports[`resolveDescriptors should fail descriptors for message-field-with-optional-contract-type 1`] = `
+"<unknown>:6:5: Fields with a contract type are not supported yet
+  5 | message TakeEscrowData {
+> 6 |     escrowData: Escrow?;
+          ^~~~~~~~~~~~~~~~~~~
+  7 | }
+"
+`;
+
 exports[`resolveDescriptors should fail descriptors for message-negative-opcode-1 1`] = `
 "<unknown>:1:9: Opcode of message "Foo" is negative ('-1') which is not allowed
 > 1 | message(-1) Foo { }
@@ -867,6 +885,15 @@ exports[`resolveDescriptors should fail descriptors for struct-decl-self-referen
 > 4 | struct A {
              ^
   5 |   a: Int;
+"
+`;
+
+exports[`resolveDescriptors should fail descriptors for struct-field-with-contract-type 1`] = `
+"<unknown>:6:5: Fields with a contract type are not supported yet
+  5 | struct TakeEscrowData {
+> 6 |     escrowData: Escrow;
+          ^~~~~~~~~~~~~~~~~~
+  7 | }
 "
 `;
 

--- a/src/types/resolveSignatures.ts
+++ b/src/types/resolveSignatures.ts
@@ -186,6 +186,21 @@ export function resolveSignatures(ctx: CompilerContext, Ast: FactoryAst) {
             throwInternalCompilerError(`Unsupported type: ${name}`);
         }
 
+        for (const field of t.fields) {
+            const type = field.type;
+            if (type.kind !== "ref") {
+                continue;
+            }
+
+            const t = getType(ctx, type.name);
+            if (t.kind === "contract") {
+                throwCompilationError(
+                    `Fields with a contract type are not supported yet`,
+                    field.loc,
+                );
+            }
+        }
+
         // Check for no "as remaining" in the middle of the struct or contract
         for (const field of t.fields.slice(0, -1)) {
             if (field.as === "remaining") {

--- a/src/types/test-failed/message-field-with-contract-type.tact
+++ b/src/types/test-failed/message-field-with-contract-type.tact
@@ -1,0 +1,7 @@
+trait BaseTrait {}
+
+contract Escrow {}
+
+message TakeEscrowData {
+    escrowData: Escrow;
+}

--- a/src/types/test-failed/message-field-with-optional-contract-type.tact
+++ b/src/types/test-failed/message-field-with-optional-contract-type.tact
@@ -1,0 +1,7 @@
+trait BaseTrait {}
+
+contract Escrow {}
+
+message TakeEscrowData {
+    escrowData: Escrow?;
+}

--- a/src/types/test-failed/struct-field-with-contract-type.tact
+++ b/src/types/test-failed/struct-field-with-contract-type.tact
@@ -1,0 +1,7 @@
+trait BaseTrait {}
+
+contract Escrow {}
+
+struct TakeEscrowData {
+    escrowData: Escrow;
+}


### PR DESCRIPTION
## Issue

Towards #2000.

## Checklist

- [x] I have updated CHANGELOG.md
- [x] I have added tests to demonstrate the contribution is correctly implemented: this usually includes both positive and negative tests, showing the happy path(s) and featuring intentionally broken cases
- [x] I have run all the tests locally and no test failure was reported
- [x] I have run the linter, formatter and spellchecker
- [x] I did not do unrelated and/or undiscussed refactorings
