### PR TITLE
docs: add descriptions for `&&=`, `||=`, `>>=` and `<<=`

### DIFF
--- a/dev-docs/CHANGELOG.md
+++ b/dev-docs/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Docs
 
-- Add descriptions for `&&=`, `||=`, `>>=` and `<<=` augmented assignment operators: PR [#XYZ](https://github.com/tact-lang/tact/pull/XYZ)
+- Add descriptions for `&&=`, `||=`, `>>=` and `<<=` augmented assignment operators: PR [#2328](https://github.com/tact-lang/tact/pull/2328)
 
 ### Release contributors
 

--- a/dev-docs/CHANGELOG.md
+++ b/dev-docs/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Docs
+
+- Add descriptions for `&&=`, `||=`, `>>=` and `<<=` augmented assignment operators: PR [#XYZ](https://github.com/tact-lang/tact/pull/XYZ)
+
+### Release contributors
+
+- [Novus Nota](https://github.com/novusnota)
+
 ## [1.6.2] - 2025-03-06
 
 ### Language features

--- a/docs/grammars/grammar-tact.json
+++ b/docs/grammars/grammar-tact.json
@@ -431,7 +431,7 @@
           },
           {
             "comment": "Augmented assignment operators",
-            "match": "(\\+=|-=|\\*=|/=|%=|\\^=|&=|\\|=|<<=|>>=)",
+            "match": "(\\+=|-=|\\*=|/=|%=|\\^=|&=|\\|=|\\|\\|=|&&=|<<=|>>=)",
             "name": "keyword.operator.assignment.tact"
           },
           {

--- a/docs/src/content/docs/book/operators.mdx
+++ b/docs/src/content/docs/book/operators.mdx
@@ -643,6 +643,10 @@ List of augmented assignment operators:
 * `&={:tact}`, which uses the [bitwise AND operator `&{:tact}`](#binary-bitwise-and). Can only be applied to values of type [`Int{:tact}`][int].
 * `^={:tact}`, which uses the [bitwise XOR operator `^{:tact}`](#binary-bitwise-xor). Can only be applied to values of type [`Int{:tact}`][int].
 * `|={:tact}`, which uses the [bitwise OR operator `|{:tact}`](#binary-bitwise-or). Can only be applied to values of type [`Int{:tact}`][int].
+* `&&={:tact}`, which uses the [logical AND operator `&&{:tact}`](#binary-logical-and). Can only be applied to values of type [`Bool{:tact}`][p]. Available since Tact 1.6.
+* `||={:tact}`, which uses the [logical OR operator `||{:tact}`](#binary-logical-or). Can only be applied to values of type [`Bool{:tact}`][p]. Available since Tact 1.6.
+* `<<={:tact}`, which uses the [bitwise shift left operator `<<{:tact}`](#binary-bitwise-shift-left). Can only be applied to values of type [`Int{:tact}`][int]. Available since Tact 1.6.
+* `>>={:tact}`, which uses the [bitwise shift right operator `>>{:tact}`](#binary-bitwise-shift-right). Can only be applied to values of type [`Int{:tact}`][int]. Available since Tact 1.6.
 
 ```tact
 let value: Int = 5;
@@ -686,6 +690,32 @@ value ^= 5;        // also bitwise XORs with 5 and assigns result back
 value | 5;         // bitwise ORs with 5
 value = value | 5; // bitwise ORs with 5 and assigns result back
 value |= 5;        // also bitwise ORs with 5 and assigns result back
+
+//
+// The following augmented assignment operators are available since Tact 1.6
+//
+
+// <<=
+value << 5;         // bitwise shifts left by 5
+value = value << 5; // bitwise shifts left by 5 and assigns result back
+value <<= 5;        // also bitwise shifts left by 5 and assigns result back
+
+// >>=
+value >> 5;         // bitwise shifts right by 5
+value = value >> 5; // bitwise shifts right by 5 and assigns result back
+value >>= 5;        // also bitwise shifts right by 5 and assigns result back
+
+let bValue: Bool = true;
+
+// &&=
+bValue && false;          // logically ANDs with false
+bValue = bValue && false; // logically ANDs with false and assigns result back
+bValue &&= false;         // also logically ANDs with false and assigns result back
+
+// ||=
+bValue || true;          // logically ORs with true
+bValue = bValue || true; // logically ORs with true and assigns result back
+bValue ||= true;         // also logically ORs with true and assigns result back
 ```
 
 [p]: /book/types#primitive-types

--- a/docs/src/content/docs/book/types.mdx
+++ b/docs/src/content/docs/book/types.mdx
@@ -32,8 +32,8 @@ The primitive type `Bool{:tact}` is the classical boolean type, which can hold o
 
 There are no implicit type conversions in Tact, so addition ([`+{:tact}`](/book/operators#binary-add)) of two boolean values is not possible. However, many comparison [operators](/book/operators) are available, such as:
 
-* `&&{:tact}` for [logical AND](/book/operators#binary-logical-and),
-* `||{:tact}` for [logical OR](/book/operators#binary-logical-or),
+* `&&{:tact}` for [logical AND](/book/operators#binary-logical-and) with its [augmented assignment version `&&={:tact}`](/book/operators#augmented-assignment),
+* `||{:tact}` for [logical OR](/book/operators#binary-logical-or) with its [augmented assignment version `||={:tact}`](/book/operators#augmented-assignment),
 * `!{:tact}` for [logical inversion](/book/operators#unary-inverse),
 * `=={:tact}` and `!={:tact}` for checking [equality](/book/operators#binary-equality),
 * and `!!{:tact}` for [non-null assertion](/book/optionals).


### PR DESCRIPTION
## Issue

Closes #2276.
