### PR TITLE
refactor(tests): split the precedence tests for internal and external receivers

### DIFF
--- a/.github/workflows/tact.yml
+++ b/.github/workflows/tact.yml
@@ -42,7 +42,8 @@ jobs:
           # Test some specific things for backwards compatibility.
           # It's important to restrain from using too much of Node.js 22+ features
           # until it goes into maintenance LTS state and majority of users catches up
-          yarn cross-env NODE_OPTIONS=--max_old_space_size=4096 jest isSubsetOf
+          # yarn cross-env NODE_OPTIONS=--max_old_space_size=4096 jest isSubsetOf
+          yarn jest isSubsetOf
           # Clean-up
           yarn cleanall
           yarn config delete ignore-engines

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "test:fast": "jest --config=./jest-fast.config.js",
     "bench": "yarn gen:contracts:benchmarks && jest ./src/test/benchmarks",
     "bench:upgrade": "yarn gen:contracts:benchmarks && ts-node src/test/benchmarks/benchmarks.update.ts",
-    "coverage": "cross-env COVERAGE=true NODE_OPTIONS=--max_old_space_size=4096 jest --config=./jest-ci.config.js",
+    "coverage": "cross-env COVERAGE=true jest --config=./jest-ci.config.js",
     "type": "tsc --noEmit",
     "lint": "yarn eslint .",
     "fmt": "yarn prettier -l -w .",


### PR DESCRIPTION
<!--
IMPORTANT:
If your PR doesn't close a particular issue, please, create the issue first and describe the whole context: what you're adding/changing and why you're doing so. And only then open the Pull Request, which would close that issue!
-->

## Issue

Towards #2045.

This PR splits in half the precedence tests for internal and external receivers in order to decrease memory usage.

## Checklist

- [ ] I have updated CHANGELOG.md
- [X] I have run all the tests locally and no test failure was reported
- [X] I have run the linter, formatter and spellchecker
- [X] I did not do unrelated and/or undiscussed refactorings
