### PR TITLE
fix: use call by name for getter if no explicit method id is stated

### DIFF
--- a/dev-docs/CHANGELOG.md
+++ b/dev-docs/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### TypeScript wrappers
 
 - Export message opcodes and exit codes: PR [#2081](https://github.com/tact-lang/tact/issues/2081)
+- [fix] calling of getters in Blueprint: PR [#2299](https://github.com/tact-lang/tact/issues/2299)
 
 ### Code generation
 

--- a/src/bindings/writeTypescript.ts
+++ b/src/bindings/writeTypescript.ts
@@ -680,7 +680,6 @@ export function writeTypescript(
                     }
 
                     const method = contract?.functions.get(g.name);
-
                     const explicitMethodId = method?.ast.attributes.find(
                         (attr) => attr.type === "get",
                     )?.methodId;

--- a/src/bindings/writeTypescript.ts
+++ b/src/bindings/writeTypescript.ts
@@ -25,6 +25,7 @@ import { serializers } from "./typescript/serializers";
 import { eqNames } from "../ast/ast-helpers";
 import { enabledOptimizedChildCode } from "../config/features";
 import type { CompilerContext } from "../context/context";
+import type { TypeDescription } from "../types/types";
 
 function writeArguments(args: ABIArgument[]) {
     const res: string[] = [];
@@ -54,6 +55,7 @@ export function writeTypescript(
     abi: ContractABI,
     ctx: CompilerContext,
     constants: WrappersConstantDescription[],
+    contract: undefined | TypeDescription,
     init?: {
         code: string;
         system: string | null;
@@ -676,7 +678,17 @@ export function writeTypescript(
                             writeArgumentToStack(a.name, a.type, w);
                         }
                     }
-                    if (g.methodId) {
+
+                    const method = contract?.functions.get(g.name);
+
+                    const explicitMethodId = method?.ast.attributes.find(
+                        (attr) => attr.type === "get",
+                    )?.methodId;
+
+                    // use call by name for getter if no explicit method id is stated
+                    // since with Blueprint we get this error:
+                    //    Error: Method name must be a string for TonClient provider
+                    if (g.methodId && typeof explicitMethodId !== "undefined") {
                         // 'as any' is used because Sandbox contracts's getters can be called
                         // using the function name or the method id number
                         // but the ContractProvider's interface get methods can only

--- a/src/pipeline/build.ts
+++ b/src/pipeline/build.ts
@@ -40,6 +40,7 @@ import type { Parser } from "../grammar";
 import { getParser } from "../grammar";
 import { defaultParser } from "../grammar/grammar";
 import { topSortContracts } from "./utils";
+import type { TypeDescription } from "../types/types";
 
 export function enableFeatures(
     ctx: CompilerContext,
@@ -137,6 +138,7 @@ export async function build(args: {
               codeBoc: Buffer;
               abi: string;
               constants: WrappersConstantDescription[];
+              contract: TypeDescription;
           }
         | undefined
     > = {};
@@ -278,6 +280,7 @@ export async function build(args: {
             codeBoc,
             abi,
             constants,
+            contract,
         };
 
         if (config.mode === "fullWithDecompilation") {
@@ -431,6 +434,7 @@ export async function build(args: {
                 JSON.parse(pkg.abi),
                 ctx,
                 built[pkg.name]?.constants ?? [],
+                built[pkg.name]?.contract,
                 {
                     code: pkg.code,
                     prefix: pkg.init.prefix,


### PR DESCRIPTION
## Issue

Closes #2295.

## Example

```tact
message Add {
    queryId: Int as uint64;
    amount: Int as uint32;
}

contract SimpleCounter {
    id: Int as uint32;
    counter: Int as uint32;

    init(id: Int) {
        self.id = id;
        self.counter = 0;
    }

    receive() {}

    receive(msg: Add) {
        self.counter += msg.amount;
    }

    get(0x10000) fun counter(): Int {
        return self.counter;
    }

    get fun id(): Int {
        return self.id;
    }
}
```

### Before

```typescript
async getCounter(provider: ContractProvider) {
    const builder = new TupleBuilder();
    const source = (await provider.get(65536 as any, builder.build())).stack;
    const result = source.readBigNumber();
    return result;
}

async getId(provider: ContractProvider) {
    const builder = new TupleBuilder();
    const source = (await provider.get(105872 as any, builder.build())).stack;
    const result = source.readBigNumber();
    return result;
}
```

### After

```typescript
async getCounter(provider: ContractProvider) {
    const builder = new TupleBuilder();
    const source = (await provider.get(65536 as any, builder.build())).stack;
    const result = source.readBigNumber();
    return result;
}

async getId(provider: ContractProvider) {
    const builder = new TupleBuilder();
    const source = (await provider.get('id', builder.build())).stack;
    const result = source.readBigNumber();
    return result;
}
```

## Checklist

- [x] I have updated CHANGELOG.md
- [ ] I have added tests to demonstrate the contribution is correctly implemented: this usually includes both positive and negative tests, showing the happy path(s) and featuring intentionally broken cases
