### PR TITLE
fix: fix new grammar keyword rules

### DIFF
--- a/src/grammar/next/grammar.gg
+++ b/src/grammar/next/grammar.gg
@@ -323,8 +323,8 @@ reservedWord "reserved word" = keyword<(
 
     "fun" / "let" / "return" / "receive" / "native" / "primitive" / "null" /
     "if" / "else" / "while" / "repeat" / "do" / "until" / "try" / "catch" /
-    "foreach" / "as" / "map" / "mutates" / "extends" / "external" / "import"
-    / "with" / "trait" / "initOf" / "override" / "abstract" / "virtual" /
+    "foreach" / "as" / "map" / "mutates" / "extends" / "external" / "import" /
+    "with" / "trait" / "initOf" / "override" / "abstract" / "virtual" /
     "inline" / "const"
 )>;
 


### PR DESCRIPTION
## Checklist

- [x] I have run the linter, formatter and spellchecker
- [x] I did not do unrelated and/or undiscussed refactorings
