### PR TITLE
refactor(pipeline): do not add `.code` for `.fc`, `.fif` and `.rev.fif` file names

### DIFF
--- a/dev-docs/CHANGELOG.md
+++ b/dev-docs/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [1.6.0] - 2025-02-28
 
+### Internal infrastructure
+
+- Do not add `.code` to the file names of the generated FunC, Fift and disassembled Fift: Pr [#2103](https://github.com/tact-lang/tact/pull/2103)
+
 ### Language features
 
 - Added `&&=`, `||=`, `>>=` and `<<=` augmented assignment operators: PR [#853](https://github.com/tact-lang/tact/pull/853)

--- a/dev-docs/CHANGELOG.md
+++ b/dev-docs/CHANGELOG.md
@@ -11,15 +11,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Contract load function is inlined: PR [#2101](https://github.com/tact-lang/tact/pull/2101)
 
+### Internal infrastructure
+
+- Do not add `.code` to the file names of the generated FunC, Fift, and disassembled Fift: PR [#2103](https://github.com/tact-lang/tact/pull/2103)
+
 ### Release contributors
 
 - [Anton Trunov](https://github.com/anton-trunov)
 
 ## [1.6.0] - 2025-02-28
-
-### Internal infrastructure
-
-- Do not add `.code` to the file names of the generated FunC, Fift and disassembled Fift: Pr [#2103](https://github.com/tact-lang/tact/pull/2103)
 
 ### Language features
 

--- a/src/generator/writeProgram.ts
+++ b/src/generator/writeProgram.ts
@@ -261,8 +261,8 @@ export async function writeProgram(
     });
 
     return {
-        entrypoint: basename + ".code.fc",
-        files: [{ name: basename + ".code.fc", code }],
+        entrypoint: `${basename}.fc`,
+        files: [{ name: `${basename}.fc`, code }],
         constants,
         abi,
     };

--- a/src/pipeline/build.ts
+++ b/src/pipeline/build.ts
@@ -154,20 +154,21 @@ export async function build(args: {
 
         const pathAbi = project.resolve(
             config.output,
-            config.name + "_" + contractName + ".abi",
+            `${config.name}_${contractName}.abi`,
         );
 
         const pathCodeBoc = project.resolve(
             config.output,
-            config.name + "_" + contractName + ".code.boc",
+            // need to keep `.code.boc` here because Blueprint looks for this pattern
+            `${config.name}_${contractName}.code.boc`,
         );
         const pathCodeFif = project.resolve(
             config.output,
-            config.name + "_" + contractName + ".code.fif",
+            `${config.name}_${contractName}.fif`,
         );
         const pathCodeFifDec = project.resolve(
             config.output,
-            config.name + "_" + contractName + ".code.rev.fif",
+            `${config.name}_${contractName}.rev.fif`,
         );
         let codeFc: { path: string; content: string }[];
         let codeEntrypoint: string;
@@ -180,7 +181,7 @@ export async function build(args: {
             const res = await compile(
                 ctx,
                 contractName,
-                config.name + "_" + contractName,
+                `${config.name}_${contractName}`,
                 built,
             );
             for (const files of res.output.files) {


### PR DESCRIPTION
We need to keep `.code.boc` though, since Blueprint looks for this pattern.

<!--
IMPORTANT:
If your PR doesn't close a particular issue, please, create the issue first and describe the whole context: what you're adding/changing and why you're doing so. And only then open the Pull Request, which would close that issue!

IMPORTANT:
In general, the Tact team does not accept refactorings from external contributors unless those were previously discussed and you've got the green light to change things without adding new functionality or to fix something broken. Language features, bugfixes, doc improvements are more than welcome!
-->

## Issue

Closes #2102.

## Checklist

- [ ] I have updated CHANGELOG.md
- [x] I have run all the tests locally and no test failure was reported
- [x] I have run the linter, formatter and spellchecker
- [x] I did not do unrelated and/or undiscussed refactorings
