### PR TITLE
docs(WIP / DRAFT!): web versions of some of the whitepapers

### DIFF
--- a/dev-docs/CHANGELOG.md
+++ b/dev-docs/CHANGELOG.md
@@ -9,7 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Docs
 
-- Add descriptions for `&&=`, `||=`, `>>=` and `<<=` augmented assignment operators: PR [#2328](https://github.com/tact-lang/tact/pull/2328)
+- Added descriptions for `&&=`, `||=`, `>>=` and `<<=` augmented assignment operators: PR [#2328](https://github.com/tact-lang/tact/pull/2328)
+- Converted some of the TON whitepapers to `.mdx` and added a new Whitepapers section: PR [#TBD](https://github.com/tact-lang/tact/pull/TBD)
 
 ### Release contributors
 

--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -300,6 +300,17 @@ export default defineConfig({
 					],
 				},
 				{
+					label: 'Whitepapers',
+					translations: {
+						'zh-CN': '白皮书',
+					},
+					items: [
+						{ slug: 'whitepapers' },
+						{ slug: 'whitepapers/tvm' },
+						// { slug: 'whitepapers/tblkch' }, // TODO
+					],
+				},
+				{
 					label: '⭐ Awesome Tact →',
 					link: 'https://github.com/tact-lang/awesome-tact',
 				},

--- a/docs/src/content/docs/whitepapers/index.mdx
+++ b/docs/src/content/docs/whitepapers/index.mdx
@@ -1,0 +1,25 @@
+---
+title: Whitepapers
+description: "Whitepapers section — a collection of official TON Blockchain whitepapers transformed for convenient online use."
+---
+
+import { CardGrid, LinkCard, Steps } from '@astrojs/starlight/components';
+
+Welcome to the **Whitepapers** section — a collection of official TON Blockchain whitepapers transformed for convenient online use.
+
+Here are its main contents:
+
+<Steps>
+
+1. #### TON Virtual Machine (TVM) {#tvm}
+
+   All smart contracts on TON are executed via TON Virtual Machine (TVM), a stack-oriented virtual machine that operates on distinct data types, such as cells or tuples.
+
+   <CardGrid>
+     <LinkCard
+       title="TON Virtual Machine (TVM)"
+       href="/whitepapers/tvm"
+     />
+   </CardGrid>
+
+</Steps>

--- a/docs/src/content/docs/whitepapers/tvm.mdx
+++ b/docs/src/content/docs/whitepapers/tvm.mdx
@@ -1,0 +1,5599 @@
+---
+title: TON Virtual Machine (TVM)
+description: "This text aims to describe the TON Virtual Machine (TON VM or TVM) used to execute smart contracts in the TON Blockchain. It was written by Nikolai Durov on March 23, 2020."
+---
+
+The primary purpose of the The Open Network Virtual Machine (TON VM or
+TVM) is to execute smart-contract code in the TON Blockchain. TVM must support
+all operations required to parse incoming messages and persistent data, and to
+create new messages and modify persistent data.
+
+Additionally, TVM must meet the following requirements:
+
+  * It must provide for possible future extensions and improvements while retaining backward compatibility and interoperability, because the code of a smart contract, once committed into the blockchain, must continue working in a predictable manner regardless of any future modifications to the VM.
+
+  * It must strive to attain high “(virtual) machine code” density, so that the code of a typical smart contract occupies as little persistent blockchain storage as possible.
+
+  * It must be completely deterministic. In other words, each run of the same code with the same input data must produce the same result, regardless of specific software and hardware used.[^1]
+
+The design of TVM is guided by these requirements. While this document
+describes a preliminary and experimental version of TVM,2 the backward
+compatibility mechanisms built into the system allow us to be relatively
+unconcerned with the efficiency of the operation encoding used for TVM code in
+this preliminary version.
+
+TVM is not intended to be implemented in hardware (e.g., in a specialized
+microprocessor chip); rather, it should be implemented in software running on
+conventional hardware. This consideration lets us incorporate some high-level
+concepts and operations in TVM that would require convoluted microcode in a
+hardware implementation but pose no significant problems for a software
+implementation. Such operations are useful for achieving high code density and
+minimizing the byte (or storage cell) profile of smart-contract code when
+deployed in the TON Blockchain.
+
+# Overview
+
+This chapter provides an overview of the main features and design principles
+of TVM. More detail on each topic is provided in subsequent chapters.
+
+## Notation for bitstrings
+
+[p:bitstring.hex] The following notation is used for bit strings (or
+_bitstrings_ )—i.e., finite strings consisting of binary digits (bits), `0`
+and `1`—throughout this document.
+
+**Hexadecimal notation for bitstrings.** When the length of a bitstring is a
+multiple of four, we subdivide it into groups of four bits and represent each
+group by one of sixteen hexadecimal digits `0`–`9`, `A`–`F` in the usual
+manner: `0`16 ↔︎ `0000`, `1`16 ↔︎ `0001`, …, `F`16 ↔︎ `1111`. The resulting
+hexadecimal string is our equivalent representation for the original binary
+string.
+
+**Bitstrings of lengths not divisible by four.** If the length of a binary
+string is not divisible by four, we augment it by one `1` and several (maybe
+zero) `0`s at the end, so that its length becomes divisible by four, and then
+transform it into a string of hexadecimal digits as described above. To
+indicate that such a transformation has taken place, a special “completion
+tag” `_` is added to the end of the hexadecimal string. The reverse
+transformation (applied if the completion tag is present) consists in first
+replacing each hexadecimal digit by four corresponding bits, and then removing
+all trailing zeroes (if any) and the last `1` immediately preceding them (if
+the resulting bitstring is non-empty at this point).
+
+Notice that there are several admissible hexadecimal representations for the
+same bitstring. Among them, the shortest one is “canonical”. It can be
+deterministically obtained by the above procedure.
+
+For example, `8A` corresponds to binary string `10001010`, while `8A_` and
+`8A0_` both correspond to `100010`. An empty bitstring may be represented by
+either ‘’, ‘`8_`’, ‘`0_`’, ‘`_`’, or ‘`00_`’.
+
+[sp:hex.bitst] **Emphasizing that a string is a hexadecimal representation of
+a bitstring.** Sometimes we need to emphasize that a string of hexadecimal
+digits (with or without a `_` at the end) is the hexadecimal representation of
+a bitstring. In such cases, we either prepend `x` to the resulting string
+(e.g., `x8A`), or prepend `x{` and append `}` (e.g., `x{2D9_}`, which is
+`00101101100`). This should not be confused with hexadecimal numbers, usually
+prepended by `0x` (e.g., `0x2D9` or `0x2d9`, which is the integer 729).
+
+**Serializing a bitstring into a sequence of octets.** When a bitstring needs
+to be represented as a sequence of 8-bit bytes (octets), which take values in
+integers 0…255, this is achieved essentially in the same fashion as above: we
+split the bitstring into groups of eight bits and interpret each group as the
+binary representation of an integer 0…255. If the length of the bitstring is
+not a multiple of eight, the bitstring is augmented by a binary `1` and up to
+seven binary `0`s before being split into groups. The fact that such a
+completion has been applied is usually reflected by a “completion tag” bit.
+
+For instance, `00101101100` corresponds to the sequence of two octets (`0x2d`,
+`0x90`) (hexadecimal), or (45, 144) (decimal), along with a completion tag bit
+equal to `1` (meaning that the completion has been applied), which must be
+stored separately.
+
+In some cases, it is more convenient to assume the completion is enabled by
+default rather than store an additional completion tag bit separately. Under
+such conventions, 8 _n_ -bit strings are represented by _n_ \+ 1 octets, with
+the last octet always equal to `0x80` = 128.
+
+## TVM is a stack machine
+
+[p:tvm.stack] First of all, _TVM is a stack machine._ This means that, instead
+of keeping values in some “variables” or “general-purpose registers”, they are
+kept in a (LIFO) _stack_ , at least from the “low-level” (TVM) perspective.3
+
+Most operations and user-defined functions take their arguments from the top
+of the stack, and replace them with their result. For example, the integer
+addition primitive (built-in operation) `ADD` does not take any arguments
+describing which registers or immediate values should be added together and
+where the result should be stored. Instead, the two top values are taken from
+the stack, they are added together, and their sum is pushed into the stack in
+their place.
+
+[sp:tvm.val] **TVM values.** The entities that can be stored in the TVM stack
+will be called _TVM values_ , or simply _values_ for brevity. They belong to
+one of several predefined _value types_. Each value belongs to exactly one
+value type. The values are always kept on the stack along with tags uniquely
+determining their types, and all built-in TVM operations (or _primitives_ )
+only accept values of predefined types.
+
+For example, the integer addition primitive `ADD` accepts only two integer
+values, and returns one integer value as a result. One cannot supply `ADD`
+with two strings instead of two integers expecting it to concatenate these
+strings or to implicitly transform the strings into their decimal integer
+values; any attempt to do so will result in a run-time type-checking
+exception.
+
+**Static typing, dynamic typing, and run-time type checking.** In some
+respects TVM performs a kind of dynamic typing using run-time type checking.
+However, this does not make the TVM code a “dynamically typed language” like
+PHP or Javascript, because all primitives accept values and return results of
+predefined (value) types, each value belongs to strictly one type, and values
+are never implicitly converted from one type to another. If, on the other
+hand, one compares the TVM code to the conventional microprocessor machine
+code, one sees that the TVM mechanism of value tagging prevents, for example,
+using the address of a string as a number—or, potentially even more
+disastrously, using a number as the address of a string—thus eliminating the
+possibility of all sorts of bugs and security vulnerabilities related to
+invalid memory accesses, usually leading to memory corruption and segmentation
+faults. This property is highly desirable for a VM used to execute smart
+contracts in a blockchain. In this respect, TVM’s insistence on tagging all
+values with their appropriate types, instead of reinterpreting the bit
+sequence in a register depending on the needs of the operation it is used in,
+is just an additional run-time type-safety mechanism.
+
+An alternative would be to somehow analyze the smart-contract code for type
+correctness and type safety before allowing its execution in the VM, or even
+before allowing it to be uploaded into the blockchain as the code of a smart
+contract. Such a static analysis of code for a Turing-complete machine appears
+to be a time-consuming and non-trivial problem (likely to be equivalent to the
+stopping problem for Turing machines), something we would rather avoid in a
+blockchain smart-contract context.
+
+One should bear in mind that one always can implement compilers from
+statically typed high-level smart-contract languages into the TVM code (and we
+do expect that most smart contracts for TON will be written in such
+languages), just as one can compile statically typed languages into
+conventional machine code (e.g., x86 architecture). If the compiler works
+correctly, the resulting machine code will never generate any run-time type-
+checking exceptions. All type tags attached to values processed by TVM will
+always have expected values and may be safely ignored during the analysis of
+the resulting TVM code, apart from the fact that the run-time generation and
+verification of these type tags by TVM will slightly slow down the execution
+of the TVM code.
+
+[sp:val.types] **Preliminary list of value types.** A preliminary list of
+value types supported by TVM is as follows:
+
+  * _Integer_ — Signed 257-bit integers, representing integer numbers in the range  − 2256…2256 − 1, as well as a special “not-a-number” value `NaN`.
+
+  * _Cell_ — A _TVM cell_ consists of at most 1023 bits of data, and of at most four references to other cells. All persistent data (including TVM code) in the TON Blockchain is represented as a collection of TVM cells (cf. ).
+
+  * _Tuple_ — An ordered collection of up to 255 components, having arbitrary value types, possibly distinct. May be used to represent non-persistent values of arbitrary algebraic data types.
+
+  * _Null_ — A type with exactly one value ⊥, used for representing empty lists, empty branches of binary trees, absence of return value in some situations, and so on.
+
+  * _Slice_ — A _TVM cell slice_ , or _slice_ for short, is a contiguous “sub-cell” of an existing cell, containing some of its bits of data and some of its references. Essentially, a slice is a read-only view for a subcell of a cell. Slices are used for unpacking data previously stored (or serialized) in a cell or a tree of cells.
+
+  * _Builder_ — A _TVM cell builder_ , or _builder_ for short, is an “incomplete” cell that supports fast operations of appending bitstrings and cell references at its end. Builders are used for packing (or serializing) data from the top of the stack into new cells (e.g., before transferring them to persistent storage).
+
+  * _Continuation_ — Represents an “execution token” for TVM, which may be invoked (executed) later. As such, it generalizes function addresses (i.e., function pointers and references), subroutine return addresses, instruction pointer addresses, exception handler addresses, closures, partial applications, anonymous functions, and so on.
+
+This list of value types is incomplete and may be extended in future revisions
+of TVM without breaking the old TVM code, due mostly to the fact that all
+originally defined primitives accept only values of types known to them and
+will fail (generate a type-checking exception) if invoked on values of new
+types. Furthermore, existing value types themselves can also be extended in
+the future: for example, 257-bit _Integer_ might become 513-bit _LongInteger_
+, with originally defined arithmetic primitives failing if either of the
+arguments or the result does not fit into the original subtype _Integer_.
+Backward compatibility with respect to the introduction of new value types and
+extension of existing value types will be discussed in more detail later (cf.
+).
+
+## Categories of TVM instructions
+
+TVM _instructions_ , also called _primitives_ and sometimes _(built-in)
+operations_ , are the smallest operations atomically performed by TVM that can
+be present in the TVM code. They fall into several categories, depending on
+the types of values (cf. ) they work on. The most important of these
+categories are:
+
+  * _Stack (manipulation) primitives_ — Rearrange data in the TVM stack, so that the other primitives and user-defined functions can later be called with correct arguments. Unlike most other primitives, they are polymorphic, i.e., work with values of arbitrary types.
+
+  * _Tuple (manipulation) primitives_ — Construct, modify, and decompose _Tuple_ s. Similarly to the stack primitives, they are polymorphic.
+
+  * _Constant_ or _literal primitives_ — Push into the stack some “constant” or “literal” values embedded into the TVM code itself, thus providing arguments to the other primitives. They are somewhat similar to stack primitives, but are less generic because they work with values of specific types.
+
+  * _Arithmetic primitives_ — Perform the usual integer arithmetic operations on values of type _Integer_.
+
+  * _Cell (manipulation) primitives_ — Create new cells and store data in them ( _cell creation primitives_ ) or read data from previously created cells ( _cell parsing primitives_ ). Because all memory and persistent storage of TVM consists of cells, these cell manipulation primitives actually correspond to “memory access instructions” of other architectures. Cell creation primitives usually work with values of type _Builder_ , while cell parsing primitives work with _Slice_ s.
+
+  * _Continuation_ and _control flow primitives_ — Create and modify _Continuation_ s, as well as execute existing _Continuation_ s in different ways, including conditional and repeated execution.
+
+  * _Custom_ or _application-specific primitives_ — Efficiently perform specific high-level actions required by the application (in our case, the TON Blockchain), such as computing hash functions, performing elliptic curve cryptography, sending new blockchain messages, creating new smart contracts, and so on. These primitives correspond to standard library functions rather than microprocessor instructions.
+
+## Control registers
+
+While TVM is a stack machine, some rarely changed values needed in almost all
+functions are better passed in certain special registers, and not near the top
+of the stack. Otherwise, a prohibitive number of stack reordering operations
+would be required to manage all these values.
+
+To this end, the TVM model includes, apart from the stack, up to 16 special
+_control registers_ , denoted by `c0` to `c15`, or `c`(0) to `c`(15). The
+original version of TVM makes use of only some of these registers; the rest
+may be supported later.
+
+**Values kept in control registers.** The values kept in control registers are
+of the same types as those kept on the stack. However, some control registers
+accept only values of specific types, and any attempt to load a value of a
+different type will lead to an exception.
+
+[sp:cr.list] **List of control registers.** The original version of TVM
+defines and uses the following control registers:
+
+  * `c0` — Contains the _next continuation_ or _return continuation_ (similar to the subroutine return address in conventional designs). This value must be a _Continuation_.
+
+  * `c1` — Contains the _alternative (return) continuation_ ; this value must be a _Continuation_. It is used in some (experimental) control flow primitives, allowing TVM to define and call “subroutines with two exit points”.
+
+  * `c2` — Contains the _exception handler_. This value is a _Continuation_ , invoked whenever an exception is triggered.
+
+  * `c3` — Contains the _current dictionary_ , essentially a hashmap containing the code of all functions used in the program. For reasons explained later in , this value is also a _Continuation_ , not a _Cell_ as one might expect.
+
+  * `c4` — Contains the _root of persistent data_ , or simply the _data_. This value is a _Cell_. When the code of a smart contract is invoked, `c4` points to the root cell of its persistent data kept in the blockchain state. If the smart contract needs to modify this data, it changes `c4` before returning.
+
+  * `c5` — Contains the _output actions_. It is also a _Cell_ initialized by a reference to an empty cell, but its final value is considered one of the smart contract outputs. For instance, the `SENDMSG` primitive, specific for the TON Blockchain, simply inserts the message into a list stored in the output actions.
+
+  * `c7` — Contains the _root of temporary data_. It is a _Tuple_ , initialized by a reference to an empty _Tuple_ before invoking the smart contract and discarded after its termination.4
+
+More control registers may be defined in the future for specific TON
+Blockchain or high-level programming language purposes, if necessary.
+
+## Total state of TVM (SCCCG)
+
+[p:tvm.state] The total state of TVM consists of the following components:
+
+  * _Stack_ (cf. ) — Contains zero or more _values_ (cf. ), each belonging to one of _value types_ listed in .
+
+  * _Control registers`c0`–`c15`_ — Contain some specific values as described in . (Only seven control registers are used in the current version.)
+
+  * _Current continuation`cc`_ — Contains the current continuation (i.e., the code that would be normally executed after the current primitive is completed). This component is similar to the instruction pointer register (`ip`) in other architectures.
+
+  * _Current codepage`cp`_ — A special signed 16-bit integer value that selects the way the next TVM opcode will be decoded. For example, future versions of TVM might use different codepages to add new opcodes while preserving backward compatibility.
+
+  * _Gas limits`gas`_ — Contains four signed 64-bit integers: the current gas limit _g_ _l_ , the maximal gas limit _g_ _m_ , the remaining gas _g_ _r_ , and the gas credit _g_ _c_. Always 0 ≤ _g_ _l_ ≤ _g_ _m_ , _g_ _c_ ≥ 0, and _g_ _r_ ≤ _g_ _l_ \+ _g_ _c_ ; _g_ _c_ is usually initialized by zero, _g_ _r_ is initialized by _g_ _l_ \+ _g_ _c_ and gradually decreases as the TVM runs. When _g_ _r_ becomes negative or if the final value of _g_ _r_ is less than _g_ _c_ , an _out of gas_ exception is triggered.
+
+Notice that there is no “return stack” containing the return addresses of all
+previously called but unfinished functions. Instead, only control register
+`c0` is used. The reason for this will be explained later in .
+
+Also notice that there are no general-purpose registers, because TVM is a
+stack machine (cf. ). So the above list, which can be summarized as “stack,
+control, continuation, codepage, and gas” (SCCCG), similarly to the classical
+SECD machine state (“stack, environment, control, dump”), is indeed the
+_total_ state of TVM.5
+
+## Integer arithmetic
+
+All arithmetic primitives of TVM operate on several arguments of type
+_Integer_ , taken from the top of the stack, and return their results, of the
+same type, into the stack. Recall that _Integer_ represents all integer values
+in the range  − 2256 ≤ _x_ < 2256, and additionally contains a special value
+`NaN` (“not-a-number”).
+
+If one of the results does not fit into the supported range of integers—or if
+one of the arguments is a `NaN`—then this result or all of the results are
+replaced by a `NaN`, and (by default) an integer overflow exception is
+generated. However, special “quiet” versions of arithmetic operations will
+simply produce `NaN`s and keep going. If these `NaN`s end up being used in a
+“non-quiet” arithmetic operation, or in a non-arithmetic operation, an integer
+overflow exception will occur.
+
+[sp:int.no.autoconv] **Absence of automatic conversion of integers.** Notice
+that TVM _Integer_ s are “mathematical” integers, and not 257-bit strings
+interpreted differently depending on the primitive used, as is common for
+other machine code designs. For example, TVM has only one multiplication
+primitive `MUL`, rather than two (`MUL` for unsigned multiplication and `IMUL`
+for signed multiplication) as occurs, for example, in the popular x86
+architecture.
+
+**Automatic overflow checks.** Notice that all TVM arithmetic primitives
+perform overflow checks of the results. If a result does not fit into the
+_Integer_ type, it is replaced by a `NaN`, and (usually) an exception occurs.
+In particular, the result is _not_ automatically reduced modulo 2256 or 2257,
+as is common for most hardware machine code architectures.
+
+**Custom overflow checks.** In addition to automatic overflow checks, TVM
+includes custom overflow checks, performed by primitives `FITS` _n_ and
+`UFITS` _n_ , where 1 ≤ _n_ ≤ 256. These primitives check whether the value on
+(the top of) the stack is an integer _x_ in the range  − 2 _n_ − 1 ≤ _x_ < 2
+_n_ − 1 or 0 ≤ _x_ < 2 _n_ , respectively, and replace the value with a `NaN`
+and (optionally) generate an integer overflow exception if this is not the
+case. This greatly simplifies the implementation of arbitrary _n_ -bit integer
+types, signed or unsigned: the programmer or the compiler must insert
+appropriate `FITS` or `UFITS` primitives either after each arithmetic
+operation (which is more reasonable, but requires more checks) or before
+storing computed values and returning them from functions. This is important
+for smart contracts, where unexpected integer overflows happen to be among the
+most common source of bugs.
+
+**Reduction modulo 2 _n_.** TVM also has a primitive `MODPOW2` _n_ , which
+reduces the integer at the top of the stack modulo 2 _n_ , with the result
+ranging from 0 to 2 _n_ − 1.
+
+**_Integer_ is 257-bit, not 256-bit.** One can understand now why TVM’s
+_Integer_ is (signed) 257-bit, not 256-bit. The reason is that it is the
+smallest integer type containing both signed 256-bit integers and unsigned
+256-bit integers, which does not require automatic reinterpreting of the same
+256-bit string depending on the operation used (cf. ).
+
+[sp:div.round] **Division and rounding.** The most important division
+primitives are `DIV`, `MOD`, and `DIVMOD`. All of them take two numbers from
+the stack, _x_ and _y_ ( _y_ is taken from the top of the stack, and _x_ is
+originally under it), compute the quotient _q_ and remainder _r_ of the
+division of _x_ by _y_ (i.e., two integers such that _x_ = _y_ _q_ \+ _r_ and
+| _r_ | < | _y_ |), and return either _q_ , _r_ , or both of them. If _y_ is
+zero, then all of the expected results are replaced by `NaN`s, and (usually)
+an integer overflow exception is generated.
+
+The implementation of division in TVM somewhat differs from most other
+implementations with regards to rounding. By default, these primitives round
+to  − ∞, meaning that _q_ = ⌊ _x_ / _y_ ⌋, and _r_ has the same sign as _y_.
+(Most conventional implementations of division use “rounding to zero” instead,
+meaning that _r_ has the same sign as _x_.) Apart from this “floor rounding”,
+two other rounding modes are available, called “ceiling rounding” (with _q_ =
+⌈ _x_ / _y_ ⌉, and _r_ and _y_ having opposite signs) and “nearest rounding”
+(with _q_ = ⌊ _x_ / _y_ \+ 1/2⌋ and | _r_ | ≤ | _y_ |/2). These rounding modes
+are selected by using other division primitives, with letters `C` and `R`
+appended to their mnemonics. For example, `DIVMODR` computes both the quotient
+and the remainder using rounding to the nearest integer.
+
+**Combined multiply-divide, multiply-shift, and shift-divide operations.** To
+simplify implementation of fixed-point arithmetic, TVM supports combined
+multiply-divide, multiply-shift, and shift-divide operations with double-
+length (i.e., 514-bit) intermediate product. For example, `MULDIVMODR` takes
+three integer arguments from the stack, _a_ , _b_ , and _c_ , first computes
+_a_ _b_ using a 514-bit intermediate result, and then divides _a_ _b_ by _c_
+using rounding to the nearest integer. If _c_ is zero or if the quotient does
+not fit into _Integer_ , either two `NaN`s are returned, or an integer
+overflow exception is generated, depending on whether a quiet version of the
+operation has been used. Otherwise, both the quotient and the remainder are
+pushed into the stack.
+
+# The stack
+
+This chapter contains a general discussion and comparison of register and
+stack machines, expanded further in Appendix , and describes the two main
+classes of stack manipulation primitives employed by TVM: the _basic_ and the
+_compound stack manipulation primitives_. An informal explanation of their
+sufficiency for all stack reordering required for correctly invoking other
+primitives and user-defined functions is also provided. Finally, the problem
+of efficiently implementing TVM stack manipulation primitives is discussed in
+.
+
+## Stack calling conventions
+
+[p:stack.conv] A stack machine, such as TVM, uses the stack—and especially the
+values near the top of the stack—to pass arguments to called functions and
+primitives (such as built-in arithmetic operations) and receive their results.
+This section discusses the TVM stack calling conventions, introduces some
+notation, and compares TVM stack calling conventions with those of certain
+register machines.
+
+**Notation for “stack registers”.** Recall that a stack machine, as opposed to
+a more conventional register machine, lacks general-purpose registers.
+However, one can treat the values near the top of the stack as a kind of
+“stack registers”.
+
+We denote by `s0` or `s`(0) the value at the top of the stack, by `s1` or
+`s`(1) the value immediately under it, and so on. The total number of values
+in the stack is called its _depth_. If the depth of the stack is _n_ , then
+`s`(0), `s`(1), …, `s`( _n_ − 1) are well-defined, while `s`( _n_ ) and all
+subsequent `s`( _i_ ) with _i_ > _n_ are not. Any attempt to use `s`( _i_ )
+with _i_ ≥ _n_ should produce a stack underflow exception.
+
+A compiler, or a human programmer in “TVM code”, would use these “stack
+registers” to hold all declared variables and intermediate values, similarly
+to the way general-purpose registers are used on a register machine.
+
+**Pushing and popping values.** When a value _x_ is _pushed_ into a stack of
+depth _n_ , it becomes the new `s0`; at the same time, the old `s0` becomes
+the new `s1`, the old `s1`—the new `s2`, and so on. The depth of the resulting
+stack is _n_ \+ 1.
+
+Similarly, when a value _x_ is _popped_ from a stack of depth _n_ ≥ 1, it is
+the old value of `s0` (i.e., the old value at the top of the stack). After
+this, it is removed from the stack, and the old `s1` becomes the new `s0` (the
+new value at the top of the stack), the old `s2` becomes the new `s1`, and so
+on. The depth of the resulting stack is _n_ − 1.
+
+If originally _n_ = 0, then the stack is _empty_ , and a value cannot be
+popped from it. If a primitive attempts to pop a value from an empty stack, a
+_stack underflow_ exception occurs.
+
+**Notation for hypothetical general-purpose registers.** In order to compare
+stack machines with sufficiently general register machines, we will denote the
+general-purpose registers of a register machine by `r0`, `r1`, and so on, or
+by `r`(0), `r`(1), …, `r`( _n_ − 1), where _n_ is the total number of
+registers. When we need a specific value of _n_ , we will use _n_ = 16,
+corresponding to the very popular x86-64 architecture.
+
+**The top-of-stack register`s0` vs. the accumulator register `r0`.** Some
+register machine architectures require one of the arguments for most
+arithmetic and logical operations to reside in a special register called the
+_accumulator_. In our comparison, we will assume that the accumulator is the
+general-purpose register `r0`; otherwise we could simply renumber the
+registers. In this respect, the accumulator is somewhat similar to the top-of-
+stack “register” `s0` of a stack machine, because virtually all operations of
+a stack machine both use `s0` as one of their arguments and return their
+result as `s0`.
+
+**Register calling conventions.** When compiled for a register machine, high-
+level language functions usually receive their arguments in certain registers
+in a predefined order. If there are too many arguments, these functions take
+the remainder from the stack (yes, a register machine usually has a stack,
+too!). Some register calling conventions pass no arguments in registers at
+all, however, and only use the stack (for example, the original calling
+conventions used in implementations of Pascal and C, although modern
+implementations of C use some registers as well).
+
+For simplicity, we will assume that up to _m_ ≤ _n_ function arguments are
+passed in registers, and that these registers are `r0`, `r1`, …, `r`( _m_ −
+1), in that order (if some other registers are used, we can simply renumber
+them).6
+
+[sp:func.arg.ord] **Order of function arguments.** If a function or primitive
+requires _m_ arguments _x_ 1, …, _x_ _m_ , they are pushed by the caller into
+the stack in the same order, starting from _x_ 1. Therefore, when the function
+or primitive is invoked, its first argument _x_ 1 is in `s`( _m_ − 1), its
+second argument _x_ 2 is in `s`( _m_ − 2), and so on. The last argument _x_
+_m_ is in `s0` (i.e., at the top of the stack). It is the called function or
+primitive’s responsibility to remove its arguments from the stack.
+
+In this respect the TVM stack calling conventions—obeyed, at least, by TMV
+primitives—match those of Pascal and Forth, and are the opposite of those of C
+(in which the arguments are pushed into the stack in the reverse order, and
+are removed by the caller after it regains control, not the callee).
+
+Of course, an implementation of a high-level language for TVM might choose
+some other calling conventions for its functions, different from the default
+ones. This might be useful for certain functions—for instance, if the total
+number of arguments depends on the value of the first argument, as happens for
+“variadic functions” such as `scanf` and `printf`. In such cases, the first
+one or several arguments are better passed near the top of the stack, not
+somewhere at some unknown location deep in the stack.
+
+[sp:reg.op.arg] **Arguments to arithmetic primitives on register machines.**
+On a stack machine, built-in arithmetic primitives (such as `ADD` or `DIVMOD`)
+follow the same calling conventions as user-defined functions. In this
+respect, user-defined functions (for example, a function computing the square
+root of a number) might be considered as “extensions” or “custom upgrades” of
+the stack machine. This is one of the clearest advantages of stack machines
+(and of stack programming languages such as Forth) compared to register
+machines.
+
+In contrast, arithmetic instructions (built-in operations) on register
+machines usually get their parameters from general-purpose registers encoded
+in the full opcode. A binary operation, such as `SUB`, thus requires two
+arguments, `r`( _i_ ) and `r`( _j_ ), with _i_ and _j_ specified by the
+instruction. A register `r`( _k_ ) for storing the result also must be
+specified. Arithmetic operations can take several possible forms, depending on
+whether _i_ , _j_ , and _k_ are allowed to take arbitrary values:
+
+  * Three-address form — Allows the programmer to arbitrarily choose not only the two source registers `r`( _i_ ) and `r`( _j_ ), but also a separate destination register `r`( _k_ ). This form is common for most RISC processors, and for the XMM and AVX SIMD instruction sets in the x86-64 architecture.
+
+  * Two-address form — Uses one of the two operand registers (usually `r`( _i_ )) to store the result of an operation, so that _k_ = _i_ is never indicated explicitly. Only _i_ and _j_ are encoded inside the instruction. This is the most common form of arithmetic operations on register machines, and is quite popular on microprocessors (including the x86 family).
+
+  * One-address form — Always takes one of the arguments from the accumulator `r0`, and stores the result in `r0` as well; then _i_ = _k_ = 0, and only _j_ needs to be specified by the instruction. This form is used by some simpler microprocessors (such as Intel 8080).
+
+Note that this flexibility is available only for built-in operations, but not
+for user-defined functions. In this respect, register machines are not as
+easily “upgradable” as stack machines.7
+
+**Return values of functions.** In stack machines such as TVM, when a function
+or primitive needs to return a result value, it simply pushes it into the
+stack (from which all arguments to the function have already been removed).
+Therefore, the caller will be able to access the result value through the top-
+of-stack “register” `s0`.
+
+This is in complete accordance with Forth calling conventions, but differs
+slightly from Pascal and C calling conventions, where the accumulator register
+`r0` is normally used for the return value.
+
+**Returning several values.** Some functions might want to return several
+values _y_ 1, …, _y_ _k_ , with _k_ not necessarily equal to one. In these
+cases, the _k_ return values are pushed into the stack in their natural order,
+starting from _y_ 1.
+
+For example, the “divide with remainder” primitive `DIVMOD` needs to return
+two values, the quotient _q_ and the remainder _r_. Therefore, `DIVMOD` pushes
+_q_ and _r_ into the stack, in that order, so that the quotient is available
+thereafter at `s1` and the remainder at `s0`. The net effect of `DIVMOD` is to
+divide the original value of `s1` by the original value of `s0`, and return
+the quotient in `s1` and the remainder in `s0`. In this particular case the
+depth of the stack and the values of all other “stack registers” remain
+unchanged, because `DIVMOD` takes two arguments and returns two results. In
+general, the values of other “stack registers” that lie in the stack below the
+arguments passed and the values returned are shifted according to the change
+of the depth of the stack.
+
+In principle, some primitives and user-defined functions might return a
+variable number of result values. In this respect, the remarks above about
+variadic functions (cf. ) apply: the total number of result values and their
+types should be determined by the values near the top of the stack. (For
+example, one might push the return values _y_ 1, …, _y_ _k_ , and then push
+their total number _k_ as an integer. The caller would then determine the
+total number of returned values by inspecting `s0`.)
+
+In this respect TVM, again, faithfully observes Forth calling conventions.
+
+[sp:stack.notat] **Stack notation.** When a stack of depth _n_ contains values
+_z_ 1, …, _z_ _n_ , in that order, with _z_ 1 the deepest element and _z_ _n_
+the top of the stack, the contents of the stack are often represented by a
+list _z_ 1 _z_ 2 … _z_ _n_ , in that order. When a primitive transforms the
+original stack state _S_ ′ into a new state _S_ ″, this is often written as
+_S_ ′ – _S_ ″; this is the so-called _stack notation_. For example, the action
+of the division primitive `DIV` can be described by _S_ _x_ _y_ – _S_ ⌊ _x_ /
+_y_ ⌋, where _S_ is any list of values. This is usually abbreviated as _x_ _y_
+– ⌊ _x_ / _y_ ⌋, tacitly assuming that all other values deeper in the stack
+remain intact.
+
+Alternatively, one can describe `DIV` as a primitive that runs on a stack _S_
+′ of depth _n_ ≥ 2, divides `s1` by `s0`, and returns the floor-rounded
+quotient as `s0` of the new stack _S_ ″ of depth _n_ − 1. The new value of
+`s`( _i_ ) equals the old value of `s`( _i_ \+ 1) for 1 ≤ _i_ < _n_ − 1. These
+descriptions are equivalent, but saying that `DIV` transforms _x_ _y_ into ⌊
+_x_ / _y_ ⌋, or … _x_ _y_ into …⌊ _x_ / _y_ ⌋, is more concise.
+
+The stack notation is extensively used throughout Appendix , where all
+currently defined TVM primitives are listed.
+
+**Explicitly defining the number of arguments to a function.** Stack machines
+usually pass the current stack in its entirety to the invoked primitive or
+function. That primitive or function accesses only the several values near the
+top of the stack that represent its arguments, and pushes the return values in
+their place, by convention leaving all deeper values intact. Then the
+resulting stack, again in its entirety, is returned to the caller.
+
+Most TVM primitives behave in this way, and we expect most user-defined
+functions to be implemented under such conventions. However, TVM provides
+mechanisms to specify how many arguments must be passed to a called function
+(cf. ). When these mechanisms are employed, the specified number of values are
+moved from the caller’s stack into the (usually initially empty) stack of the
+called function, while deeper values remain in the caller’s stack and are
+inaccessible to the callee. The caller can also specify how many return values
+it expects from the called function.
+
+Such argument-checking mechanisms might be useful, for example, for a library
+function that calls user-provided functions passed as arguments to it.
+
+## Stack manipulation primitives
+
+[p:stack.manip] A stack machine, such as TVM, employs a lot of stack
+manipulation primitives to rearrange arguments to other primitives and user-
+defined functions, so that they become located near the top of the stack in
+correct order. This section discusses which stack manipulation primitives are
+necessary and sufficient for achieving this goal, and which of them are used
+by TVM. Some examples of code using these primitives can be found in Appendix
+.
+
+[sp:stack.basic] **Basic stack manipulation primitives.** The most important
+stack manipulation primitives used by TVM are the following:
+
+  * _Top-of-stack exchange operation_ : `XCHG s0,s(i)` or `XCHG s(i)` — Exchanges values of `s0` and `s`( _i_ ). When _i_ = 1, operation `XCHG s1` is traditionally denoted by `SWAP`. When _i_ = 0, this is a `NOP` (an operation that does nothing, at least if the stack is non-empty).
+
+  * _Arbitrary exchange operation_ : `XCHG s(i),s(j)` — Exchanges values of `s`( _i_ ) and `s`( _j_ ). Notice that this operation is not strictly necessary, because it can be simulated by three top-of-stack exchanges: `XCHG s(i)`; `XCHG s(j)`; `XCHG s(i)`. However, it is useful to have arbitrary exchanges as primitives, because they are required quite often.
+
+  * _Push operation_ : `PUSH s(i)` — Pushes a copy of the (old) value of `s`( _i_ ) into the stack. Traditionally, `PUSH s0` is also denoted by `DUP` (it duplicates the value at the top of the stack), and `PUSH s1` by `OVER`.
+
+  * _Pop operation_ : `POP s(i)` — Removes the top-of-stack value and puts it into the (new) `s`( _i_ − 1), or the old `s`( _i_ ). Traditionally, `POP s0` is also denoted by `DROP` (it simply drops the top-of-stack value), and `POP s1` by `NIP`.
+
+Some other “unsystematic” stack manipulation operations might be also defined
+(e.g., `ROT`, with stack notation _a_ _b_ _c_ – _b_ _c_ _a_ ). While such
+operations are defined in stack languages like Forth (where `DUP`, `DROP`,
+`OVER`, `NIP` and `SWAP` are also present), they are not strictly necessary
+because the _basic stack manipulation primitives_ listed above suffice to
+rearrange stack registers to allow any arithmetic primitives and user-defined
+functions to be invoked correctly.
+
+[sp:basic.stack.suff] **Basic stack manipulation primitives suffice.** A
+compiler or a human TVM-code programmer might use the basic stack primitives
+as follows.
+
+Suppose that the function or primitive to be invoked is to be passed, say,
+three arguments _x_ , _y_ , and _z_ , currently located in stack registers
+`s`( _i_ ), `s`( _j_ ), and `s`( _k_ ). In this circumstance, the compiler (or
+programmer) might issue operation `PUSH s(i)` (if a copy of _x_ is needed
+after the call to this primitive) or `XCHG s(i)` (if it will not be needed
+afterwards) to put the first argument _x_ into the top of the stack. Then, the
+compiler (or programmer) could use either `PUSH s(j')` or `XCHG s(j')`, where
+_j_ ′ = _j_ or _j_ \+ 1, to put _y_ into the new top of the stack.8
+
+Proceeding in this manner, we see that we can put the original values of _x_ ,
+_y_ , and _z_ —or their copies, if needed—into locations `s2`, `s1`, and `s0`,
+using a sequence of push and exchange operations (cf. and for a more detailed
+explanation). In order to generate this sequence, the compiler will need to
+know only the three values _i_ , _j_ and _k_ , describing the old locations of
+variables or temporary values in question, and some flags describing whether
+each value will be needed thereafter or is needed only for this primitive or
+function call. The locations of other variables and temporary values will be
+affected in the process, but a compiler (or a human programmer) can easily
+track their new locations.
+
+Similarly, if the results returned from a function need to be discarded or
+moved to other stack registers, a suitable sequence of exchange and pop
+operations will do the job. In the typical case of one return value in `s0`,
+this is achieved either by an `XCHG s(i)` or a `POP s(i)` (in most cases, a
+`DROP`) operation.9
+
+Rearranging the result value or values before returning from a function is
+essentially the same problem as arranging arguments for a function call, and
+is achieved similarly.
+
+[sp:stack.comp] **Compound stack manipulation primitives.** In order to
+improve the density of the TVM code and simplify development of compilers,
+compound stack manipulation primitives may be defined, each combining up to
+four exchange and push or exchange and pop basic primitives. Such compound
+stack operations might include, for example:
+
+  * `XCHG2 s(i),s(j)` — Equivalent to `XCHG s1,s(i)`; `XCHG s(j)`.
+
+  * `PUSH2 s(i),s(j)` — Equivalent to `PUSH s(i)`; `PUSH s(j+1)`.
+
+  * `XCPU s(i),s(j)` — Equivalent to `XCHG s(i)`; `PUSH s(j)`.
+
+  * `PUXC s(i),s(j)` — Equivalent to `PUSH s(i)`; `SWAP`; `XCHG s(j+1)`. When _j_ ≠ _i_ and _j_ ≠ 0, it is also equivalent to `XCHG s(j)`; `PUSH s(i)`; `SWAP`.
+
+  * `XCHG3 s(i),s(j),s(k)` — Equivalent to `XCHG s2,s(i)`; `XCHG s1,s(j)`; `XCHG s(k)`.
+
+  * `PUSH3 s(i),s(j),s(k)` — Equivalent to `PUSH s(i)`; `PUSH s(j+1)`; `PUSH s(k+2)`.
+
+Of course, such operations make sense only if they admit a more compact
+encoding than the equivalent sequence of basic operations. For example, if all
+top-of-stack exchanges, `XCHG s1,s(i)` exchanges, and push and pop operations
+admit one-byte encodings, the only compound stack operations suggested above
+that might merit inclusion in the set of stack manipulation primitives are
+`PUXC`, `XCHG3`, and `PUSH3`.
+
+These compound stack operations essentially augment other primitives
+(instructions) in the code with the “true” locations of their operands,
+somewhat similarly to what happens with two-address or three-address register
+machine code. However, instead of encoding these locations inside the opcode
+of the arithmetic or another instruction, as is customary for register
+machines, we indicate these locations in a preceding compound stack
+manipulation operation. As already described in , the advantage of such an
+approach is that user-defined functions (or rarely used specific primitives
+added in a future version of TVM) can benefit from it as well (cf. for a more
+detailed discussion with examples).
+
+[sp:mnem.comp.stk] **Mnemonics of compound stack operations.** The mnemonics
+of compound stack operations, some examples of which have been provided in ,
+are created as follows.
+
+The _γ_ ≥ 2 formal arguments `s(i_1)`, …, `s(i_\gamma)` to such an operation
+_O_ represent the values in the original stack that will end up in
+`s(\gamma-1)`, …, `s0` after the execution of this compound operation, at
+least if all _i_ _ν_ , 1 ≤ _ν_ ≤ _γ_ , are distinct and at least _γ_. The
+mnemonic itself of the operation _O_ is a sequence of _γ_ two-letter strings
+`PU` and `XC`, with `PU` meaning that the corresponding argument is to be
+PUshed (i.e., a copy is to be created), and `XC` meaning that the value is to
+be eXChanged (i.e., no other copy of the original value is created). Sequences
+of several `PU` or `XC` strings may be abbreviated to one `PU` or `XC`
+followed by the number of copies. (For instance, we write `PUXC2PU` instead of
+`PUXCXCPU`.)
+
+As an exception, if a mnemonic would consist of only `PU` or only `XC`
+strings, so that the compound operation is equivalent to a sequence of _m_
+PUSHes or eXCHanGes, the notation `PUSH` _m_ or `XCHG` _m_ is used instead of
+`PUm` or `XCm`.
+
+[sp:sem.comp.stk] **Semantics of compound stack operations.** Each compound
+_γ_ -ary operation _O_ `s(i_1)`,…,`s(i_\gamma)` is translated into an
+equivalent sequence of basic stack operations by induction in _γ_ as follows:
+
+  * As a base of induction, if _γ_ = 0, the only nullary compound stack operation corresponds to an empty sequence of basic stack operations.
+
+  * Equivalently, we might begin the induction from _γ_ = 1. Then `PU s(i)` corresponds to the sequence consisting of one basic operation `PUSH s(i)`, and `XC s(i)` corresponds to the one-element sequence consisting of `XCHG s(i)`.
+
+  * For _γ_ ≥ 1 (or for _γ_ ≥ 2, if we use _γ_ = 1 as induction base), there are two subcases:
+
+    1. _O_`s`( _i_ 1), …, `s`( _i_ _γ_ ), with _O_ = `XC` _O_ ′, where _O_ ′ is a compound operation of arity _γ_ − 1 (i.e., the mnemonic of _O_ ′ consists of _γ_ − 1 strings `XC` and `PU`). Let _α_ be the total quantity of `PU`shes in _O_ , and _β_ be that of e`XC`hanges, so that _α_ \+ _β_ = _γ_. Then the original operation is translated into `XCHG s(\beta-1),s(i_1)`, followed by the translation of _O_ ′`s`( _i_ 2), …, `s`( _i_ _γ_ ), defined by the induction hypothesis.
+
+    2. _O_`s`( _i_ 1), …, `s`( _i_ _γ_ ), with _O_ = `PU` _O_ ′, where _O_ ′ is a compound operation of arity _γ_ − 1. Then the original operation is translated into `PUSH s(i_1)`; `XCHG s(\beta)`, followed by the translation of _O_ ′`s`( _i_ 2 \+ 1), …, `s`( _i_ _γ_ \+ 1), defined by the induction hypothesis.10
+
+[sp:stack.prim.poly] **Stack manipulation instructions are polymorphic.**
+Notice that the stack manipulation instructions are almost the only
+“polymorphic” primitives in TVM—i.e., they work with values of arbitrary types
+(including the value types that will appear only in future revisions of TVM).
+For example, `SWAP` always interchanges the two top values of the stack, even
+if one of them is an integer and the other is a cell. Almost all other
+instructions, especially the data processing instructions (including
+arithmetic instructions), require each of their arguments to be of some fixed
+type (possibly different for different arguments).
+
+## Efficiency of stack manipulation primitives
+
+[p:eff.stack.manip] Stack manipulation primitives employed by a stack machine,
+such as TVM, have to be implemented very efficiently, because they constitute
+more than half of all the instructions used in a typical program. In fact, TVM
+performs all these instructions in a (small) constant time, regardless of the
+values involved (even if they represent very large integers or very large
+trees of cells).
+
+**Implementation of stack manipulation primitives: using references for
+operations instead of objects.** The efficiency of TVM’s implementation of
+stack manipulation primitives results from the fact that a typical TVM
+implementation keeps in the stack not the value objects themselves, but only
+the references (pointers) to such objects. Therefore, a `SWAP` instruction
+only needs to interchange the references at `s0` and `s1`, not the actual
+objects they refer to.
+
+[sp:cow] **Efficient implementation of`DUP` and `PUSH` instructions using
+copy-on-write.** Furthermore, a `DUP` (or, more generally, `PUSH s(i)`)
+instruction, which appears to make a copy of a potentially large object, also
+works in small constant time, because it uses a copy-on-write technique of
+delayed copying: it copies only the reference instead of the object itself,
+but increases the “reference counter” inside the object, thus sharing the
+object between the two references. If an attempt to modify an object with a
+reference counter greater than one is detected, a separate copy of the object
+in question is made first (incurring a certain “non-uniqueness penalty” or
+“copying penalty” for the data manipulation instruction that triggered the
+creation of a new copy).
+
+**Garbage collecting and reference counting.** When the reference counter of a
+TVM object becomes zero (for example, because the last reference to such an
+object has been consumed by a `DROP` operation or an arithmetic instruction),
+it is immediately freed. Because cyclic references are impossible in TVM data
+structures, this method of reference counting provides a fast and convenient
+way of freeing unused objects, replacing slow and unpredictable garbage
+collectors.
+
+[sp:no.refs] **Transparency of the implementation: Stack values are “values”,
+not “references”.** Regardless of the implementation details just discussed,
+all stack values are really “values”, not “references”, from the perspective
+of the TVM programmer, similarly to the values of all types in functional
+programming languages. Any attempt to modify an existing object referred to
+from any other objects or stack locations will result in a transparent
+replacement of this object by its perfect copy before the modification is
+actually performed.
+
+In other words, the programmer should always act as if the objects themselves
+were directly manipulated by stack, arithmetic, and other data transformation
+primitives, and treat the previous discussion only as an explanation of the
+high efficiency of the stack manipulation primitives.
+
+[sp:no.cyclic] **Absence of circular references.** One might attempt to create
+a circular reference between two cells, _A_ and _B_ , as follows: first create
+_A_ and write some data into it; then create _B_ and write some data into it,
+along with a reference to previously constructed cell _A_ ; finally, add a
+reference to _B_ into _A_. While it may seem that after this sequence of
+operations we obtain a cell _A_ , which refers to _B_ , which in turn refers
+to _A_ , this is not the case. In fact, we obtain a new cell _A_ ′, which
+contains a copy of the data originally stored into cell _A_ along with a
+reference to cell _B_ , which contains a reference to (the original) cell _A_.
+
+In this way the transparent copy-on-write mechanism and the “everything is a
+value” paradigm enable us to create new cells using only previously
+constructed cells, thus forbidding the appearance of circular references. This
+property also applies to all other data structures: for instance, the absence
+of circular references enables TVM to use reference counting to immediately
+free unused memory instead of relying on garbage collectors. Similarly, this
+property is crucial for storing data in the TON Blockchain.
+
+# Cells, memory, and persistent storage
+
+This chapter briefly describes TVM cells, used to represent all data
+structures inside the TVM memory and its persistent storage, and the basic
+operations used to create cells, write (or serialize) data into them, and read
+(or deserialize) data from them.
+
+## Generalities on cells
+
+This section presents a classification and general descriptions of cell types.
+
+**TVM memory and persistent storage consist of cells.** Recall that the TVM
+memory and persistent storage consist of _(TVM) cells_. Each cell contains up
+to 1023 bits of data and up to four references to other cells.11 Circular
+references are forbidden and cannot be created by means of TVM (cf. ). In this
+way, all cells kept in TVM memory and persistent storage constitute a directed
+acyclic graph (DAG).
+
+[sp:exotic.cells] **Ordinary and exotic cells.** Apart from the data and
+references, a cell has a _cell type_ , encoded by an integer  − 1…255. A cell
+of type  − 1 is called _ordinary_ ; such cells do not require any special
+processing. Cells of other types are called _exotic_ , and may be _loaded_
+—automatically replaced by other cells when an attempt to deserialize them
+(i.e., to convert them into a _Slice_ by a `CTOS` instruction) is made. They
+may also exhibit a non-trivial behavior when their hashes are computed.
+
+The most common use for exotic cells is to represent some other cells—for
+instance, cells present in an external library, or pruned from the original
+tree of cells when a Merkle proof has been created.
+
+The type of an exotic cell is stored as the first eight bits of its data. If
+an exotic cell has less than eight data bits, it is invalid.
+
+[sp:cell.level] **The level of a cell.** Every cell _c_ has another attribute
+$\operatorname{\mathrm{Lvl}}(c)$ called its _(de Brujn) level_ , which
+currently takes integer values in the range 0…3. The level of an ordinary cell
+is always equal to the maximum of the levels of all its children _c_ _i_ :  
+$$\operatorname{\mathrm{Lvl}}(c)=\max_{1\leq i\leq
+r}\operatorname{\mathrm{Lvl}}(c_i)\quad,$$  
+for an ordinary cell _c_ containing _r_ references to cells _c_ 1, …, _c_ _r_.
+If _r_ = 0, $\operatorname{\mathrm{Lvl}}(c)=0$. Exotic cells may have
+different rules for setting their level.
+
+A cell’s level affects the number of _higher hashes_ it has. More precisely, a
+level _l_ cell has _l_ higher hashes $\operatorname{\mathrm{Hash}}_1(c)$, …,
+$\operatorname{\mathrm{Hash}}_l(c)$ in addition to its representation hash
+$\operatorname{\mathrm{Hash}}(c)=\operatorname{\mathrm{Hash}}_\infty(c)$.
+Cells of non-zero level appear inside _Merkle proofs_ and _Merkle updates_ ,
+after some branches of the tree of cells representing a value of an abstract
+data type are pruned.
+
+[sp:std.cell.repr] **Standard cell representation.** When a cell needs to be
+transferred by a network protocol or stored in a disk file, it must be
+_serialized_. The standard representation
+$\operatorname{\mathrm{CellRepr}}(c)=\operatorname{\mathrm{CellRepr}}_\infty(c)$
+of a cell _c_ as an octet (byte) sequence is constructed as follows:
+
+  1. Two descriptor bytes _d_ 1 and _d_ 2 are serialized first. Byte _d_ 1 equals _r_ \+ 8 _s_ \+ 32 _l_ , where 0 ≤ _r_ ≤ 4 is the quantity of cell references contained in the cell, 0 ≤ _l_ ≤ 3 is the level of the cell, and 0 ≤ _s_ ≤ 1 is 1 for exotic cells and 0 for ordinary cells. Byte _d_ 2 equals ⌊ _b_ /8⌋ + ⌈ _b_ /8⌉, where 0 ≤ _b_ ≤ 1023 is the quantity of data bits in _c_.
+
+  2. Then the data bits are serialized as ⌈ _b_ /8⌉ 8-bit octets (bytes). If _b_ is not a multiple of eight, a binary `1` and up to six binary `0`s are appended to the data bits. After that, the data is split into ⌈ _b_ /8⌉ eight-bit groups, and each group is interpreted as an unsigned big-endian integer 0…255 and stored into an octet.
+
+  3. Finally, each of the _r_ cell references is represented by 32 bytes containing the 256-bit _representation hash_ $\operatorname{\mathrm{Hash}}(c_i)$, explained below in , of the cell _c_ _i_ referred to.
+
+In this way, 2 + ⌈ _b_ /8⌉ + 32 _r_ bytes of
+$\operatorname{\mathrm{CellRepr}}(c)$ are obtained.
+
+[sp:repr.hash] **The representation hash of a cell.** The 256-bit
+_representation hash_ or simply _hash_ $\operatorname{\mathrm{Hash}}(c)$ of a
+cell _c_ is recursively defined as the $\operatorname{\mathrm{sha256}}$ of the
+standard representation of the cell _c_ :  
+$$\operatorname{\mathrm{Hash}}(c):=\operatorname{\mathrm{sha256}}\bigl(\operatorname{\mathrm{CellRepr}}(c)\bigr)$$  
+Notice that cyclic cell references are not allowed and cannot be created by
+means of the TVM (cf. ), so this recursion always ends, and the representation
+hash of any cell is well-defined.
+
+**The higher hashes of a cell.** Recall that a cell _c_ of level _l_ has _l_
+higher hashes $\operatorname{\mathrm{Hash}}_i(c)$, 1 ≤ _i_ ≤ _l_ , as well.
+Exotic cells have their own rules for computing their higher hashes. Higher
+hashes $\operatorname{\mathrm{Hash}}_i(c)$ of an ordinary cell _c_ are
+computed similarly to its representation hash, but using the higher hashes
+$\operatorname{\mathrm{Hash}}_i(c_j)$ of its children _c_ _j_ instead of their
+representation hashes $\operatorname{\mathrm{Hash}}(c_j)$. By convention, we
+set $\operatorname{\mathrm{Hash}}_\infty(c):=\operatorname{\mathrm{Hash}}(c)$,
+and
+$\operatorname{\mathrm{Hash}}_i(c):=\operatorname{\mathrm{Hash}}_\infty(c)=\operatorname{\mathrm{Hash}}(c)$
+for all _i_ > _l_.12
+
+[sp:exotic.cell.types] **Types of exotic cells.** TVM currently supports the
+following cell types:
+
+  * Type  − 1: _Ordinary cell_ — Contains up to 1023 bits of data and up to four cell references.
+
+  * Type 1: _Pruned branch cell _c__ — May have any level 1 ≤ _l_ ≤ 3. It contains exactly 8 + 256 _l_ data bits: first an 8-bit integer equal to 1 (representing the cell’s type), then its _l_ higher hashes $\operatorname{\mathrm{Hash}}_1(c)$, …, $\operatorname{\mathrm{Hash}}_l(c)$. The level _l_ of a pruned branch cell may be called its _de Brujn index_ , because it determines the outer Merkle proof or Merkle update during the construction of which the branch has been pruned. An attempt to load a pruned branch cell usually leads to an exception.
+
+  * Type 2: _Library reference cell_ — Always has level 0, and contains 8 + 256 data bits, including its 8-bit type integer 2 and the representation hash $\operatorname{\mathrm{Hash}}(c')$ of the library cell being referred to. When loaded, a library reference cell may be transparently replaced by the cell it refers to, if found in the current _library context_.
+
+  * Type 3: _Merkle proof cell _c__ — Has exactly one reference _c_ 1 and level 0 ≤ _l_ ≤ 3, which must be one less than the level of its only child _c_ 1:   
+$$\operatorname{\mathrm{Lvl}}(c)=\max(\operatorname{\mathrm{Lvl}}(c_1)-1,0)$$  
+The 8 + 256 data bits of a Merkle proof cell contain its 8-bit type integer 3,
+followed by $\operatorname{\mathrm{Hash}}_1(c_1)$ (assumed to be equal to
+$\operatorname{\mathrm{Hash}}(c_1)$ if $\operatorname{\mathrm{Lvl}}(c_1)=0$).
+The higher hashes $\operatorname{\mathrm{Hash}}_i(c)$ of _c_ are computed
+similarly to the higher hashes of an ordinary cell, but with
+$\operatorname{\mathrm{Hash}}_{i+1}(c_1)$ used instead of
+$\operatorname{\mathrm{Hash}}_i(c_1)$. When loaded, a Merkle proof cell is
+replaced by _c_ 1.
+
+  * Type 4: _Merkle update cell _c__ — Has two children _c_ 1 and _c_ 2. Its level 0 ≤ _l_ ≤ 3 is given by   
+$$\operatorname{\mathrm{Lvl}}(c)=\max(\operatorname{\mathrm{Lvl}}(c_1)-1,\operatorname{\mathrm{Lvl}}(c_2)-1,0)$$  
+A Merkle update behaves like a Merkle proof for both _c_ 1 and _c_ 2, and
+contains 8 + 256 + 256 data bits with $\operatorname{\mathrm{Hash}}_1(c_1)$
+and $\operatorname{\mathrm{Hash}}_1(c_2)$. However, an extra requirement is
+that _all pruned branch cells _c_ ′ that are descendants of _c_ 2 and are
+bound by _c_ must also be descendants of _c_ 1._13 When a Merkle update cell
+is loaded, it is replaced by _c_ 2.
+
+[sp:data.boc] **All values of algebraic data types are trees of cells.**
+Arbitrary values of arbitrary algebraic data types (e.g., all types used in
+functional programming languages) can be serialized into trees of cells (of
+level 0), and such representations are used for representing such values
+within TVM. The copy-on-write mechanism (cf. ) allows TVM to identify cells
+containing the same data and references, and to keep only one copy of such
+cells. This actually transforms a tree of cells into a directed acyclic graph
+(with the additional property that all its vertices be accessible from a
+marked vertex called the “root”). However, this is a storage optimization
+rather than an essential property of TVM. From the perspective of a TVM code
+programmer, one should think of TVM data structures as trees of cells.
+
+[sp:code.boc] **TVM code is a tree of cells.** The TVM code itself is also
+represented by a tree of cells. Indeed, TVM code is simply a value of some
+complex algebraic data type, and as such, it can be serialized into a tree of
+cells.
+
+The exact way in which the TVM code (e.g., TVM assembly code) is transformed
+into a tree of cells is explained later (cf. and ), in sections discussing
+control flow instructions, continuations, and TVM instruction encoding.
+
+**“Everything is a bag of cells” paradigm.** As described in , all the data
+used by the TON Blockchain, including the blocks themselves and the blockchain
+state, can be represented—and are represented—as collections, or “bags”, of
+cells. We see that TVM’s structure of data (cf. ) and code (cf. ) nicely fits
+into this “everything is a bag of cells” paradigm. In this way, TVM can
+naturally be used to execute smart contracts in the TON Blockchain, and the
+TON Blockchain can be used to store the code and persistent data of these
+smart contracts between invocations of TVM. (Of course, both TVM and the TON
+Blockchain have been designed so that this would become possible.)
+
+## Data manipulation instructions and cells
+
+[p:cell.manip] The next large group of TVM instructions consists of _data
+manipulation instructions_ , also known as _cell manipulation instructions_ or
+simply _cell instructions_. They correspond to memory access instructions of
+other architectures.
+
+**Classes of cell manipulation instructions.** The TVM cell instructions are
+naturally subdivided into two principal classes:
+
+  * _Cell creation instructions_ or _serialization instructions_ , used to construct new cells from values previously kept in the stack and previously constructed cells.
+
+  * _Cell parsing instructions_ or _deserialization instructions_ , used to extract data previously stored into cells by cell creation instructions.
+
+Additionally, there are _exotic cell instructions_ used to create and inspect
+exotic cells (cf. ), which in particular are used to represent pruned branches
+of Merkle proofs and Merkle proofs themselves.
+
+[sp:builder.slice.val] ** _Builder_ and _Slice_ values.** Cell creation
+instructions usually work with _Builder_ values, which can be kept only in the
+stack (cf. ). Such values represent partially constructed cells, for which
+fast operations for appending bitstrings, integers, other cells, and
+references to other cells can be defined. Similarly, cell parsing instructions
+make heavy use of _Slice_ values, which represent either the remainder of a
+partially parsed cell, or a value (subcell) residing inside such a cell and
+extracted from it by a parsing instruction.
+
+**_Builder_ and _Slice_ values exist only as stack values.** Notice that
+_Builder_ and _Slice_ objects appear only as values in a TVM stack. They
+cannot be stored in “memory” (i.e., trees of cells) or “persistent storage”
+(which is also a bag of cells). In this sense, there are far more _Cell_
+objects than _Builder_ or _Slice_ objects in a TVM environment, but, somewhat
+paradoxically, a TVM program sees _Builder_ and _Slice_ objects in its stack
+more often than _Cell_ s. In fact, a TVM program does not have much use for
+_Cell_ values, because they are immutable and opaque; all cell manipulation
+primitives require that a _Cell_ value be transformed into either a _Builder_
+or a _Slice_ first, before it can be modified or inspected.
+
+**TVM has no separate _Bitstring_ value type.** Notice that TVM offers no
+separate bitstring value type. Instead, bitstrings are represented by _Slice_
+s that happen to have no references at all, but can still contain up to 1023
+data bits.
+
+[sp:cells.of.bits] **Cells and cell primitives are bit-oriented, not byte-
+oriented.** An important point is that _TVM regards data kept in cells as
+sequences (strings, streams) of (up to 1023) bits, not of bytes_. In other
+words, TVM is a _bit-oriented machine_ , not a byte-oriented machine. If
+necessary, an application is free to use, say, 21-bit integer fields inside
+records serialized into TVM cells, thus using fewer persistent storage bytes
+to represent the same data.
+
+[sp:cc.taxonomy] **Taxonomy of cell creation (serialization) primitives.**
+Cell creation primitives usually accept a _Builder_ argument and an argument
+representing the value to be serialized. Additional arguments controlling some
+aspects of the serialization process (e.g., how many bits should be used for
+serialization) can be also provided, either in the stack or as an immediate
+value inside the instruction. The result of a cell creation primitive is
+usually another _Builder_ , representing the concatenation of the original
+builder and the serialization of the value provided.
+
+Therefore, one can suggest a classification of cell serialization primitives
+according to the answers to the following questions:
+
+  * Which is the type of values being serialized?
+
+  * How many bits are used for serialization? If this is a variable number, does it come from the stack, or from the instruction itself?
+
+  * What happens if the value does not fit into the prescribed number of bits? Is an exception generated, or is a success flag equal to zero silently returned in the top of stack?
+
+  * What happens if there is insufficient space left in the _Builder_? Is an exception generated, or is a zero success flag returned along with the unmodified original _Builder_?
+
+The mnemonics of cell serialization primitives usually begin with `ST`.
+Subsequent letters describe the following attributes:
+
+  * The type of values being serialized and the serialization format (e.g., `I` for signed integers, `U` for unsigned integers).
+
+  * The source of the field width in bits to be used (e.g., `X` for integer serialization instructions means that the bit width _n_ is supplied in the stack; otherwise it has to be embedded into the instruction as an immediate value).
+
+  * The action to be performed if the operation cannot be completed (by default, an exception is generated; “quiet” versions of serialization instructions are marked by a `Q` letter in their mnemonics).
+
+This classification scheme is used to create a more complete taxonomy of cell
+serialization primitives, which can be found in .
+
+**Integer serialization primitives.** Integer serialization primitives can be
+classified according to the above taxonomy as well. For example:
+
+  * There are signed and unsigned (big-endian) integer serialization primitives.
+
+  * The size _n_ of the bit field to be used (1 ≤ _n_ ≤ 257 for signed integers, 0 ≤ _n_ ≤ 256 for unsigned integers) can either come from the top of stack or be embedded into the instruction itself.
+
+  * If the integer _x_ to be serialized is not in the range  − 2 _n_ − 1 ≤ _x_ < 2 _n_ − 1 (for signed integer serialization) or 0 ≤ _x_ < 2 _n_ (for unsigned integer serialization), a range check exception is usually generated, and if _n_ bits cannot be stored into the provided _Builder_ , a cell overflow exception is generated.
+
+  * Quiet versions of serialization instructions do not throw exceptions; instead, they push `-1` on top of the resulting _Builder_ upon success, or return the original _Builder_ with `0` on top of it to indicate failure.
+
+Integer serialization instructions have mnemonics like `STU 20` (“store an
+unsigned 20-bit integer value”) or `STIXQ` (“quietly store an integer value of
+variable length provided in the stack”). The full list of these
+instructions—including their mnemonics, descriptions, and opcodes—is provided
+in .
+
+**Integers in cells are big-endian by default.** Notice that the default order
+of bits in _Integer_ s serialized into _Cell_ s is _big-endian_ , not little-
+endian.14 In this respect _TVM is a big-endian machine_. However, this affects
+only the serialization of integers inside cells. The internal representation
+of the _Integer_ value type is implementation-dependent and irrelevant for the
+operation of TVM. Besides, there are some special primitives such as `STULE`
+for (de)serializing little-endian integers, which must be stored into an
+integral number of bytes (otherwise “little-endianness” does not make sense,
+unless one is also willing to revert the order of bits inside octets). Such
+primitives are useful for interfacing with the little-endian world—for
+instance, for parsing custom-format messages arriving to a TON Blockchain
+smart contract from the outside world.
+
+**Other serialization primitives.** Other cell creation primitives serialize
+bitstrings (i.e., cell slices without references), either taken from the stack
+or supplied as literal arguments; cell slices (which are concatenated to the
+cell builder in an obvious way); other _Builder_ s (which are also
+concatenated); and cell references (`STREF`).
+
+**Other cell creation primitives.** In addition to the cell serialization
+primitives for certain built-in value types described above, there are simple
+primitives that create a new empty _Builder_ and push it into the stack
+(`NEWC`), or transform a _Builder_ into a _Cell_ (`ENDC`), thus finishing the
+cell creation process. An `ENDC` can be combined with a `STREF` into a single
+instruction `ENDCST`, which finishes the creation of a cell and immediately
+stores a reference to it in an “outer” _Builder_. There are also primitives
+that obtain the quantity of data bits or references already stored in a
+_Builder_ , and check how many data bits or references can be stored.
+
+[sp:cd.taxonomy] **Taxonomy of cell deserialisation primitives.** Cell
+parsing, or deserialization, primitives can be classified as described in ,
+with the following modifications:
+
+  * They work with _Slice_ s (representing the remainder of the cell being parsed) instead of _Builder_ s.
+
+  * They return deserialized values instead of accepting them as arguments.
+
+  * They may come in two flavors, depending on whether they remove the deserialized portion from the _Slice_ supplied (“fetch operations”) or leave it unmodified (“prefetch operations”).
+
+  * Their mnemonics usually begin with `LD` (or `PLD` for prefetch operations) instead of `ST`.
+
+For example, an unsigned big-endian 20-bit integer previously serialized into
+a cell by a `STU 20` instruction is likely to be deserialized later by a
+matching `LDU 20` instruction.
+
+Again, more detailed information about these instructions is provided in .
+
+**Other cell slice primitives.** In addition to the cell deserialisation
+primitives outlined above, TVM provides some obvious primitives for
+initializing and completing the cell deserialization process. For instance,
+one can convert a _Cell_ into a _Slice_ (`CTOS`), so that its deserialisation
+might begin; or check whether a _Slice_ is empty, and generate an exception if
+it is not (`ENDS`); or deserialize a cell reference and immediately convert it
+into a _Slice_ (`LDREFTOS`, equivalent to two instructions `LDREF` and
+`CTOS`).
+
+[sp:mod.val.cell] **Modifying a serialized value in a cell.** The reader might
+wonder how the values serialized inside a cell may be modified. Suppose a cell
+contains three serialized 29-bit integers, ( _x_ , _y_ , _z_ ), representing
+the coordinates of a point in space, and we want to replace _y_ with _y_ ′ =
+_y_ \+ 1, leaving the other coordinates intact. How would we achieve this?
+
+TVM does not offer any ways to modify existing values (cf. and ), so our
+example can only be accomplished with a series of operations as follows:
+
+  1. Deserialize the original cell into three _Integer_ s _x_ , _y_ , _z_ in the stack (e.g., by `CTOS; LDI 29; LDI 29; LDI 29; ENDS`).
+
+  2. Increase _y_ by one (e.g., by `SWAP; INC; SWAP`).
+
+  3. Finally, serialize the resulting _Integer_ s into a new cell (e.g., by `XCHG s2; NEWC; STI 29; STI 29; STI 29; ENDC`).
+
+**Modifying the persistent storage of a smart contract.** If the TVM code
+wants to modify its persistent storage, represented by the tree of cells
+rooted at `c4`, it simply needs to rewrite control register `c4` by the root
+of the tree of cells containing the new value of its persistent storage. (If
+only part of the persistent storage needs to be modified, cf. .)
+
+## Hashmaps, or dictionaries
+
+[p:hashmaps]
+
+_Hashmaps_ , or _dictionaries_ , are a specific data structure represented by
+a tree of cells. Essentially, a hashmap represents a map from _keys_ , which
+are bitstrings of either fixed or variable length, into _values_ of an
+arbitrary type _X_ , in such a way that fast lookups and modifications be
+possible. While any such structure might be inspected or modified with the aid
+of generic cell serialization and deserialization primitives, TVM introduces
+special primitives to facilitate working with these hashmaps.
+
+**Basic hashmap types.** The two most basic hashmap types predefined in TVM
+are _HashmapE_ _n_ _X_ or _HashmapE_ ( _n_ , _X_ ), which represents a
+partially defined map from _n_ -bit strings (called _keys_ ) for some fixed 0
+≤ _n_ ≤ 1023 into _values_ of some type _X_ , and _Hashmap_ ( _n_ , _X_ ),
+which is similar to _HashmapE_ ( _n_ , _X_ ) but is not allowed to be empty
+(i.e., it must contain at least one key-value pair).
+
+Other hashmap types are also available—for example, one with keys of arbitrary
+length up to some predefined bound (up to 1023 bits).
+
+[sp:hm.patricia] **Hashmaps as Patricia trees.** The abstract representation
+of a hashmap in TVM is a _Patricia tree_ , or a _compact binary trie_. It is a
+binary tree with edges labelled by bitstrings, such that the concatenation of
+all edge labels on a path from the root to a leaf equals a key of the hashmap.
+The corresponding value is kept in this leaf (for hashmaps with keys of fixed
+length), or optionally in the intermediate vertices as well (for hashmaps with
+keys of variable length). Furthermore, any intermediate vertex must have two
+children, and the label of the left child must begin with a binary zero, while
+the label of the right child must begin with a binary one. This enables us not
+to store the first bit of the edge labels explicitly.
+
+It is easy to see that any collection of key-value pairs (with distinct keys)
+is represented by a unique Patricia tree.
+
+[sp:hm.tlb] **Serialization of hashmaps.** The serialization of a hashmap into
+a tree of cells (or, more generally, into a _Slice_ ) is defined by the
+following TL-B scheme:15
+
+    
+    
+    bit#_ _:(## 1) = Bit;
+    
+    hm_edge#_ {n:#} {X:Type} {l:#} {m:#} label:(HmLabel ~l n) 
+              {n = (~m) + l} node:(HashmapNode m X) = Hashmap n X;
+    
+    hmn_leaf#_ {X:Type} value:X = HashmapNode 0 X;
+    hmn_fork#_ {n:#} {X:Type} left:^(Hashmap n X) 
+               right:^(Hashmap n X) = HashmapNode (n + 1) X;
+    
+    hml_short$0 {m:#} {n:#} len:(Unary ~n) 
+                s:(n * Bit) = HmLabel ~n m;
+    hml_long$10 {m:#} n:(#<= m) s:(n * Bit) = HmLabel ~n m;
+    hml_same$11 {m:#} v:Bit n:(#<= m) = HmLabel ~n m;
+    
+    unary_zero$0 = Unary ~0;
+    unary_succ$1 {n:#} x:(Unary ~n) = Unary ~(n + 1);
+    
+    hme_empty$0 {n:#} {X:Type} = HashmapE n X;
+    hme_root$1 {n:#} {X:Type} root:^(Hashmap n X) = HashmapE n X;
+    
+    true#_ = True;
+    _ {n:#} _:(Hashmap n True) = BitstringSet n;
+
+[sp:tlb.brief] **Brief explanation of TL-B schemes.** A TL-B scheme, like the
+one above, includes the following components.
+
+The right-hand side of each “equation” is a _type_ , either simple (such as
+`Bit` or `True`) or parametrized (such as `Hashmap n X`). The parameters of a
+type must be either natural numbers (i.e., non-negative integers, which are
+required to fit into 32 bits in practice), such as _n_ in `Hashmap n X`, or
+other types, such as _X_ in `Hashmap n X`.
+
+The left-hand side of each equation describes a way to define, or even to
+serialize, a value of the type indicated in the right-hand side. Such a
+description begins with the name of a _constructor_ , such as `hm_edge` or
+`hml_long`, immediately followed by an optional _constructor tag_ , such as
+`#_` or `$10`, which describes the bitstring used to encode (serialize) the
+constructor in question. Such tags may be given in either binary (after a
+dollar sign) or hexadecimal notation (after a hash sign), using the
+conventions described in . If a tag is not explicitly provided, TL-B computes
+a default 32-bit constructor tag by hashing the text of the “equation”
+defining this constructor in a certain fashion. Therefore, empty tags must be
+explicitly provided by `#_` or `$_`. All constructor names must be distinct,
+and constructor tags for the same type must constitute a prefix code
+(otherwise the deserialization would not be unique).
+
+The constructor and its optional tag are followed by _field definitions_. Each
+field definition is of the form _ident_ : _type-expr_ , where
+${\textit{ident}}\/$ is an identifier with the name of the field16 (replaced
+by an underscore for anonymous fields), and _type-expr_ is the field’s type.
+The type provided here is a _type expression_ , which may include simple types
+or parametrized types with suitable parameters. _Variables_ —i.e., the
+(identifiers of the) previously defined fields of types # (natural numbers) or
+_Type_ (type of types)—may be used as parameters for the parametrized types.
+The serialization process recursively serializes each field according to its
+type, and the serialization of a value ultimately consists of the
+concatenation of bitstrings representing the constructor (i.e., the
+constructor tag) and the field values.
+
+Some fields may be _implicit_. Their definitions are surrounded by curly
+braces, which indicate that the field is not actually present in the
+serialization, but that its value must be deduced from other data (usually the
+parameters of the type being serialized).
+
+Some occurrences of “variables” (i.e., already-defined fields) are prefixed by
+a tilde. This indicates that the variable’s occurrence is used in the opposite
+way of the default behavior: in the left-hand side of the equation, it means
+that the variable will be deduced (computed) based on this occurrence, instead
+of substituting its previously computed value; in the right-hand side,
+conversely, it means that the variable will not be deduced from the type being
+serialized, but rather that it will be computed during the deserialization
+process. In other words, a tilde transforms an “input argument” into an
+“output argument”, and vice versa.17
+
+Finally, some equalities may be included in curly brackets as well. These are
+certain “equations”, which must be satisfied by the “variables” included in
+them. If one of the variables is prefixed by a tilde, its value will be
+uniquely determined by the values of all other variables participating in the
+equation (which must be known at this point) when the definition is processed
+from the left to the right.
+
+A caret (`^`) preceding a type _X_ means that instead of serializing a value
+of type _X_ as a bitstring inside the current cell, we place this value into a
+separate cell, and add a reference to it into the current cell. Therefore `^X`
+means “the type of references to cells containing values of type _X_ ”.
+
+Parametrized type `#<= p` with _p_ : `#` (this notation means “ _p_ of type
+`#`”, i.e., a natural number) denotes the subtype of the natural numbers type
+#, consisting of integers 0… _p_ ; it is serialized into ⌈log2( _p_ \+ 1)⌉
+bits as an unsigned big-endian integer. Type `#` by itself is serialized as an
+unsigned 32-bit integer. Parametrized type `## b` with _b_ : `#<=`31 is
+equivalent to `#<= 2^b-1` (i.e., it is an unsigned _b_ -bit integer).
+
+**Application to the serialization of hashmaps.** Let us explain the net
+result of applying the general rules described in to the TL-B scheme presented
+in .
+
+Suppose we wish to serialize a value of type _HashmapE_ _n_ _X_ for some
+integer 0 ≤ _n_ ≤ 1023 and some type _X_ (i.e., a dictionary with _n_ -bit
+keys and values of type _X_ , admitting an abstract representation as a
+Patricia tree (cf. )).
+
+First of all, if our dictionary is empty, it is serialized into a single
+binary `0`, which is the tag of nullary constructor `hme_empty`. Otherwise,
+its serialization consists of a binary `1` (the tag of `hme_root`), along with
+a reference to a cell containing the serialization of a value of type
+_Hashmap_ _n_ _X_ (i.e., a necessarily non-empty dictionary).
+
+The only way to serialize a value of type _Hashmap_ _n_ _X_ is given by the
+`hm_edge` constructor, which instructs us to serialize first the label `label`
+of the edge leading to the root of the subtree under consideration (i.e., the
+common prefix of all keys in our (sub)dictionary). This label is of type
+`HmLabel l^\perp n`, which means that it is a bitstring of length at most _n_
+, serialized in such a way that the true length _l_ of the label, 0 ≤ _l_ ≤
+_n_ , becomes known from the serialization of the label. (This special
+serialization method is described separately in .)
+
+The label must be followed by the serialization of a `node` of type
+_HashmapNode _m_ _X__ , where _m_ = _n_ − _l_. It corresponds to a vertex of
+the Patricia tree, representing a non-empty subdictionary of the original
+dictionary with _m_ -bit keys, obtained by removing from all the keys of the
+original subdictionary their common prefix of length _l_.
+
+If _m_ = 0, a value of type `HashmapNode 0 X` is given by the `hmn_leaf`
+constructor, which describes a leaf of the Patricia tree—or, equivalently, a
+subdictionary with 0-bit keys. A leaf simply consists of the corresponding
+`value` of type _X_ and is serialized accordingly.
+
+On the other hand, if _m_ > 0, a value of type `HashmapNode m X` corresponds
+to a fork (i.e., an intermediate node) in the Patricia tree, and is given by
+the `hmn_fork` constructor. Its serialization consists of `left` and `right`,
+two references to cells containing values of type `Hashmap m-1 X`, which
+correspond to the left and the right child of the intermediate node in
+question—or, equivalently, to the two subdictionaries of the original
+dictionary consisting of key-value pairs with keys beginning with a binary `0`
+or a binary `1`, respectively. Because the first bit of all keys in each of
+these subdictionaries is known and fixed, it is removed, and the resulting
+(necessarily non-empty) subdictionaries are recursively serialized as values
+of type `Hashmap m-1 X`.
+
+[sp:hm.label.ser] **Serialization of labels.** There are several ways to
+serialize a label of length at most _n_ , if its exact length is _l_ ≤ _n_
+(recall that the exact length must be deducible from the serialization of the
+label itself, while the upper bound _n_ is known before the label is
+serialized or deserialized). These ways are described by the three
+constructors `hml_short`, `hml_long`, and `hml_same` of type `HmLabel l^\perp
+n`:
+
+  * `hml_short` — Describes a way to serialize “short” labels, of small length _l_ ≤ _n_. Such a serialization consists of a binary `0` (the constructor tag of `hml_short`), followed by _l_ binary `1`s and one binary `0` (the unary representation of the length _l_ ), followed by _l_ bits comprising the label itself.
+
+  * `hml_long` — Describes a way to serialize “long” labels, of arbitrary length _l_ ≤ _n_. Such a serialization consists of a binary `10` (the constructor tag of `hml_long`), followed by the big-endian binary representation of the length 0 ≤ _l_ ≤ _n_ in ⌈log2( _n_ \+ 1)⌉ bits, followed by _l_ bits comprising the label itself.
+
+  * `hml_same` — Describes a way to serialize “long” labels, consisting of _l_ repetitions of the same bit _v_. Such a serialization consists of `11` (the constructor tag of `hml_same`), followed by the bit _v_ , followed by the length _l_ stored in ⌈log2( _n_ \+ 1)⌉ bits as before.
+
+Each label can always be serialized in at least two different fashions, using
+`hml_short` or `hml_long` constructors. Usually the shortest serialization
+(and in the case of a tie—the lexicographically smallest among the shortest)
+is preferred and is generated by TVM hashmap primitives, while the other
+variants are still considered valid.
+
+This label encoding scheme has been designed to be efficient for dictionaries
+with “random” keys (e.g., hashes of some data), as well as for dictionaries
+with “regular” keys (e.g., big-endian representations of integers in some
+range).
+
+**An example of dictionary serialization.** Consider a dictionary with three
+16-bit keys 13, 17, and 239 (considered as big-endian integers) and
+corresponding 16-bit values 169, 289, and 57121.
+
+In binary form:
+
+    
+    
+    0000000000001101 => 0000000010101001
+    0000000000010001 => 0000000100100001
+    0000000011101111 => 1101111100100001
+
+The corresponding Patricia tree consists of a root _A_ , two intermediate
+nodes _B_ and _C_ , and three leaf nodes _D_ , _E_ , and _F_ , corresponding
+to 13, 17, and 239, respectively. The root _A_ has only one child, _B_ ; the
+label on the edge _A_ _B_ is 00000000 = 08. The node _B_ has two children: its
+left child is an intermediate node _C_ with the edge _B_ _C_ labelled by
+(0)00, while its right child is the leaf _F_ with _B_ _F_ labelled by
+(1)1101111. Finally, _C_ has two leaf children _D_ and _E_ , with _C_ _D_
+labelled by (0)1101 and _C_ _E_ —by (1)0001.
+
+The corresponding value of type `HashmapE 16 (## 16)` may be written in human-
+readable form as:
+
+    
+    
+    (hme_root$1 
+      root:^(hm_edge label:(hml_same$11 v:0 n:8) node:(hm_fork 
+        left:^(hm_edge label:(hml_short$0 len:$110 s:$00) 
+          node:(hm_fork
+            left:^(hm_edge label:(hml_long$10 n:4 s:$1101) 
+              node:(hm_leaf value:169))
+            right:^(hm_edge label:(hml_long$10 n:4 s:$0001) 
+              node:(hm_leaf value:289))))
+        right:^(hm_edge label:(hml_long$10 n:7 s:$1101111) 
+          node:(hm_leaf value:57121)))))
+
+The serialization of this data structure into a tree of cells consists of six
+cells with the following binary data contained in them:
+
+    
+    
+    A := 1
+    A.0 := 11 0 01000 
+    A.0.0 := 0 110 00
+    A.0.0.0 := 10 100 1101 0000000010101001
+    A.0.0.1 := 10 100 0001 0000000100100001
+    A.0.1 := 10 111 1101111 1101111100100001
+
+Here _A_ is the root cell, _A_.0 is the cell at the first reference of _A_ ,
+_A_.1 is the cell at the second reference of _A_ , and so on. This tree of
+cells can be represented more compactly using the hexadecimal notation
+described in , using indentation to reflect the tree-of-cells structure:
+
+    
+    
+    C_
+     C8
+      62_
+       A68054C_
+       A08090C_
+      BEFDF21
+
+A total of 93 data bits and 5 references in 6 cells have been used to
+serialize this dictionary. Notice that a straightforward representation of
+three 16-bit keys and their corresponding 16-bit values would already require
+96 bits (albeit without any references), so this particular serialization
+turns out to be quite efficient.
+
+**Ways to describe the serialization of type _X_.** Notice that the built-in
+TVM primitives for dictionary manipulation need to know something about the
+serialization of type _X_ ; otherwise, they would not be able to work
+correctly with _Hashmap_ _n_ _X_ , because values of type _X_ are immediately
+contained in the Patricia tree leaf cells. There are several options available
+to describe the serialization of type _X_ :
+
+  * The simplest case is when $X=\texttt{\^{}} Y$ for some other type _Y_. In this case the serialization of _X_ itself always consists of one reference to a cell, which in fact must contain a value of type _Y_ , something that is not relevant for dictionary manipulation primitives.
+
+  * Another simple case is when the serialization of any value of type _X_ always consists of 0 ≤ _b_ ≤ 1023 data bits and 0 ≤ _r_ ≤ 4 references. Integers _b_ and _r_ can then be passed to a dictionary manipulation primitive as a simple description of _X_. (Notice that the previous case corresponds to _b_ = 0, _r_ = 1.)
+
+  * A more sophisticated case can be described by four integers 1 ≤ _b_ 0, _b_ 1 ≤ 1023, 0 ≤ _r_ 0, _r_ 1 ≤ 4, with _b_ _i_ and _r_ _i_ used when the first bit of the serialization equals _i_. When _b_ 0 = _b_ 1 and _r_ 0 = _r_ 1, this case reduces to the previous one.
+
+  * Finally, the most general description of the serialization of a type _X_ is given by a _splitting function_ ${\textit split}_X$ for _X_ , which accepts one _Slice_ parameter _s_ , and returns two _Slice_ s, _s_ ′ and _s_ ″, where _s_ ′ is the only prefix of _s_ that is the serialization of a value of type _X_ , and _s_ ″ is the remainder of _s_. If no such prefix exists, the splitting function is expected to throw an exception. Notice that a compiler for a high-level language, which supports some or all algebraic TL-B types, is likely to automatically generate splitting functions for all types defined in the program.
+
+**A simplifying assumption on the serialization of _X_.** One may notice that
+values of type _X_ always occupy the remaining part of an `hm_edge`/`hme_leaf`
+cell inside the serialization of a _HashmapE_ _n_ _X_. Therefore, if we do not
+insist on strict validation of all dictionaries accessed, we may assume that
+everything left unparsed in an `hm_edge`/`hme_leaf` cell after deserializing
+its `label` is a value of type _X_. This greatly simplifies the creation of
+dictionary manipulation primitives, because in most cases they turn out not to
+need any information about _X_ at all.
+
+[sp:dict.ops] **Basic dictionary operations.** Let us present a classification
+of basic operations with dictionaries (i.e., values _D_ of type _HashmapE_ _n_
+_X_ ):
+
+  * $\mathrm{Get}(D,k)$ — Given _D_ : _HashmapE_ ( _n_ , _X_ ) and a key $k:n\cdot{\tt bit}$, returns the corresponding value _D_ [ _k_ ] : _X_? kept in _D_.
+
+  * $\mathrm{Set}(D,k,x)$ — Given _D_ : _HashmapE_ ( _n_ , _X_ ), a key $k:n\cdot{\tt bit}$, and a value _x_ : _X_ , sets _D_ ′[ _k_ ] to _x_ in a copy _D_ ′ of _D_ , and returns the resulting dictionary _D_ ′ (cf. ).
+
+  * $\mathrm{Add}(D,k,x)$ — Similar to Set, but adds the key-value pair ( _k_ , _x_ ) to _D_ only if key _k_ is absent in _D_.
+
+  * $\mathrm{Replace}(D,k,x)$ — Similar to Set, but changes _D_ ′[ _k_ ] to _x_ only if key _k_ is already present in _D_.
+
+  * GetSet, GetAdd, GetReplace — Similar to Set, Add, and Replace, respectively, but returns the old value of _D_ [ _k_ ] as well.
+
+  * $\mathrm{Delete}(D,k)$ — Deletes key _k_ from dictionary _D_ , and returns the resulting dictionary _D_ ′.
+
+  * $\mathrm{GetMin}(D)$, $\mathrm{GetMax}(D)$ — Gets the minimal or maximal key _k_ from dictionary _D_ , along with the associated value _x_ : _X_.
+
+  * $\mathrm{RemoveMin}(D)$, $\mathrm{RemoveMax}(D)$ — Similar to GetMin and GetMax, but also removes the key in question from dictionary _D_ , and returns the modified dictionary _D_ ′. May be used to iterate over all elements of _D_ , effectively using (a copy of) _D_ itself as an iterator.
+
+  * $\mathrm{GetNext}(D,k)$ — Computes the minimal key _k_ ′ > _k_ (or _k_ ′ ≥ _k_ in a variant) and returns it along with the corresponding value _x_ ′ : _X_. May be used to iterate over all elements of _D_.
+
+  * $\mathrm{GetPrev}(D,k)$ — Computes the maximal key _k_ ′ < _k_ (or _k_ ′ ≤ _k_ in a variant) and returns it along with the corresponding value _x_ ′ : _X_.
+
+  * $\mathrm{Empty}(n)$ — Creates an empty dictionary _D_ : _HashmapE_ ( _n_ , _X_ ).
+
+  * $\mathrm{IsEmpty}(D)$ — Checks whether a dictionary is empty.
+
+  * $\mathrm{Create}(n,\\{(k_i,x_i)\\})$ — Given _n_ , creates a dictionary from a list ( _k_ _i_ , _x_ _i_ ) of key-value pairs passed in stack.
+
+  * $\mathrm{GetSubdict}(D,l,k_0)$ — Given _D_ : _HashmapE_ ( _n_ , _X_ ) and some _l_ -bit string $k_0:l\cdot{\tt bit}$ for 0 ≤ _l_ ≤ _n_ , returns subdictionary _D_ ′ = _D_ / _k_ 0 of _D_ , consisting of keys beginning with _k_ 0. The result _D_ ′ may be of either type _HashmapE_ ( _n_ , _X_ ) or type _HashmapE_ ( _n_ − _l_ , _X_ ).
+
+  * $\mathrm{ReplaceSubdict}(D,l,k_0,D')$ — Given _D_ : _HashmapE_ ( _n_ , _X_ ), 0 ≤ _l_ ≤ _n_ , $k_0:l\cdot{\tt bit}$, and _D_ ′ : _HashmapE_ ( _n_ − _l_ , _X_ ), replaces with _D_ ′ the subdictionary _D_ / _k_ 0 of _D_ consisting of keys beginning with _k_ 0, and returns the resulting dictionary _D_ ″ : _HashmapE_ ( _n_ , _X_ ). Some variants of $\mathrm{ReplaceSubdict}$ may also return the old value of the subdictionary _D_ / _k_ 0 in question.
+
+  * $\mathrm{DeleteSubdict}(D,l,k_0)$ — Equivalent to $\mathrm{ReplaceSubdict}$ with _D_ ′ being an empty dictionary.
+
+  * $\mathrm{Split}(D)$ — Given _D_ : _HashmapE_ ( _n_ , _X_ ), returns _D_ 0 := _D_ /0 and _D_ 1 := _D_ /1 : _HashmapE_ ( _n_ − 1, _X_ ), the two subdictionaries of _D_ consisting of all keys beginning with 0 and 1, respectively.
+
+  * $\mathrm{Merge}(D_0,D_1)$ — Given _D_ 0 and _D_ 1 : _HashmapE_ ( _n_ − 1, _X_ ), computes _D_ : _HashmapE_ ( _n_ , _X_ ), such that _D_ /0 = _D_ 0 and _D_ /1 = _D_ 1.
+
+  * $\mathrm{Foreach}(D,f)$ — Executes a function _f_ with two arguments _k_ and _x_ , with ( _k_ , _x_ ) running over all key-value pairs of a dictionary _D_ in lexicographical order.18
+
+  * $\mathrm{ForeachRev}(D,f)$ — Similar to Foreach, but processes all key-value pairs in reverse order.
+
+  * $\mathrm{TreeReduce}(D,o,f,g)$ — Given _D_ : _HashmapE_ ( _n_ , _X_ ), a value _o_ : _X_ , and two functions _f_ : _X_ → _Y_ and _g_ : _Y_ × _Y_ → _Y_ , performs a “tree reduction” of _D_ by first applying _f_ to all the leaves, and then using _g_ to compute the value corresponding to a fork starting from the values assigned to its children.19
+
+[sp:dict.prim.taxonomy] **Taxonomy of dictionary primitives.** The dictionary
+primitives, described in detail in , can be classified according to the
+following categories:
+
+  * Which dictionary operation (cf. ) do they perform?
+
+  * Are they specialized for the case $X=\texttt{\^{}} Y$? If so, do they represent values of type _Y_ by _Cell_ s or by _Slice_ s? (Generic versions always represent values of type _X_ as _Slice_ s.)
+
+  * Are the dictionaries themselves passed and returned as _Cell_ s or as _Slice_ s? (Most primitives represent dictionaries as _Slice_ s.)
+
+  * Is the key length _n_ fixed inside the primitive, or is it passed in the stack?
+
+  * Are the keys represented by _Slice_ s, or by signed or unsigned _Integer_ s?
+
+In addition, TVM includes special serialization/deserialization primitives,
+such as `STDICT`, `LDDICT`, and `PLDDICT`. They can be used to extract a
+dictionary from a serialization of an encompassing object, or to insert a
+dictionary into such a serialization.
+
+## Hashmaps with variable-length keys
+
+TVM provides some support for dictionaries, or hashmaps, with variable-length
+keys, in addition to its support for dictionaries with fixed-length keys (as
+described in above).
+
+**Serialization of dictionaries with variable-length keys.** The serialization
+of a _VarHashmap_ into a tree of cells (or, more generally, into a _Slice_ )
+is defined by a TL-B scheme, similar to that described in :
+
+    
+    
+    vhm_edge#_ {n:#} {X:Type} {l:#} {m:#} label:(HmLabel ~l n) 
+               {n = (~m) + l} node:(VarHashmapNode m X) 
+               = VarHashmap n X;
+    vhmn_leaf$00 {n:#} {X:Type} value:X = VarHashmapNode n X;
+    vhmn_fork$01 {n:#} {X:Type} left:^(VarHashmap n X) 
+                 right:^(VarHashmap n X) value:(Maybe X) 
+                 = VarHashmapNode (n + 1) X;
+    vhmn_cont$1 {n:#} {X:Type} branch:bit child:^(VarHashmap n X) 
+                value:X = VarHashmapNode (n + 1) X;
+    
+    nothing$0 {X:Type} = Maybe X;
+    just$1 {X:Type} value:X = Maybe X;
+    
+    vhme_empty$0 {n:#} {X:Type} = VarHashmapE n X;
+    vhme_root$1 {n:#} {X:Type} root:^(VarHashmap n X) 
+                = VarHashmapE n X;
+
+[sp:pfx.dict.tlb] **Serialization of prefix codes.** One special case of a
+dictionary with variable-length keys is that of a _prefix code_ , where the
+keys cannot be prefixes of each other. Values in such dictionaries may occur
+only in the leaves of a Patricia tree.
+
+The serialization of a prefix code is defined by the following TL-B scheme:
+
+    
+    
+    phm_edge#_ {n:#} {X:Type} {l:#} {m:#} label:(HmLabel ~l n) 
+               {n = (~m) + l} node:(PfxHashmapNode m X) 
+               = PfxHashmap n X;
+    
+    phmn_leaf$0 {n:#} {X:Type} value:X = PfxHashmapNode n X;
+    phmn_fork$1 {n:#} {X:Type} left:^(PfxHashmap n X) 
+                right:^(PfxHashmap n X) = PfxHashmapNode (n + 1) X;
+    
+    phme_empty$0 {n:#} {X:Type} = PfxHashmapE n X;
+    phme_root$1 {n:#} {X:Type} root:^(PfxHashmap n X) 
+                = PfxHashmapE n X;
+
+# Control flow, continuations, and exceptions
+
+This chapter describes _continuations_ , which may represent execution tokens
+and exception handlers in TVM. Continuations are deeply involved with the
+control flow of a TVM program; in particular, subroutine calls and conditional
+and iterated execution are implemented in TVM using special primitives that
+accept one or more continuations as their arguments.
+
+We conclude this chapter with a discussion of the problem of recursion and of
+families of mutually recursive functions, exacerbated by the fact that cyclic
+references are not allowed in TVM data structures (including TVM code).
+
+## Continuations and subroutines
+
+[p:cont.subr]
+
+Recall (cf.) that _Continuation_ values represent “execution tokens” that can
+be executed later—for example, by `EXECUTE`=`CALLX` (“execute” or “call
+indirect”) or `JMPX` (“jump indirect”) primitives. As such, the continuations
+are responsible for the execution of the program, and are heavily used by
+control flow primitives, enabling subroutine calls, conditional expressions,
+loops, and so on.
+
+[sp:ord.cont] **Ordinary continuations.** The most common kind of
+continuations are the _ordinary continuations_ , containing the following
+data:
+
+  * A _Slice_ `code` (cf. and ), containing (the remainder of) the TVM code to be executed.
+
+  * A (possibly empty) _Stack_ `stack`, containing the original contents of the stack for the code to be executed.
+
+  * A (possibly empty) list `save` of pairs (`c`( _i_ ), _v_ _i_ ) (also called “savelist”), containing the values of control registers to be restored before the execution of the code.
+
+  * A 16-bit integer value `cp`, selecting the TVM codepage used to interpret the TVM code from `code`.
+
+  * An optional non-negative integer `nargs`, indicating the number of arguments expected by the continuation.
+
+**Simple ordinary continuations.** In most cases, the ordinary continuations
+are the simplest ones, having empty `stack` and `save`. They consist
+essentially of a reference `code` to (the remainder of) the code to be
+executed, and of the codepage `cp` to be used while decoding the instructions
+from this code.
+
+**Current continuation`cc`.** The “current continuation” `cc` is an important
+part of the total state of TVM, representing the code being executed right now
+(cf. ). In particular, what we call “the current stack” (or simply “the
+stack”) when discussing all other primitives is in fact the stack of the
+current continuation. All other components of the total state of TVM may be
+also thought of as parts of the current continuation `cc`; however, they may
+be extracted from the current continuation and kept separately as part of the
+total state for performance reasons. This is why we describe the stack, the
+control registers, and the codepage as separate parts of the TVM state in .
+
+[sp:ord.cont.exec] **Normal work of TVM, or the main loop.** TVM usually
+performs the following operations:
+
+If the current continuation `cc` is an ordinary one, it decodes the first
+instruction from the _Slice_ `code`, similarly to the way other cells are
+deserialized by TVM `LD*` primitives (cf. and ): it decodes the opcode first,
+and then the parameters of the instruction (e.g., 4-bit fields indicating
+“stack registers” involved for stack manipulation primitives, or constant
+values for “push constant” or “literal” primitives). The remainder of the
+_Slice_ is then put into the `code` of the new `cc`, and the decoded operation
+is executed on the current stack. This entire process is repeated until there
+are no operations left in `cc.code`.
+
+If the `code` is empty (i.e., contains no bits of data and no references), or
+if a (rarely needed) explicit subroutine return (`RET`) instruction is
+encountered, the current continuation is discarded, and the “return
+continuation” from control register `c0` is loaded into `cc` instead (this
+process is discussed in more detail starting in ).20 Then the execution
+continues by parsing operations from the new current continuation.
+
+[sp:extraord.cont] **Extraordinary continuations.** In addition to the
+ordinary continuations considered so far (cf. ), TVM includes some
+_extraordinary continuations_ , representing certain less common states.
+Examples of extraordinary continuations include:
+
+  * The continuation `ec_quit` with its parameter set to zero, which represents the end of the work of TVM. This continuation is the original value of `c0` when TVM begins executing the code of a smart contract.
+
+  * The continuation `ec_until`, which contains references to two other continuations (ordinary or not) representing the body of the loop being executed and the code to be executed after the loop.
+
+Execution of an extraordinary continuation by TVM depends on its specific
+class, and differs from the operations for ordinary continuations described in
+.21
+
+[sp:jmp.sw] **Switching to another continuation:`JMP` and `RET`.** The process
+of switching to another continuation _c_ may be performed by such instructions
+as `JMPX` (which takes _c_ from the stack) or `RET` (which uses `c0` as _c_ ).
+This process is slightly more complex than simply setting the value of `cc` to
+_c_ : before doing this, either all values or the top _n_ values in the
+current stack are moved to the stack of the continuation _c_ , and only then
+is the remainder of the current stack discarded.
+
+If all values need to be moved (the most common case), and if the continuation
+_c_ has an empty stack (also the most common case; notice that extraordinary
+continuations are assumed to have an empty stack), then the new stack of _c_
+equals the stack of the current continuation, so we can simply transfer the
+current stack in its entirety to _c_. (If we keep the current stack as a
+separate part of the total state of TVM, we have to do nothing at all.)
+
+[sp:jmp.sw.n] **Determining the number _n_ of arguments passed to the next
+continuation _c_.** By default, _n_ equals the depth of the current stack.
+However, if _c_ has an explicit value of `nargs` (number of arguments to be
+provided), then _n_ is computed as _n_ ′, equal to $c.{\tt nargs}$ minus the
+current depth of _c_ ’s stack.
+
+Furthermore, there are special forms of `JMPX` and `RET` that provide an
+explicit value _n_ ″, the number of parameters from the current stack to be
+passed to continuation _c_. If _n_ ″ is provided, it must be less than or
+equal to the depth of the current stack, or else a stack underflow exception
+occurs. If both _n_ ′ and _n_ ″ are provided, we must have _n_ ′ ≤ _n_ ″, in
+which case _n_ = _n_ ′ is used. If _n_ ″ is provided and _n_ ′ is not, then
+_n_ = _n_ ″ is used.
+
+One could also imagine that the default value of _n_ ″ equals the depth of the
+original stack, and that _n_ ″ values are always removed from the top of the
+original stack even if only _n_ ′ of them are actually moved to the stack of
+the next continuation _c_. Even though the remainder of the current stack is
+discarded afterwards, this description will become useful later.
+
+[sp:jmp.sw.cp] **Restoring control registers from the new continuation _c_.**
+After the new stack is computed, the values of control registers present in
+$c.{\tt save}$ are restored accordingly, and the current codepage `cp` is also
+set to $c.{\tt cp}$. Only then does TVM set `cc` equal to the new _c_ and
+begin its execution.22
+
+[sp:call.sw] **Subroutine calls:`CALLX` or `EXECUTE` primitives.** The
+execution of continuations as subroutines is slightly more complicated than
+switching to continuations.
+
+Consider the `CALLX` or `EXECUTE` primitive, which takes a continuation _c_
+from the (current) stack and executes it as a subroutine.
+
+Apart from doing the stack manipulations described in and and setting the new
+control registers and codepage as described in , these primitives perform
+several additional steps:
+
+  1. After the top _n_ ″ values are removed from the current stack (cf. ), the (usually empty) remainder is not discarded, but instead is stored in the (old) current continuation `cc`.
+
+  2. The old value of the special register `c0` is saved into the (previously empty) savelist `cc.save`.
+
+  3. The continuation `cc` thus modified is not discarded, but instead is set as the new `c0`, which performs the role of “next continuation” or “return continuation” for the subroutine being called.
+
+  4. After that, the switching to _c_ continues as before. In particular, some control registers are restored from $c.{\tt save}$, potentially overwriting the value of `c0` set in the previous step. (Therefore, a good optimization would be to check that _c_ 0 is present in $c.{\tt save}$ from the very beginning, and skip the three previous steps as useless in this case.)
+
+In this way, the called subroutine can return control to the caller by
+switching the current continuation to the return continuation saved in `c0`.
+Nested subroutine calls work correctly because the previous value of `c0` ends
+up saved into the new `c0`’s control register savelist `c0.save`, from which
+it is restored later.
+
+[sp:callx.num.args] **Determining the number of arguments passed to and/or
+return values accepted from a subroutine.** Similarly to `JMPX` and `RET`,
+`CALLX` also has special (rarely used) forms, which allow us to explicitly
+specify the number _n_ ″ of arguments passed from the current stack to the
+called subroutine (by default, _n_ ″ equals the depth of the current stack,
+i.e., it is passed in its entirety). Furthermore, a second number _n_ ‴ can be
+specified, used to set `nargs` of the modified `cc` continuation before
+storing it into the new `c0`; the new `nargs` equals the depth of the old
+stack minus _n_ ″ plus _n_ ‴. This means that the caller is willing to pass
+exactly _n_ ″ arguments to the called subroutine, and is willing to accept
+exactly _n_ ‴ results in their stead.
+
+Such forms of `CALLX` and `RET` are mostly intended for library functions that
+accept functional arguments and want to invoke them safely. Another
+application is related to the “virtualization support” of TVM, which enables
+TVM code to run other TVM code inside a “virtual TVM machine”. Such
+virtualization techniques might be useful for implementing sophisticated
+payment channels in the TON Blockchain (cf. ).
+
+[sp:call.cc] **`CALLCC`: call with current continuation.** Notice that TVM
+supports a form of the “call with current continuation” primitive. Namely,
+primitive `CALLCC` is similar to `CALLX` or `JMPX` in that it takes a
+continuation _c_ from the stack and switches to it; however, `CALLCC` does not
+discard the previous current continuation _c_ ′ (as `JMPX` does) and does not
+write _c_ ′ to `c0` (as `CALLX` does), but rather pushes _c_ ′ into the (new)
+stack as an extra argument to _c_. The primitive `JMPXDATA` does a similar
+thing, but pushes only the (remainder of the) code of the previous current
+continuation as a _Slice_.
+
+## Control flow primitives: conditional and iterated execution
+
+[p:cond.iter.exec]
+
+**Conditional execution:`IF`, `IFNOT`, `IFELSE`.** An important modification
+of `EXECUTE` (or `CALLX`) consists in its conditional forms. For example, `IF`
+accepts an integer _x_ and a continuation _c_ , and executes _c_ (in the same
+way as `EXECUTE` would do it) only if _x_ is non-zero; otherwise both values
+are simply discarded from the stack. Similarly, `IFNOT` accepts _x_ and _c_ ,
+but executes _c_ only if _x_ = 0. Finally, `IFELSE` accepts _x_ , _c_ , and
+_c_ ′, removes these values from the stack, and executes _c_ if _x_ ≠ 0 or _c_
+′ if _x_ = 0.
+
+**Iterated execution and loops.** More sophisticated modifications of
+`EXECUTE` include:
+
+  * `REPEAT` — Takes an integer _n_ and a continuation _c_ , and executes _c_ _n_ times.23
+
+  * `WHILE` — Takes _c_ ′ and _c_ ″, executes _c_ ′, and then takes the top value _x_ from the stack. If _x_ is non-zero, it executes _c_ ″ and then begins a new loop by executing _c_ ′ again; if _x_ is zero, it stops.
+
+  * `UNTIL` — Takes _c_ , executes it, and then takes the top integer _x_ from the stack. If _x_ is zero, a new iteration begins; if _x_ is non-zero, the previously executed code is resumed.
+
+[sp:lit.cont] **Constant, or literal, continuations.** We see that we can
+create arbitrarily complex conditional expressions and loops in the TVM code,
+provided we have a means to push constant continuations into the stack. In
+fact, TVM includes special versions of “literal” or “constant” primitives that
+cut the next _n_ bytes or bits from the remainder of the current code
+`cc.code` into a cell slice, and then push it into the stack not as a _Slice_
+(as a `PUSHSLICE` does) but as a simple ordinary _Continuation_ (which has
+only `code` and `cp`).
+
+The simplest of these primitives is `PUSHCONT`, which has an immediate
+argument _n_ describing the number of subsequent bytes (in a byte-oriented
+version of TVM) or bits to be converted into a simple continuation. Another
+primitive is `PUSHREFCONT`, which removes the first cell reference from the
+current continuation `cc.code`, converts the cell referred to into a cell
+slice, and finally converts the cell slice into a simple continuation.
+
+**Constant continuations combined with conditional or iterated execution
+primitives.** Because constant continuations are very often used as arguments
+to conditional or iterated execution primitives, combined versions of these
+primitives (e.g., `IFCONT` or `UNTILREFCONT`) may be defined in a future
+revision of TVM, which combine a `PUSHCONT` or `PUSHREFCONT` with another
+primitive. If one inspects the resulting code, `IFCONT` looks very much like
+the more customary “conditional-branch-forward” instruction.
+
+## Operations with continuations
+
+**Continuations are opaque.** Notice that all continuations are _opaque_ , at
+least in the current version of TVM, meaning that there is no way to modify a
+continuation or inspect its internal data. Almost the only use of a
+continuation is to supply it to a control flow primitive.
+
+While there are some arguments in favor of including support for non-opaque
+continuations in TVM (along with opaque continuations, which are required for
+virtualization), the current revision offers no such support.
+
+[sp:op.cont] **Allowed operations with continuations.** However, some
+operations with opaque continuations are still possible, mostly because they
+are equivalent to operations of the kind “create a new continuation, which
+will do something special, and then invoke the original continuation”. Allowed
+operations with continuations include:
+
+  * Push one or several values into the stack of a continuation _c_ (thus creating a partial application of a function, or a closure).
+
+  * Set the saved value of a control register ${\tt c}(i)$ inside the savelist $c.{\tt save}$ of a continuation _c_. If there is already a value for the control register in question, this operation silently does nothing.
+
+**Example: operations with control registers.** TVM has some primitives to set
+and inspect the values of control registers. The most important of them are
+`PUSH c(i)` (pushes the current value of `c(i)` into the stack) and `POP c(i)`
+(sets the value of `c(i)` from the stack, if the supplied value is of the
+correct type). However, there is also a modified version of the latter
+instruction, called `POPSAVE c(i)`, which saves the old value of `c(i)` (for
+_i_ > 0) into the continuation at `c0` as described in before setting the new
+value.
+
+**Example: setting the number of arguments to a function in its code.** The
+primitive `LEAVEARGS n` demonstrates another application of continuations in
+an operation: it leaves only the top _n_ values of the current stack, and
+moves the remainder to the stack of the continuation in `c0`. This primitive
+enables a called function to “return” unneeded arguments to its caller’s
+stack, which is useful in some situations (e.g., those related to exception
+handling).
+
+**Boolean circuits.** A continuation _c_ may be thought of as a piece of code
+with two optional exit points kept in the savelist of _c_ : the principal exit
+point given by _c_.`c0` := _c_.`save`(`c0`), and the auxiliary exit point
+given by _c_.`c1` := _c_.`save`(`c1`). If executed, a continuation performs
+whatever action it was created for, and then (usually) transfers control to
+the principal exit point, or, on some occasions, to the auxiliary exit point.
+We sometimes say that a continuation _c_ with both exit points $c.{\tt c0}$
+and $c.{\tt c1}$ defined is a _two-exit continuation_ , or a _boolean circuit_
+, especially if the choice of the exit point depends on some internally-
+checked condition.
+
+**Composition of continuations.** One can _compose_ two continuations _c_ and
+_c_ ′ simply by setting _c_.`c0` or _c_.`c1` to _c_ ′. This creates a new
+continuation denoted by _c_ ∘0 _c_ ′ or _c_ ∘1 _c_ ′, which differs from _c_
+in its savelist. (Recall that if the savelist of _c_ already has an entry
+corresponding to the control register in question, such an operation silently
+does nothing as explained in ).
+
+By composing continuations, one can build chains or other graphs, possibly
+with loops, representing the control flow. In fact, the resulting graph
+resembles a flow chart, with the boolean circuits corresponding to the
+“condition nodes” (containing code that will transfer control either to `c0`
+or to `c1` depending on some condition), and the one-exit continuations
+corresponding to the “action nodes”.
+
+**Basic continuation composition primitives.** Two basic primitives for
+composing continuations are `COMPOS` (also known as `SETCONT c0` and
+`BOOLAND`) and `COMPOSALT` (also known as `SETCONT c1` and `BOOLOR`), which
+take _c_ and _c_ ′ from the stack, set _c_.`c0` or _c_.`c1` to _c_ ′, and
+return the resulting continuation _c_ ″ = _c_ ∘0 _c_ ′ or _c_ ∘1 _c_ ′. All
+other continuation composition operations can be expressed in terms of these
+two primitives.
+
+**Advanced continuation composition primitives.** However, TVM can compose
+continuations not only taken from stack, but also taken from `c0` or `c1`, or
+from the current continuation `cc`; likewise, the result may be pushed into
+the stack, stored into either `c0` or `c1`, or used as the new current
+continuation (i.e., the control may be transferred to it). Furthermore, TVM
+can define conditional composition primitives, performing some of the above
+actions only if an integer value taken from the stack is non-zero.
+
+For instance, `EXECUTE` can be described as ${\tt cc}\leftarrow
+c\circ_0\tt{cc}$, with continuation _c_ taken from the original stack.
+Similarly, `JMPX` is ${\tt cc}\leftarrow c$, and `RET` (also known as
+`RETTRUE` in a boolean circuit context) is ${\tt cc}\leftarrow\tt{c0}$. Other
+interesting primitives include `THENRET` ($c'\leftarrow c\circ_0{\tt c0}$) and
+`ATEXIT` (${\tt c0}\leftarrow c\circ_0{\tt c0}$).
+
+Finally, some “experimental” primitives also involve `c1` and ∘1. For example:
+
+  * `RETALT` or `RETFALSE` does ${\tt cc}\leftarrow{\tt c1}$.
+
+  * Conditional versions of `RET` and `RETALT` may also be useful: `RETBOOL` takes an integer _x_ from the stack, and performs `RETTRUE` if _x_ ≠ 0, `RETFALSE` otherwise.
+
+  * `INVERT` does ${\tt c0}\leftrightarrow{\tt c1}$; if the two continuations in `c0` and `c1` represent the two branches we should select depending on some boolean expression, `INVERT` negates this expression on the outer level.
+
+  * `INVERTCONT` does $c.{\tt c0}\leftrightarrow c.{\tt c1}$ to a continuation _c_ taken from the stack.
+
+  * Variants of `ATEXIT` include `ATEXITALT` (${\tt c1}\leftarrow c\circ_1{\tt c1}$) and `SETEXITALT` (${\tt c1}\leftarrow (c\circ_0{\tt c0})\circ_1{\tt c1}$).
+
+  * `BOOLEVAL` takes a continuation _c_ from the stack and does ${\tt cc}\leftarrow \bigl((c\circ_0({\tt PUSH -1}))\circ_1({\tt PUSH 0})\bigr)\circ_0{\tt cc}$. If _c_ represents a boolean circuit, the net effect is to evaluate it and push either  − 1 or 0 into the stack before continuing.
+
+## Continuations as objects
+
+[sp:cont.obj] **Representing objects using continuations.** Object-oriented
+programming in Smalltalk (or Objective C) style may be implemented with the
+aid of continuations. For this, an object is represented by a special
+continuation _o_. If it has any data fields, they can be kept in the stack of
+_o_ , making _o_ a partial application (i.e., a continuation with a non-empty
+stack).
+
+When somebody wants to invoke a method _m_ of _o_ with arguments _x_ 1, _x_ 2,
+…, _x_ _n_ , she pushes the arguments into the stack, then pushes a magic
+number corresponding to the method _m_ , and then executes _o_ passing _n_ \+
+1 arguments (cf. ). Then _o_ uses the top-of-stack integer _m_ to select the
+branch with the required method, and executes it. If _o_ needs to modify its
+state, it simply computes a new continuation _o_ ′ of the same sort (perhaps
+with the same code as _o_ , but with a different initial stack). The new
+continuation _o_ ′ is returned to the caller along with whatever other return
+values need to be returned.
+
+**Serializable objects.** Another way of representing Smalltalk-style objects
+as continuations, or even as trees of cells, consists in using the
+`JMPREFDATA` primitive (a variant of `JMPXDATA`, cf. ), which takes the first
+cell reference from the code of the current continuation, transforms the cell
+referred to into a simple ordinary continuation, and transfers control to it,
+first pushing the remainder of the current continuation as a _Slice_ into the
+stack. In this way, an object might be represented by a cell _õ_ that
+contains `JMPREFDATA` at the beginning of its data, and the actual code of the
+object in the first reference (one might say that the first reference of cell
+_õ_ is the _class_ of object _õ_ ). Remaining data and references of this
+cell will be used for storing the fields of the object.
+
+Such objects have the advantage of being trees of cells, and not just
+continuations, meaning that they can be stored into the persistent storage of
+a TON smart contract.
+
+**Unique continuations and capabilities.** It might make sense (in a future
+revision of TVM) to mark some continuations as _unique_ , meaning that they
+cannot be copied, even in a delayed manner, by increasing their reference
+counter to a value greater than one. If an opaque continuation is unique, it
+essentially becomes a _capability_ , which can either be used by its owner
+exactly once or be transferred to somebody else.
+
+For example, imagine a continuation that represents the output stream to a
+printer (this is an example of a continuation used as an object, cf. ). When
+invoked with one integer argument _n_ , this continuation outputs the
+character with code _n_ to the printer, and returns a new continuation of the
+same kind reflecting the new state of the stream. Obviously, copying such a
+continuation and using the two copies in parallel would lead to some
+unintended side effects; marking it as unique would prohibit such adverse
+usage.
+
+## Exception handling
+
+TVM’s exception handling is quite simple and consists in a transfer of control
+to the continuation kept in control register `c2`.
+
+**Two arguments of the exception handler: exception parameter and exception
+number.** Every exception is characterized by two arguments: the _exception
+number_ (an _Integer_ ) and the _exception parameter_ (any value, most often a
+zero _Integer_ ). Exception numbers 0–31 are reserved for TVM, while all other
+exception numbers are available for user-defined exceptions.
+
+**Primitives for throwing an exception.** There are several special primitives
+used for throwing an exception. The most general of them, `THROWANY`, takes
+two arguments, _v_ and 0 ≤ _n_ < 216, from the stack, and throws the exception
+with number _n_ and value _v_. There are variants of this primitive that
+assume _v_ to be a zero integer, store _n_ as a literal value, and/or are
+conditional on an integer value taken from the stack. User-defined exceptions
+may use arbitrary values as _v_ (e.g., trees of cells) if needed.
+
+**Exceptions generated by TVM.** Of course, some exceptions are generated by
+normal primitives. For example, an arithmetic overflow exception is generated
+whenever the result of an arithmetic operation does not fit into a signed
+257-bit integer. In such cases, the arguments of the exception, _v_ and _n_ ,
+are determined by TVM itself.
+
+**Exception handling.** The exception handling itself consists in a control
+transfer to the exception handler—i.e., the continuation specified in control
+register `c2`, with _v_ and _n_ supplied as the two arguments to this
+continuation, as if a `JMP` to `c2` had been requested with _n_ ″ = 2
+arguments (cf. and ). As a consequence, _v_ and _n_ end up in the top of the
+stack of the exception handler. The remainder of the old stack is discarded.
+
+Notice that if the continuation in `c2` has a value for `c2` in its savelist,
+it will be used to set up the new value of `c2` before executing the exception
+handler. In particular, if the exception handler invokes `THROWANY`, it will
+re-throw the original exception with the restored value of `c2`. This trick
+enables the exception handler to handle only some exceptions, and pass the
+rest to an outer exception handler.
+
+**Default exception handler.** When an instance of TVM is created, `c2`
+contains a reference to the “default exception handler continuation”, which is
+an `ec_fatal` extraordinary continuation (cf. ). Its execution leads to the
+termination of the execution of TVM, with the arguments _v_ and _n_ of the
+exception returned to the outside caller. In the context of the TON
+Blockchain, _n_ will be stored as a part of the transaction’s result.
+
+**`TRY` primitive.** A `TRY` primitive can be used to implement C++-like
+exception handling. This primitive accepts two continuations, _c_ and _c_ ′.
+It stores the old value of `c2` into the savelist of _c_ ′, sets `c2` to _c_
+′, and executes _c_ just as `EXECUTE` would, but additionally saving the old
+value of `c2` into the savelist of the new `c0` as well. Usually a version of
+the `TRY` primitive with an explicit number of arguments _n_ ″ passed to the
+continuation _c_ is used.
+
+The net result is roughly equivalent to C++’s `try { c } catch(...) { c' }`
+operator.
+
+[sp:exc.list] **List of predefined exceptions.** Predefined exceptions of TVM
+correspond to exception numbers _n_ in the range 0–31. They include:
+
+  * _Normal termination_ ( _n_ = 0) — Should never be generated, but it is useful for some tricks.
+
+  * _Alternative termination_ ( _n_ = 1) — Again, should never be generated.
+
+  * _Stack underflow_ ( _n_ = 2) — Not enough arguments in the stack for a primitive.
+
+  * _Stack overflow_ ( _n_ = 3) — More values have been stored on a stack than allowed by this version of TVM.
+
+  * _Integer overflow_ ( _n_ = 4) — Integer does not fit into  − 2256 ≤ _x_ < 2256, or a division by zero has occurred.
+
+  * _Range check error_ ( _n_ = 5) — Integer out of expected range.
+
+  * _Invalid opcode_ ( _n_ = 6) — Instruction or its immediate arguments cannot be decoded.
+
+  * _Type check error_ ( _n_ = 7) — An argument to a primitive is of incorrect value type.
+
+  * _Cell overflow_ ( _n_ = 8) — Error in one of the serialization primitives.
+
+  * _Cell underflow_ ( _n_ = 9) — Deserialization error.
+
+  * _Dictionary error_ ( _n_ = 10) — Error while deserializing a dictionary object.
+
+  * _Unknown error_ ( _n_ = 11) — Unknown error, may be thrown by user programs.
+
+  * _Fatal error_ ( _n_ = 12) — Thrown by TVM in situations deemed impossible.
+
+  * _Out of gas_ ( _n_ = 13) — Thrown by TVM when the remaining gas ( _g_ _r_ ) becomes negative. This exception usually cannot be caught and leads to an immediate termination of TVM.
+
+Most of these exceptions have no parameter (i.e., use a zero integer instead).
+The order in which these exceptions are checked is outlined below in .
+
+[sp:exc.check.order] **Order of stack underflow, type check, and range check
+exceptions.** All TVM primitives first check whether the stack contains the
+required number of arguments, generating a stack underflow exception if this
+is not the case. Only then are the type tags of the arguments and their ranges
+(e.g., if a primitive expects an argument not only to be an _Integer_ , but
+also to be in the range from 0 to 256) checked, starting from the value in the
+top of the stack (the last argument) and proceeding deeper into the stack. If
+an argument’s type is incorrect, a type-checking exception is generated; if
+the type is correct, but the value does not fall into the expected range, a
+range check exception is generated.
+
+Some primitives accept a variable number of arguments, depending on the values
+of some small fixed subset of arguments located near the top of the stack. In
+this case, the above procedure is first run for all arguments from this small
+subset. Then it is repeated for the remaining arguments, once their number and
+types have been determined from the arguments already processed.
+
+## Functions, recursion, and dictionaries
+
+[p:func.rec.dict]
+
+**The problem of recursion.** The conditional and iterated execution
+primitives described in —along with the unconditional branch, call, and return
+primitives described in — enable one to implement more or less arbitrary code
+with nested loops and conditional expressions, with one notable exception: one
+can only create new constant continuations from parts of the current
+continuation. (In particular, one cannot invoke a subroutine from itself in
+this way.) Therefore, the code being executed—i.e., the current
+continuation—gradually becomes smaller and smaller.24
+
+**_Y_ -combinator solution: pass a continuation as an argument to itself.**
+One way of dealing with the problem of recursion is by passing a copy of the
+continuation representing the body of a recursive function as an extra
+argument to itself. Consider, for example, the following code for a factorial
+function:
+
+    
+    
+    71      PUSHINT 1
+    9C      PUSHCONT {
+    22        PUSH s2
+    72        PUSHINT 2
+    B9        LESS
+    DC        IFRET
+    59        ROTREV
+    21        PUSH s1
+    A8        MUL
+    01        SWAP
+    A5        DEC
+    02        XCHG s2
+    20        DUP
+    D9        JMPX
+            }
+    20      DUP
+    D8      EXECUTE
+    30      DROP
+    31      NIP
+
+This roughly corresponds to defining an auxiliary function _body_ with three
+arguments _n_ , _x_ , and _f_ , such that _body_ ( _n_ , _x_ , _f_ ) equals
+_x_ if _n_ < 2 and _f_ ( _n_ − 1, _n_ _x_ , _f_ ) otherwise, then invoking
+_body_ ( _n_ , 1, _body_ ) to compute the factorial of _n_. The recursion is
+then implemented with the aid of the `DUP`; `EXECUTE` construction, or `DUP`;
+`JMPX` in the case of tail recursion. This trick is equivalent to applying _Y_
+-combinator to a function _body_.
+
+**A variant of _Y_ -combinator solution.** Another way of recursively
+computing the factorial, more closely following the classical recursive
+definition  
+$$\textit{fact}(n):= \begin{cases} 1&\quad\text{if $n<2$},\\\
+n\cdot\textit{fact}(n-1)&\quad\text{otherwise} \end{cases}$$  
+is as follows:
+
+    
+    
+    9D      PUSHCONT {
+    21        OVER
+    C102      LESSINT 2
+    92        PUSHCONT {
+    5B          2DROP
+    71          PUSHINT 1
+              }
+    E0        IFJMP
+    21        OVER
+    A5        DEC
+    01        SWAP
+    20        DUP
+    D8        EXECUTE
+    A8        MUL
+            }
+    20      DUP
+    D9      JMPX
+
+This definition of the factorial function is two bytes shorter than the
+previous one, but it uses general recursion instead of tail recursion, so it
+cannot be easily transformed into a loop.
+
+**Comparison: non-recursive definition of the factorial function.**
+Incidentally, a non-recursive definition of the factorial with the aid of a
+`REPEAT` loop is also possible, and it is much shorter than both recursive
+definitions:
+
+    
+    
+    71      PUSHINT 1
+    01      SWAP
+    20      DUP
+    94      PUSHCONT {
+    66        TUCK
+    A8        MUL
+    01        SWAP
+    A5        DEC
+            }
+    E4      REPEAT
+    30      DROP
+
+**Several mutually recursive functions.** If one has a collection _f_ 1, …,
+_f_ _n_ of mutually recursive functions, one can use the same trick by passing
+the whole collection of continuations { _f_ _i_ } in the stack as an extra _n_
+arguments to each of these functions. However, as _n_ grows, this becomes more
+and more cumbersome, since one has to reorder these extra arguments in the
+stack to work with the “true” arguments, and then push their copies into the
+top of the stack before any recursive call.
+
+**Combining several functions into one tuple.** One might also combine a
+collection of continuations representing functions _f_ 1, …, _f_ _n_ into a
+“tuple” **f** := ( _f_ 1, …, _f_ _n_ ), and pass this tuple as one stack
+element **f**. For instance, when _n_ ≤ 4, each function can be represented by
+a cell _f̃_ _i_ (along with the tree of cells rooted in this cell), and the
+tuple may be represented by a cell $\tilde{\mathbf f}$, which has references
+to its component cells _f̃_ _i_. However, this would lead to the necessity of
+“unpacking” the needed component from this tuple before each recursive call.
+
+**Combining several functions into a selector function.** Another approach is
+to combine several functions _f_ 1, …, _f_ _n_ into one “selector function”
+_f_ , which takes an extra argument _i_ , 1 ≤ _i_ ≤ _n_ , from the top of the
+stack, and invokes the appropriate function _f_ _i_. Stack machines such as
+TVM are well-suited to this approach, because they do not require the
+functions _f_ _i_ to have the same number and types of arguments. Using this
+approach, one would need to pass only one extra argument, _f_ , to each of
+these functions, and push into the stack an extra argument _i_ before each
+recursive call to _f_ to select the correct function to be called.
+
+**Using a dedicated register to keep the selector function.** However, even if
+we use one of the two previous approaches to combine all functions into one
+extra argument, passing this argument to all mutually recursive functions is
+still quite cumbersome and requires a lot of additional stack manipulation
+operations. Because this argument changes very rarely, one might use a
+dedicated register to keep it and transparently pass it to all functions
+called. This is the approach used by TVM by default.
+
+**Special register`c3` for the selector function.** In fact, TVM uses a
+dedicated register `c3` to keep the continuation representing the current or
+global “selector function”, which can be used to invoke any of a family of
+mutually recursive functions. Special primitives `CALL nn` or `CALLDICT nn`
+(cf. ) are equivalent to `PUSHINT nn`; `PUSH c3`; `EXECUTE`, and similarly
+`JMP nn` or `JMPDICT nn` are equivalent to `PUSHINT nn`; `PUSH c3`; `JMPX`. In
+this way a TVM program, which ultimately is a large collection of mutually
+recursive functions, may initialize `c3` with the correct selector function
+representing the family of all the functions in the program, and then use
+`CALL nn` to invoke any of these functions by its index (sometimes also called
+the _selector_ of a function).
+
+**Initialization of`c3`.** A TVM program might initialize `c3` by means of a
+`POP c3` instruction. However, because this usually is the very first action
+undertaken by a program (e.g., a smart contract), TVM makes some provisions
+for the automatic initialization of `c3`. Namely, `c3` is initialized by the
+code (the initial value of `cc`) of the program itself, and an extra zero (or,
+in some cases, some other predefined number _s_ ) is pushed into the stack
+before the program’s execution. This is approximately equivalent to invoking
+`JMPDICT 0` (or `JMPDICT s`) at the very beginning of a program—i.e., the
+function with index zero is effectively the `main()` function for the program.
+
+**Creating selector functions and`switch` statements.** TVM makes special
+provisions for simple and concise implementation of selector functions (which
+usually constitute the top level of a TVM program) or, more generally,
+arbitrary `switch` or `case` statements (which are also useful in `TVM`
+programs). The most important primitives included for this purpose are
+`IFBITJMP`, `IFNBITJMP`, `IFBITJMPREF`, and `IFNBITJMPREF` (cf. ). They
+effectively enable one to combine subroutines, kept either in separate cells
+or as subslices of certain cells, into a binary decision tree with decisions
+made according to the indicated bits of the integer passed in the top of the
+stack.
+
+Another instruction, useful for the implementation of sum-product types, is
+`PLDUZ` (cf. ). This instruction preloads the first several bits of a _Slice_
+into an _Integer_ , which can later be inspected by `IFBITJMP` and other
+similar instructions.
+
+**Alternative: using a hashmap to select the correct function.** Yet another
+alternative is to use a _Hashmap_ (cf. ) to hold the “collection” or
+“dictionary” of the code of all functions in a program, and use the hashmap
+lookup primitives (cf. ) to select the code of the required function, which
+can then be `BLESS`ed into a continuation (cf. ) and executed. Special
+combined “lookup, bless, and execute” primitives, such as `DICTIGETJMP` and
+`DICTIGETEXEC`, are also available (cf. ). This approach may be more efficient
+for larger programs and `switch` statements.
+
+# Codepages and instruction encoding
+
+This chapter describes the codepage mechanism, which allows TVM to be flexible
+and extendable while preserving backward compatibility with respect to
+previously generated code.
+
+We also discuss some general considerations about instruction encodings
+(applicable to arbitrary machine code, not just TVM), as well as the
+implications of these considerations for TVM and the choices made while
+designing TVM’s (experimental) codepage zero. The instruction encodings
+themselves are presented later in Appendix .
+
+## Codepages and interoperability of different TVM versions
+
+[p:codepages]
+
+The _codepages_ are an essential mechanism of backward compatibility and of
+future extensions to TVM. They enable transparent execution of code written
+for different revisions of TVM, with transparent interaction between instances
+of such code. The mechanism of the codepages, however, is general and powerful
+enough to enable some other originally unintended applications.
+
+**Codepages in continuations.** Every ordinary continuation contains a 16-bit
+_codepage_ field `cp` (cf. ), which determines the codepage that will be used
+to execute its code. If a continuation is created by a `PUSHCONT` (cf. ) or
+similar primitive, it usually inherits the current codepage (i.e., the
+codepage of `cc`).25
+
+**Current codepage.** The current codepage `cp` (cf. ) is the codepage of the
+current continuation `cc`. It determines the way the next instruction will be
+decoded from `cc.code`, the remainder of the current continuation’s code. Once
+the instruction has been decoded and executed, it determines the next value of
+the current codepage. In most cases, the current codepage is left unchanged.
+
+On the other hand, all primitives that switch the current continuation load
+the new value of `cp` from the new current continuation. In this way, all code
+in continuations is always interpreted exactly as it was intended to be.
+
+**Different versions of TVM may use different codepages.** Different versions
+of TVM may use different codepages for their code. For example, the original
+version of TVM might use codepage zero. A newer version might use codepage
+one, which contains all the previously defined opcodes, along with some newly
+defined ones, using some of the previously unused opcode space. A subsequent
+version might use yet another codepage, and so on.
+
+However, a newer version of TVM will execute old code for codepage zero
+exactly as before. If the old code contained an opcode used for some new
+operations that were undefined in the original version of TVM, it will still
+generate an invalid opcode exception, because the new operations are absent in
+codepage zero.
+
+[sp:old.op.change] **Changing the behavior of old operations.** New codepages
+can also change the effects of some operations present in the old codepages
+while preserving their opcodes and mnemonics.
+
+For example, imagine a future 513-bit upgrade of TVM (replacing the current
+257-bit design). It might use a 513-bit _Integer_ type within the same
+arithmetic primitives as before. However, while the opcodes and instructions
+in the new codepage would look exactly like the old ones, they would work
+differently, accepting 513-bit integer arguments and results. On the other
+hand, during the execution of the same code in codepage zero, the new machine
+would generate exceptions whenever the integers used in arithmetic and other
+primitives do not fit into 257 bits.26 In this way, the upgrade would not
+change the behavior of the old code.
+
+**Improving instruction encoding.** Another application for codepages is to
+change instruction encodings, reflecting improved knowledge of the actual
+frequencies of such instructions in the code base. In this case, the new
+codepage will have exactly the same instructions as the old one, but with
+different encodings, potentially of differing lengths. For example, one might
+create an experimental version of the first version of TVM, using a (prefix)
+bitcode instead of the original bytecode, aiming to achieve higher code
+density.
+
+[sp:context.instr.enc] **Making instruction encoding context-dependent.**
+Another way of using codepages to improve code density is to use several
+codepages with different subsets of the whole instruction set defined in each
+of them, or with the whole instruction set defined, but with different length
+encodings for the same instructions in different codepages.
+
+Imagine, for instance, a “stack manipulation” codepage, where stack
+manipulation primitives have short encodings at the expense of all other
+operations, and a “data processing” codepage, where all other operations are
+shorter at the expense of stack manipulation operations. If stack manipulation
+operations tend to come one after another, we can automatically switch to
+“stack manipulation” codepage after executing any such instruction. When a
+data processing instruction occurs, we switch back to “data processing”
+codepage. If conditional probabilities of the class of the next instruction
+depending on the class of the previous instruction are considerably different
+from corresponding unconditional probabilities, this technique—automatically
+switching into stack manipulation mode to rearrange the stack with shorter
+instructions, then switching back—might considerably improve the code density.
+
+**Using codepages for status and control flags.** Another potential
+application of multiple codepages inside the same revision of TVM consists in
+switching between several codepages depending on the result of the execution
+of some instructions.
+
+For example, imagine a version of TVM that uses two new codepages, 2 and 3.
+Most operations do not change the current codepage. However, the integer
+comparison operations will switch to codepage 2 if the condition is false, and
+to codepage 3 if it is true. Furthermore, a new operation `?EXECUTE`, similar
+to `EXECUTE`, will indeed be equivalent to `EXECUTE` in codepage 3, but will
+instead be a `DROP` in codepage 2. Such a trick effectively uses bit 0 of the
+current codepage as a status flag.
+
+Alternatively, one might create a couple of codepages—say, 4 and 5—which
+differ only in their cell deserialisation primitives. For instance, in
+codepage 4 they might work as before, while in codepage 5 they might
+deserialize data not from the beginning of a _Slice_ , but from its end. Two
+new instructions—say, `CLD` and `STD`—might be used for switching to codepage
+4 or codepage 5. Clearly, we have now described a status flag, affecting the
+execution of some instructions in a certain new manner.
+
+**Setting the codepage in the code itself.** [sp:setcp.opc] For convenience,
+we reserve some opcode in all codepages—say, `FF n`—for the instruction `SETCP
+n`, with _n_ from 0 to 255 (cf. ). Then by inserting such an instruction into
+the very beginning of (the main function of) a program (e.g., a TON Blockchain
+smart contract) or a library function, we can ensure that the code will always
+be executed in the intended codepage.
+
+## Instruction encoding
+
+[p:instr.encode]
+
+This section discusses the general principles of instruction encoding valid
+for all codepages and all versions of TVM. Later, discusses the choices made
+for the experimental “codepage zero”.
+
+**Instructions are encoded by a binary prefix code.** All complete
+instructions (i.e., instructions along with all their parameters, such as the
+names of stack registers _s_ ( _i_ ) or other embedded constants) of a TVM
+codepage are encoded by a _binary prefix code_. This means that a (finite)
+binary string (i.e., a bitstring) corresponds to each complete instruction, in
+such a way that binary strings corresponding to different complete
+instructions do not coincide, and no binary string among the chosen subset is
+a prefix of another binary string from this subset.
+
+**Determining the first instruction from a code stream.** As a consequence of
+this encoding method, any binary string admits at most one prefix, which is an
+encoding of some complete instruction. In particular, the code `cc.code` of
+the current continuation (which is a _Slice_ , and thus a bitstring along with
+some cell references) admits at most one such prefix, which corresponds to the
+(uniquely determined) instruction that TVM will execute first. After
+execution, this prefix is removed from the code of the current continuation,
+and the next instruction can be decoded.
+
+**Invalid opcode.** If no prefix of `cc.code` encodes a valid instruction in
+the current codepage, an _invalid opcode exception_ is generated (cf. ).
+However, the case of an empty `cc.code` is treated separately as explained in
+(the exact behavior may depend on the current codepage).
+
+**Special case: end-of-code padding.** As an exception to the above rule, some
+codepages may accept some values of `cc.code` that are too short to be valid
+instruction encodings as additional variants of `NOP`, thus effectively using
+the same procedure for them as for an empty `cc.code`. Such bitstrings may be
+used for padding the code near its end.
+
+For example, if binary string `00000000` (i.e., `x00`, cf. ) is used in a
+codepage to encode `NOP`, its proper prefixes cannot encode any instructions.
+So this codepage may accept `0`, `00`, `000`, …, `0000000` as variants of
+`NOP` if this is all that is left in `cc.code`, instead of generating an
+invalid opcode exception.
+
+Such a padding may be useful, for example, if the `PUSHCONT` primitive (cf. )
+creates only continuations with code consisting of an integral number of
+bytes, but not all instructions are encoded by an integral number of bytes.
+
+[sp:bitcode] **TVM code is a bitcode, not a bytecode.** Recall that TVM is a
+bit-oriented machine in the sense that its _Cell_ s (and _Slice_ s) are
+naturally considered as sequences of bits, not just of octets (bytes), cf. .
+Because the TVM code is also kept in cells (cf. and ), there is no reason to
+use only bitstrings of length divisible by eight as encodings of complete
+instructions. In other words, generally speaking, _the TVM code is a bitcode,
+not a bytecode_.
+
+That said, some codepages (such as our experimental codepage zero) may opt to
+use a bytecode (i.e., to use only encodings consisting of an integral number
+of bytes)—either for simplicity, or for the ease of debugging and of studying
+memory (i.e., cell) dumps.27
+
+**Opcode space used by a complete instruction.** Recall from coding theory
+that the lengths of bitstrings _l_ _i_ used in a binary prefix code satisfy
+Kraft–McMillan inequality ∑ _i_ 2 − _l_ _i_ ≤ 1. This is applicable in
+particular to the (complete) instruction encoding used by a TVM codepage. We
+say that _a particular complete instruction_ (or, more precisely, _the
+encoding of a complete instruction_ ) _utilizes the portion 2 − _l_ of the
+opcode space_, if it is encoded by an _l_ -bit string. One can see that all
+complete instructions together utilize at most 1 (i.e., “at most the whole
+opcode space”).
+
+**Opcode space used by an instruction, or a class of instructions.** The above
+terminology is extended to instructions (considered with all admissible values
+of their parameters), or even classes of instructions (e.g., all arithmetic
+instructions). We say that an (incomplete) instruction, or a class of
+instructions, occupies portion _α_ of the opcode space, if _α_ is the sum of
+the portions of the opcode space occupied by all complete instructions
+belonging to that class.
+
+**Opcode space for bytecodes.** A useful approximation of the above
+definitions is as follows: Consider all 256 possible values for the first byte
+of an instruction encoding. Suppose that _k_ of these values correspond to the
+specific instruction or class of instructions we are considering. Then this
+instruction or class of instructions occupies approximately the portion _k_
+/256 of the opcode space.
+
+This approximation shows why all instructions cannot occupy together more than
+the portion 256/256 = 1 of the opcode space, at least without compromising the
+uniqueness of instruction decoding.
+
+[sp:opcode.sp.distr] **Almost optimal encodings.** Coding theory tells us that
+in an optimally dense encoding, the portion of the opcode space used by a
+complete instruction (2 − _l_ , if the complete instruction is encoded in _l_
+bits) should be approximately equal to the probability or frequency of its
+occurrence in real programs.28 The same should hold for (incomplete)
+instructions, or primitives (i.e., generic instructions without specified
+values of parameters), and for classes of instructions.
+
+[sp:stk.opcode.distr] **Example: stack manipulation primitives.** For
+instance, if stack manipulation instructions constitute approximately half of
+all instructions in a typical TVM program, one should allocate approximately
+half of the opcode space for encoding stack manipulation instructions. One
+might reserve the first bytes (“opcodes”) `0x00`–`0x7f` for such instructions.
+If a quarter of these instructions are `XCHG`, it would make sense to reserve
+`0x00`–`0x1f` for `XCHG`s. Similarly, if half of all `XCHG`s involve the top
+of stack `s0`, it would make sense to use `0x00`–`0x0f` to encode `XCHG
+s0,s(i)`.
+
+[sp:simple.enc] **Simple encodings of instructions.** In most cases, _simple_
+encodings of complete instructions are used. Simple encodings begin with a
+fixed bitstring called the _opcode_ of the instruction, followed by, say,
+4-bit fields containing the indices _i_ of stack registers `s(i)` specified in
+the instruction, followed by all other constant (literal, immediate)
+parameters included in the complete instruction. While simple encodings may
+not be exactly optimal, they admit short descriptions, and their decoding and
+encoding can be easily implemented.
+
+If a (generic) instruction uses a simple encoding with an _l_ -bit opcode,
+then the instruction will utilize 2 − _l_ portion of the opcode space. This
+observation might be useful for considerations described in and .
+
+**Optimizing code density further: Huffman codes.** One might construct
+optimally dense binary code for the set of all complete instructions, provided
+their probabilities or frequences in real code are known. This is the well-
+known Huffman code (for the given probability distribution). However, such
+code would be highly unsystematic and hard to decode.
+
+[sp:pract.enc] **Practical instruction encodings.** In practice, instruction
+encodings used in TVM and other virtual machines offer a compromise between
+code density and ease of encoding and decoding. Such a compromise may be
+achieved by selecting simple encodings (cf. ) for all instructions (maybe with
+separate simple encodings for some often used variants, such as `XCHG s0,s(i)`
+among all `XCHG s(i),s(j)`), and allocating opcode space for such simple
+encodings using the heuristics outlined in and ; this is the approach
+currently used in TVM.
+
+## Instruction encoding in codepage zero
+
+[p:cp0.instr.enc]
+
+This section provides details about the experimental instruction encoding for
+codepage zero, as described elsewhere in this document (cf. Appendix ) and
+used in the preliminary test version of TVM.
+
+**Upgradability.** First of all, even if this preliminary version somehow gets
+into the production version of the TON Blockchain, the codepage mechanism (cf.
+) enables us to introduce better versions later without compromising backward
+compatibility.29 So in the meantime, we are free to experiment.
+
+**Choice of instructions.** We opted to include many “experimental” and not
+strictly necessary instructions in codepage zero just to see how they might be
+used in real code. For example, we have both the basic (cf. ) and the compound
+(cf. ) stack manipulation primitives, as well as some “unsystematic” ones such
+as `ROT` (mostly borrowed from Forth). If such primitives are rarely used,
+their inclusion just wastes some part of the opcode space and makes the
+encodings of other instructions slightly less effective, something we can
+afford at this stage of TVM’s development.
+
+**Using experimental instructions.** Some of these experimental instructions
+have been assigned quite long opcodes, just to fit more of them into the
+opcode space. One should not be afraid to use them just because they are long;
+if these instructions turn out to be useful, they will receive shorter opcodes
+in future revisions. Codepage zero is not meant to be fine-tuned in this
+respect.
+
+**Choice of bytecode.** We opted to use a bytecode (i.e., to use encodings of
+complete instructions of lengths divisible by eight). While this may not
+produce optimal code density, because such a length restriction makes it more
+difficult to match portions of opcode space used for the encoding of
+instructions with estimated frequencies of these instructions in TVM code (cf.
+and ), such an approach has its advantages: it admits a simpler instruction
+decoder and simplifies debugging (cf. ).
+
+After all, we do not have enough data on the relative frequencies of different
+instructions right now, so our code density optimizations are likely to be
+very approximate at this stage. The ease of debugging and experimenting and
+the simplicity of implementation are more important at this point.
+
+**Simple encodings for all instructions.** For similar reasons, we opted to
+use simple encodings for all instructions (cf. and ), with separate simple
+encodings for some very frequently used subcases as outlined in . That said,
+we tried to distribute opcode space using the heuristics described in and .
+
+**Lack of context-dependent encodings.** This version of TVM also does not use
+context-dependent encodings (cf. ). They may be added at a later stage, if
+deemed useful.
+
+**The list of all instructions.** The list of all instructions available in
+codepage zero, along with their encodings and (in some cases) short
+descriptions, may be found in Appendix .
+
+2
+
+N. Durov, _The Open Network_ , 2017.
+
+# Instructions and opcodes
+
+[app:opcodes]
+
+This appendix lists all instructions available in the (experimental) codepage
+zero of TVM, as explained in .
+
+We list the instructions in lexicographical opcode order. However, the opcode
+space is distributed in such way as to make all instructions in each category
+(e.g., arithmetic primitives) have neighboring opcodes. So we first list a
+number of stack manipulation primitives, then constant primitives, arithmetic
+primitives, comparison primitives, cell primitives, continuation primitives,
+dictionary primitives, and finally application-specific primitives.
+
+We use hexadecimal notation (cf. ) for bitstrings. Stack registers `s(i)`
+usually have 0 ≤ _i_ ≤ 15, and _i_ is encoded in a 4-bit field (or, on a few
+rare occasions, in an 8-bit field). Other immediate parameters are usually
+4-bit, 8-bit, or variable length.
+
+The stack notation described in is extensively used throughout this appendix.
+
+## Gas prices
+
+The gas price for most primitives equals the _basic gas price_ , computed as
+_P_ _b_ := 10 + _b_ \+ 5 _r_ , where _b_ is the instruction length in bits and
+_r_ is the number of cell references included in the instruction. When the gas
+price of an instruction differs from this basic price, it is indicated in
+parentheses after its mnemonics, either as _( _x_ )_, meaning that the total
+gas price equals _x_ , or as _( \+ _x_ )_, meaning _P_ _b_ \+ _x_. Apart from
+integer constants, the following expressions may appear:
+
+  * _C_ _r_ — The total price of “reading” cells (i.e., transforming cell references into cell slices). Currently equal to 100 or 25 gas units per cell depending on whether it is the first time a cell with this hash is being “read” during the current run of the VM or not.
+
+  * _L_ — The total price of loading cells. Depends on the loading action required.
+
+  * _B_ _w_ — The total price of creating new _Builder_ s. Currently equal to 0 gas units per builder.
+
+  * _C_ _w_ — The total price of creating new _Cell_ s from _Builder_ s. Currently equal to 500 gas units per cell.
+
+By default, the gas price of an instruction equals _P_ := _P_ _b_ \+ _C_ _r_
+\+ _L_ \+ _B_ _w_ \+ _C_ _w_.
+
+## Stack manipulation primitives
+
+This section includes both the basic (cf. ) and the compound (cf. ) stack
+manipulation primitives, as well as some “unsystematic” ones. Some compound
+stack manipulation primitives, such as `XCPU` or `XCHG2`, turn out to have the
+same length as an equivalent sequence of simpler operations. We have included
+these primitives regardless, so that they can easily be allocated shorter
+opcodes in a future revision of TVM—or removed for good.
+
+Some stack manipulation instructions have two mnemonics: one Forth-style
+(e.g., `-ROT`), the other conforming to the usual rules for identifiers (e.g.,
+`ROTREV`). Whenever a stack manipulation primitive (e.g., `PICK`) accepts an
+integer parameter _n_ from the stack, it must be within the range 0…255;
+otherwise a range check exception happens before any further checks.
+
+**Basic stack manipulation primitives.**
+
+  * `00` — `NOP`, does nothing.
+
+  * `01` — `XCHG s1`, also known as `SWAP`.
+
+  * `0i` — `XCHG s(i)` or `XCHG s0,s(i)`, interchanges the top of the stack with `s(i)`, 1 ≤ _i_ ≤ 15.
+
+  * `10ij` — `XCHG s(i),s(j)`, 1 ≤ _i_ < _j_ ≤ 15, interchanges `s(i)` with `s(j)`.
+
+  * `11ii` — `XCHG s0,s(ii)`, with 0 ≤ _i_ _i_ ≤ 255.
+
+  * `1i` — `XCHG s1,s(i)`, 2 ≤ _i_ ≤ 15.
+
+  * `2i` — `PUSH s(i)`, 0 ≤ _i_ ≤ 15, pushes a copy of the old `s(i)` into the stack.
+
+  * `20` — `PUSH s0`, also known as `DUP`.
+
+  * `21` — `PUSH s1`, also known as `OVER`.
+
+  * `3i` — `POP s(i)`, 0 ≤ _i_ ≤ 15, pops the old top-of-stack value into the old `s(i)`.
+
+  * `30` — `POP s0`, also known as `DROP`, discards the top-of-stack value.
+
+  * `31` — `POP s1`, also known as `NIP`.
+
+**Compound stack manipulation primitives.** Parameters _i_ , _j_ , and _k_ of
+the following primitives all are 4-bit integers in the range 0…15.
+
+  * `4ijk` — `XCHG3 s(i),s(j),s(k)`, equivalent to `XCHG s2,s(i)`; `XCHG s1, s(j)`; `XCHG s0,s(k)`, with 0 ≤ _i_ , _j_ , _k_ ≤ 15.
+
+  * `50ij` — `XCHG2 s(i),s(j)`, equivalent to `XCHG s1,s(i)`; `XCHG s(j)`.
+
+  * `51ij` — `XCPU s(i),s(j)`, equivalent to `XCHG s(i)`; `PUSH s(j)`.
+
+  * `52ij` — `PUXC s(i),s(j-1)`, equivalent to `PUSH s(i)`; `SWAP`; `XCHG s(j)`.
+
+  * `53ij` — `PUSH2 s(i),s(j)`, equivalent to `PUSH s(i)`; `PUSH s(j+1)`.
+
+  * `540ijk` — `XCHG3 s(i),s(j),s(k)` (long form).
+
+  * `541ijk` — `XC2PU s(i),s(j),s(k)`, equivalent to `XCHG2 s(i),s(j)`; `PUSH s(k)`.
+
+  * `542ijk` — `XCPUXC s(i),s(j),s(k-1)`, equivalent to `XCHG s1,s(i)`; `PUXC s(j),s(k-1)`.
+
+  * `543ijk` — `XCPU2 s(i),s(j),s(k)`, equivalent to `XCHG s(i)`; `PUSH2 s(j), s(k)`.
+
+  * `544ijk` — `PUXC2 s(i),s(j-1),s(k-1)`, equivalent to `PUSH s(i)`; `XCHG s2`; `XCHG2 s(j),s(k)`.
+
+  * `545ijk` — `PUXCPU s(i),s(j-1),s(k-1)`, equivalent to `PUXC s(i),s(j-1)`; `PUSH s(k)`.
+
+  * `546ijk` — `PU2XC s(i),s(j-1),s(k-2)`, equivalent to `PUSH s(i)`; `SWAP;` `PUXC s(j),s(k-1)`.
+
+  * `547ijk` — `PUSH3 s(i),s(j),s(k)`, equivalent to `PUSH s(i)`; `PUSH2 s(j+1),s(k+1)`.
+
+  * `54C_` — unused.
+
+**Exotic stack manipulation primitives.**
+
+  * `55ij` — `BLKSWAP i+1,j+1`, permutes two blocks `s(j+i+1)`…`s(j+1)` and `s(j)`…`s0`, for 0 ≤ _i_ , _j_ ≤ 15. Equivalent to `REVERSE i+1,j+1`; `REVERSE j+1,0`; `REVERSE i+j+2,0`.
+
+  * `5513` — `ROT2` or `2ROT` ( _a_ _b_ _c_ _d_ _e_ _f_ – _c_ _d_ _e_ _f_ _a_ _b_ ), rotates the three topmost pairs of stack entries.
+
+  * `550i` — `ROLL i+1`, rotates the top _i_ \+ 1 stack entries. Equivalent to `BLKSWAP 1,i+1`.
+
+  * `55i0` — `ROLLREV i+1` or `-ROLL i+1`, rotates the top _i_ \+ 1 stack entries in the other direction. Equivalent to `BLKSWAP i+1,1`.
+
+  * `56ii` — `PUSH s(ii)` for 0 ≤ _i_ _i_ ≤ 255.
+
+  * `57ii` — `POP s(ii)` for 0 ≤ _i_ _i_ ≤ 255.
+
+  * `58` — `ROT` ( _a_ _b_ _c_ – _b_ _c_ _a_ ), equivalent to `BLKSWAP 1,2` or to `XCHG2 s2,s1`.
+
+  * `59` — `ROTREV` or `-ROT` ( _a_ _b_ _c_ – _c_ _a_ _b_ ), equivalent to `BLKSWAP 2,1` or to `XCHG2 s2,s2`.
+
+  * `5A` — `SWAP2` or `2SWAP` ( _a_ _b_ _c_ _d_ – _c_ _d_ _a_ _b_ ), equivalent to `BLKSWAP 2,2` or to `XCHG2 s3,s2`.
+
+  * `5B` — `DROP2` or `2DROP` ( _a_ _b_ – ), equivalent to `DROP`; `DROP`.
+
+  * `5C` — `DUP2` or `2DUP` ( _a_ _b_ – _a_ _b_ _a_ _b_ ), equivalent to `PUSH2 s1,s0`.
+
+  * `5D` — `OVER2` or `2OVER` ( _a_ _b_ _c_ _d_ – _a_ _b_ _c_ _d_ _a_ _b_ ), equivalent to `PUSH2 s3,s2`.
+
+  * `5Eij` — `REVERSE i+2,j`, reverses the order of `s(j+i+1)`…`s(j)` for 0 ≤ _i_ , _j_ ≤ 15; equivalent to a sequence of ⌊ _i_ /2⌋ + 1 `XCHG`s.
+
+  * `5F0i` — `BLKDROP i`, equivalent to `DROP` performed _i_ times.
+
+  * `5Fij` — `BLKPUSH i,j`, equivalent to `PUSH s(j)` performed _i_ times, 1 ≤ _i_ ≤ 15, 0 ≤ _j_ ≤ 15.
+
+  * `60` — `PICK` or `PUSHX`, pops integer _i_ from the stack, then performs `PUSH s(i)`.
+
+  * `61` — `ROLLX`, pops integer _i_ from the stack, then performs `BLKSWAP 1,i`.
+
+  * `62` — `-ROLLX` or `ROLLREVX`, pops integer _i_ from the stack, then performs `BLKSWAP i,1`.
+
+  * `63` — `BLKSWX`, pops integers _i_ , _j_ from the stack, then performs `BLKSWAP i,j`.
+
+  * `64` — `REVX`, pops integers _i_ , _j_ from the stack, then performs `REVERSE i,j`.
+
+  * `65` — `DROPX`, pops integer _i_ from the stack, then performs `BLKDROP i`.
+
+  * `66` — `TUCK` ( _a_ _b_ − _b_ _a_ _b_ ), equivalent to `SWAP`; `OVER` or to `XCPU s1,s1`.
+
+  * `67` — `XCHGX`, pops integer _i_ from the stack, then performs `XCHG s(i)`.
+
+  * `68` — `DEPTH`, pushes the current depth of the stack.
+
+  * `69` — `CHKDEPTH`, pops integer _i_ from the stack, then checks whether there are at least _i_ elements, generating a stack underflow exception otherwise.
+
+  * `6A` — `ONLYTOPX`, pops integer _i_ from the stack, then removes all but the top _i_ elements.
+
+  * `6B` — `ONLYX`, pops integer _i_ from the stack, then leaves only the bottom _i_ elements. Approximately equivalent to `DEPTH`; `SWAP`; `SUB`; `DROPX`.
+
+  * `6C00`–`6C0F` — reserved for stack operations.
+
+  * `6Cij` — `BLKDROP2 i,j`, drops _i_ stack elements under the top _j_ elements, where 1 ≤ _i_ ≤ 15 and 0 ≤ _j_ ≤ 15. Equivalent to `REVERSE i+j,0`; `BLKDROP i`; `REVERSE j,0`.
+
+## Tuple, List, and Null primitives
+
+_Tuple_ s are ordered collections consisting of at most 255 TVM stack values
+of arbitrary types (not necessarily the same). Tuple primitives create,
+modify, and unpack _Tuple_ s; they manipulate values of arbitrary types in the
+process, similarly to the stack primitives. We do not recommend using _Tuple_
+s of more than 15 elements.
+
+When a _Tuple_ _t_ contains elements _x_ 1, …, _x_ _n_ (in that order), we
+write _t_ = ( _x_ 1, …, _x_ _n_ ); number _n_ ≥ 0 is the _length_ of _Tuple_
+_t_. It is also denoted by | _t_ |. _Tuple_ s of length two are called _pairs_
+, and _Tuple_ s of length three are _triples_.
+
+Lisp-style lists are represented with the aid of pairs, i.e., tuples
+consisting of exactly two elements. An empty list is represented by a _Null_
+value, and a non-empty list is represented by pair ( _h_ , _t_ ), where _h_ is
+the first element of the list, and _t_ is its tail.
+
+**_Null_ primitives.**[sp:null.ops] The following primitives work with (the
+only) value ⊥ of type _Null_ , useful for representing empty lists, empty
+branches of binary trees, and absence of values in _Maybe _X__ types. An empty
+_Tuple_ created by `NIL` could have been used for the same purpose; however,
+_Null_ is more efficient and costs less gas.
+
+  * `6D` — `NULL` or `PUSHNULL` ( – ⊥), pushes the only value of type _Null_.
+
+  * `6E` — `ISNULL` ( _x_ – ?), checks whether _x_ is a _Null_ , and returns  − 1 or 0 accordingly.
+
+**Tuple primitives.** [sp:prim.tuple]
+
+  * `6F0n` — `TUPLE n` ( _x_ 1 … _x_ _n_ – _t_ ), creates a new _Tuple_ _t_ = ( _x_ 1, …, _x_ _n_ ) containing _n_ values _x_ 1, …, _x_ _n_ , where 0 ≤ _n_ ≤ 15.
+
+  * `6F00` — `NIL` ( – _t_ ), pushes the only _Tuple_ _t_ = () of length zero.
+
+  * `6F01` — `SINGLE` ( _x_ – _t_ ), creates a singleton _t_ := ( _x_ ), i.e., a _Tuple_ of length one.
+
+  * `6F02` — `PAIR` or `CONS` ( _x_ _y_ – _t_ ), creates pair _t_ := ( _x_ , _y_ ).
+
+  * `6F03` — `TRIPLE` ( _x_ _y_ _z_ – _t_ ), creates triple _t_ := ( _x_ , _y_ , _z_ ).
+
+  * `6F1k` — `INDEX k` ( _t_ – _x_ ), returns the _k_ -th element of a _Tuple_ _t_ , where 0 ≤ _k_ ≤ 15. In other words, returns _x_ _k_ \+ 1 if _t_ = ( _x_ 1, …, _x_ _n_ ). If _k_ ≥ _n_ , throws a range check exception.
+
+  * `6F10` — `FIRST` or `CAR` ( _t_ – _x_ ), returns the first element of a _Tuple_.
+
+  * `6F11` — `SECOND` or `CDR` ( _t_ – _y_ ), returns the second element of a _Tuple_.
+
+  * `6F12` — `THIRD` ( _t_ – _z_ ), returns the third element of a _Tuple_.
+
+  * `6F2n` — `UNTUPLE n` ( _t_ – _x_ 1 … _x_ _n_ ), unpacks a _Tuple_ _t_ = ( _x_ 1, …, _x_ _n_ ) of length equal to 0 ≤ _n_ ≤ 15. If _t_ is not a _Tuple_ , of if | _t_ | ≠ _n_ , a type check exception is thrown.
+
+  * `6F21` — `UNSINGLE` ( _t_ – _x_ ), unpacks a singleton _t_ = ( _x_ ).
+
+  * `6F22` — `UNPAIR` or `UNCONS` ( _t_ – _x_ _y_ ), unpacks a pair _t_ = ( _x_ , _y_ ).
+
+  * `6F23` — `UNTRIPLE` ( _t_ – _x_ _y_ _z_ ), unpacks a triple _t_ = ( _x_ , _y_ , _z_ ).
+
+  * `6F3k` — `UNPACKFIRST k` ( _t_ – _x_ 1 … _x_ _k_ ), unpacks first 0 ≤ _k_ ≤ 15 elements of a _Tuple_ _t_. If | _t_ | < _k_ , throws a type check exception.
+
+  * `6F30` — `CHKTUPLE` ( _t_ – ), checks whether _t_ is a _Tuple_.
+
+  * `6F4n` — `EXPLODE n` ( _t_ – _x_ 1 … _x_ _m_ _m_ ), unpacks a _Tuple_ _t_ = ( _x_ 1, …, _x_ _m_ ) and returns its length _m_ , but only if _m_ ≤ _n_ ≤ 15. Otherwise throws a type check exception.
+
+  * `6F5k` — `SETINDEX k` ( _t_ _x_ – _t_ ′), computes _Tuple_ _t_ ′ that differs from _t_ only at position _t_ ′ _k_ \+ 1, which is set to _x_. In other words, | _t_ ′| = | _t_ |, _t_ ′ _i_ = _t_ _i_ for _i_ ≠ _k_ \+ 1, and _t_ ′ _k_ \+ 1 = _x_ , for given 0 ≤ _k_ ≤ 15. If _k_ ≥ | _t_ |, throws a range check exception.
+
+  * `6F50` — `SETFIRST` ( _t_ _x_ – _t_ ′), sets the first component of _Tuple_ _t_ to _x_ and returns the resulting _Tuple_ _t_ ′.
+
+  * `6F51` — `SETSECOND` ( _t_ _x_ – _t_ ′), sets the second component of _Tuple_ _t_ to _x_ and returns the resulting _Tuple_ _t_ ′.
+
+  * `6F52` — `SETTHIRD` ( _t_ _x_ – _t_ ′), sets the third component of _Tuple_ _t_ to _x_ and returns the resulting _Tuple_ _t_ ′.
+
+  * `6F6k` — `INDEXQ k` ( _t_ – _x_ ), returns the _k_ -th element of a _Tuple_ _t_ , where 0 ≤ _k_ ≤ 15. In other words, returns _x_ _k_ \+ 1 if _t_ = ( _x_ 1, …, _x_ _n_ ). If _k_ ≥ _n_ , or if _t_ is _Null_ , returns a _Null_ instead of _x_.
+
+  * `6F7k` — `SETINDEXQ k` ( _t_ _x_ – _t_ ′), sets the _k_ -th component of _Tuple_ _t_ to _x_ , where 0 ≤ _k_ < 16, and returns the resulting _Tuple_ _t_ ′. If | _t_ | ≤ _k_ , first extends the original _Tuple_ to length _k_ \+ 1 by setting all new components to _Null_. If the original value of _t_ is _Null_ , treats it as an empty _Tuple_. If _t_ is not _Null_ or _Tuple_ , throws an exception. If _x_ is _Null_ and either | _t_ | ≤ _k_ or _t_ is _Null_ , then always returns _t_ ′ = _t_ (and does not consume tuple creation gas).
+
+  * `6F80` — `TUPLEVAR` ( _x_ 1 … _x_ _n_ _n_ – _t_ ), creates a new _Tuple_ _t_ of length _n_ similarly to `TUPLE`, but with 0 ≤ _n_ ≤ 255 taken from the stack.
+
+  * `6F81` — `INDEXVAR` ( _t_ _k_ – _x_ ), similar to `INDEX k`, but with 0 ≤ _k_ ≤ 254 taken from the stack.
+
+  * `6F82` — `UNTUPLEVAR` ( _t_ _n_ – _x_ 1 … _x_ _n_ ), similar to `UNTUPLE n`, but with 0 ≤ _n_ ≤ 255 taken from the stack.
+
+  * `6F83` — `UNPACKFIRSTVAR` ( _t_ _n_ – _x_ 1 … _x_ _n_ ), similar to `UNPACKFIRST n`, but with 0 ≤ _n_ ≤ 255 taken from the stack.
+
+  * `6F84` — `EXPLODEVAR` ( _t_ _n_ – _x_ 1 … _x_ _m_ _m_ ), similar to `EXPLODE n`, but with 0 ≤ _n_ ≤ 255 taken from the stack.
+
+  * `6F85` — `SETINDEXVAR` ( _t_ _x_ _k_ – _t_ ′), similar to `SETINDEX k`, but with 0 ≤ _k_ ≤ 254 taken from the stack.
+
+  * `6F86` — `INDEXVARQ` ( _t_ _k_ – _x_ ), similar to `INDEXQ n`, but with 0 ≤ _k_ ≤ 254 taken from the stack.
+
+  * `6F87` — `SETINDEXVARQ` ( _t_ _x_ _k_ – _t_ ′), similar to `SETINDEXQ k`, but with 0 ≤ _k_ ≤ 254 taken from the stack.
+
+  * `6F88` — `TLEN` ( _t_ – _n_ ), returns the length of a _Tuple_.
+
+  * `6F89` — `QTLEN` ( _t_ – _n_ or  − 1), similar to `TLEN`, but returns  − 1 if _t_ is not a _Tuple_.
+
+  * `6F8A` — `ISTUPLE` ( _t_ – ?), returns  − 1 or 0 depending on whether _t_ is a _Tuple_.
+
+  * `6F8B` — `LAST` ( _t_ – _x_ ), returns the last element _t_ | _t_ | of a non-empty _Tuple_ _t_.
+
+  * `6F8C` — `TPUSH` or `COMMA` ( _t_ _x_ – _t_ ′), appends a value _x_ to a _Tuple_ _t_ = ( _x_ 1, …, _x_ _n_ ), but only if the resulting _Tuple_ _t_ ′ = ( _x_ 1, …, _x_ _n_ , _x_ ) is of length at most 255. Otherwise throws a type check exception.
+
+  * `6F8D` — `TPOP` ( _t_ – _t_ ′ _x_ ), detaches the last element _x_ = _x_ _n_ from a non-empty _Tuple_ _t_ = ( _x_ 1, …, _x_ _n_ ), and returns both the resulting _Tuple_ _t_ ′ = ( _x_ 1, …, _x_ _n_ − 1) and the original last element _x_.
+
+  * `6FA0` — `NULLSWAPIF` ( _x_ – _x_ or ⊥ _x_ ), pushes a _Null_ under the topmost _Integer_ _x_ , but only if _x_ ≠ 0.
+
+  * `6FA1` — `NULLSWAPIFNOT` ( _x_ – _x_ or ⊥ _x_ ), pushes a _Null_ under the topmost _Integer_ _x_ , but only if _x_ = 0. May be used for stack alignment after quiet primitives such as `PLDUXQ`.
+
+  * `6FA2` — `NULLROTRIF` ( _x_ _y_ – _x_ _y_ or ⊥ _x_ _y_ ), pushes a _Null_ under the second stack entry from the top, but only if the topmost _Integer_ _y_ is non-zero.
+
+  * `6FA3` — `NULLROTRIFNOT` ( _x_ _y_ – _x_ _y_ or ⊥ _x_ _y_ ), pushes a _Null_ under the second stack entry from the top, but only if the topmost _Integer_ _y_ is zero. May be used for stack alignment after quiet primitives such as `LDUXQ`.
+
+  * `6FA4` — `NULLSWAPIF2` ( _x_ – _x_ or ⊥ ⊥ _x_ ), pushes two _Null_ s under the topmost _Integer_ _x_ , but only if _x_ ≠ 0. Equivalent to `NULLSWAPIF`; `NULLSWAPIF`.
+
+  * `6FA5` — `NULLSWAPIFNOT2` ( _x_ – _x_ or ⊥ ⊥ _x_ ), pushes two _Null_ s under the topmost _Integer_ _x_ , but only if _x_ = 0. Equivalent to `NULLSWAPIFNOT`; `NULLSWAPIFNOT`.
+
+  * `6FA6` — `NULLROTRIF2` ( _x_ _y_ – _x_ _y_ or ⊥ ⊥ _x_ _y_ ), pushes two _Null_ s under the second stack entry from the top, but only if the topmost _Integer_ _y_ is non-zero. Equivalent to `NULLROTRIF`; `NULLROTRIF`.
+
+  * `6FA7` — `NULLROTRIFNOT2` ( _x_ _y_ – _x_ _y_ or ⊥ ⊥ _x_ _y_ ), pushes two _Null_ s under the second stack entry from the top, but only if the topmost _Integer_ _y_ is zero. Equivalent to `NULLROTRIFNOT`; `NULLROTRIFNOT`.
+
+  * `6FBij` — `INDEX2 i,j` ( _t_ – _x_ ), recovers _x_ = ( _t_ _i_ \+ 1) _j_ \+ 1 for 0 ≤ _i_ , _j_ ≤ 3. Equivalent to `INDEX i`; `INDEX j`.
+
+  * `6FB4` — `CADR` ( _t_ – _x_ ), recovers _x_ = ( _t_ 2)1.
+
+  * `6FB5` — `CDDR` ( _t_ – _x_ ), recovers _x_ = ( _t_ 2)2.
+
+  * `6FE_ijk` — `INDEX3 i,j,k` ( _t_ – _x_ ), recovers _x_ = (( _t_ _i_ \+ 1) _j_ \+ 1) _k_ \+ 1 for 0 ≤ _i_ , _j_ , _k_ ≤ 3. Equivalent to `INDEX2 i,j`; `INDEX k`.
+
+  * `6FD4` — `CADDR` ( _t_ – _x_ ), recovers _x_ = (( _t_ 2)2)1.
+
+  * `6FD5` — `CDDDR` ( _t_ – _x_ ), recovers _x_ = (( _t_ 2)2)2.
+
+## Constant, or literal primitives
+
+The following primitives push into the stack one literal (or unnamed constant)
+of some type and range, stored as a part (an immediate argument) of the
+instruction. Therefore, if the immediate argument is absent or too short, an
+“invalid or too short opcode” exception (code 6) is thrown.
+
+**Integer and boolean constants.**
+
+  * `7i` — `PUSHINT x` with  − 5 ≤ _x_ ≤ 10, pushes integer _x_ into the stack; here _i_ equals four lower-order bits of _x_ (i.e., _i_ = _x_ mod 16).
+
+  * `70` — `ZERO`, `FALSE`, or `PUSHINT 0`, pushes a zero.
+
+  * `71` — `ONE` or `PUSHINT 1`.
+
+  * `72` — `TWO` or `PUSHINT 2`.
+
+  * `7A` — `TEN` or `PUSHINT` 10.
+
+  * `7F` — `TRUE` or `PUSHINT -1`.
+
+  * `80xx` — `PUSHINT xx` with  − 128 ≤ _x_ _x_ ≤ 127.
+
+  * `81xxxx` — `PUSHINT xxxx` with  − 215 ≤ _x_ _x_ _x_ _x_ < 215 a signed 16-bit big-endian integer.
+
+  * `81FC18` — `PUSHINT -1000`.
+
+  * `82lxxx` — `PUSHINT xxx`, where 5-bit 0 ≤ _l_ ≤ 30 determines the length _n_ = 8 _l_ \+ 19 of signed big-endian integer _x_ _x_ _x_. The total length of this instruction is _l_ \+ 4 bytes or _n_ \+ 13 = 8 _l_ \+ 32 bits.
+
+  * `821005F5E100` — `PUSHINT 10^8`.
+
+  * `83xx` — `PUSHPOW2 xx+1`, (quietly) pushes 2 _x_ _x_ \+ 1 for 0 ≤ _x_ _x_ ≤ 255.
+
+  * `83FF` — `PUSHNAN`, pushes a `NaN`.
+
+  * `84xx` — `PUSHPOW2DEC xx+1`, pushes 2 _x_ _x_ \+ 1 − 1 for 0 ≤ _x_ _x_ ≤ 255.
+
+  * `85xx` — `PUSHNEGPOW2 xx+1`, pushes  − 2 _x_ _x_ \+ 1 for 0 ≤ _x_ _x_ ≤ 255.
+
+  * `86`, `87` — reserved for integer constants.
+
+**Constant slices, continuations, cells, and references.** Most of the
+instructions listed below push literal slices, continuations, cells, and cell
+references, stored as immediate arguments to the instruction. Therefore, if
+the immediate argument is absent or too short, an “invalid or too short
+opcode” exception (code 6) is thrown.
+
+  * `88` — `PUSHREF`, pushes the first reference of `cc.code` into the stack as a _Cell_ (and removes this reference from the current continuation).
+
+  * `89` — `PUSHREFSLICE`, similar to `PUSHREF`, but converts the cell into a _Slice_.
+
+  * `8A` — `PUSHREFCONT`, similar to `PUSHREFSLICE`, but makes a simple ordinary _Continuation_ out of the cell.
+
+  * `8Bxsss` — `PUSHSLICE sss`, pushes the (prefix) subslice of `cc.code` consisting of its first 8 _x_ \+ 4 bits and no references (i.e., essentially a bitstring), where 0 ≤ _x_ ≤ 15. A completion tag is assumed, meaning that all trailing zeroes and the last binary one (if present) are removed from this bitstring. If the original bitstring consists only of zeroes, an empty slice will be pushed.
+
+  * `8B08` — `PUSHSLICE x8_`, pushes an empty slice (bitstring `‘’`).
+
+  * `8B04` — `PUSHSLICE x4_`, pushes bitstring `‘0’`.
+
+  * `8B0C` — `PUSHSLICE xC_`, pushes bitstring `‘1’`.
+
+  * `8Crxxssss` — `PUSHSLICE ssss`, pushes the (prefix) subslice of `cc.code` consisting of its first 1 ≤ _r_ \+ 1 ≤ 4 references and up to first 8 _x_ _x_ \+ 1 bits of data, with 0 ≤ _x_ _x_ ≤ 31. A completion tag is also assumed.
+
+  * `8C01` is equivalent to `PUSHREFSLICE`.
+
+  * `8Drxxsssss` — `PUSHSLICE sssss`, pushes the subslice of `cc.code` consisting of 0 ≤ _r_ ≤ 4 references and up to 8 _x_ _x_ \+ 6 bits of data, with 0 ≤ _x_ _x_ ≤ 127. A completion tag is assumed.
+
+  * `8DE_` — unused (reserved).
+
+  * `8F_rxxcccc` — `PUSHCONT cccc`, where _c_ _c_ _c_ _c_ is the simple ordinary continuation made from the first 0 ≤ _r_ ≤ 3 references and the first 0 ≤ _x_ _x_ ≤ 127 bytes of `cc.code`.
+
+  * `9xccc` — `PUSHCONT ccc`, pushes an _x_ -byte continuation for 0 ≤ _x_ ≤ 15.
+
+## Arithmetic primitives
+
+**Addition, subtraction, multiplication.**
+
+  * `A0` — `ADD` ( _x_ _y_ – _x_ \+ _y_ ), adds together two integers.
+
+  * `A1` — `SUB` ( _x_ _y_ – _x_ − _y_ ).
+
+  * `A2` — `SUBR` ( _x_ _y_ – _y_ − _x_ ), equivalent to `SWAP`; `SUB`.
+
+  * `A3` — `NEGATE` ( _x_ –  − _x_ ), equivalent to `MULCONST -1` or to `ZERO; SUBR`. Notice that it triggers an integer overflow exception if _x_ = − 2256.
+
+  * `A4` — `INC` ( _x_ – _x_ \+ 1), equivalent to `ADDCONST 1`.
+
+  * `A5` — `DEC` ( _x_ – _x_ − 1), equivalent to `ADDCONST -1`.
+
+  * `A6cc` — `ADDCONST cc` ( _x_ – _x_ \+ _c_ _c_ ),  − 128 ≤ _c_ _c_ ≤ 127.
+
+  * `A7cc` — `MULCONST cc` ( _x_ – _x_ ⋅ _c_ _c_ ),  − 128 ≤ _c_ _c_ ≤ 127.
+
+  * `A8` — `MUL` ( _x_ _y_ – _x_ _y_ ).
+
+**Division.**
+
+The general encoding of a `DIV`, `DIVMOD`, or `MOD` operation is `A9mscdf`,
+with an optional pre-multiplication and an optional replacement of the
+division or multiplication by a shift. Variable one- or two-bit fields _m_ ,
+_s_ , _c_ , _d_ , and _f_ are as follows:
+
+  * 0 ≤ _m_ ≤ 1 — Indicates whether there is pre-multiplication (`MULDIV` operation and its variants), possibly replaced by a left shift.
+
+  * 0 ≤ _s_ ≤ 2 — Indicates whether either the multiplication or the division have been replaced by shifts: _s_ = 0—no replacement, _s_ = 1—division replaced by a right shift, _s_ = 2—multiplication replaced by a left shift (possible only for _m_ = 1).
+
+  * 0 ≤ _c_ ≤ 1 — Indicates whether there is a constant one-byte argument _t_ _t_ for the shift operator (if _s_ ≠ 0). For _s_ = 0, _c_ = 0. If _c_ = 1, then 0 ≤ _t_ _t_ ≤ 255, and the shift is performed by _t_ _t_ \+ 1 bits. If _s_ ≠ 0 and _c_ = 0, then the shift amount is provided to the instruction as a top-of-stack _Integer_ in range 0…256.
+
+  * 1 ≤ _d_ ≤ 3 — Indicates which results of division are required: 1—only the quotient, 2—only the remainder, 3—both.
+
+  * 0 ≤ _f_ ≤ 2 — Rounding mode: 0—floor, 1—nearest integer, 2—ceiling (cf. ).
+
+Examples:
+
+  * `A904` — `DIV` ( _x_ _y_ – _q_ := ⌊ _x_ / _y_ ⌋).
+
+  * `A905` — `DIVR` ( _x_ _y_ – _q_ ′ := ⌊ _x_ / _y_ \+ 1/2⌋).
+
+  * `A906` — `DIVC` ( _x_ _y_ – _q_ ″ := ⌈ _x_ / _y_ ⌉).
+
+  * `A908` — `MOD` ( _x_ _y_ – _r_ ), where _q_ := ⌊ _x_ / _y_ ⌋, _r_ := _x_ mod _y_ := _x_ − _y_ _q_.
+
+  * `A90C` — `DIVMOD` ( _x_ _y_ – _q_ _r_ ), where _q_ := ⌊ _x_ / _y_ ⌋, _r_ := _x_ − _y_ _q_.
+
+  * `A90D` — `DIVMODR` ( _x_ _y_ – _q_ ′ _r_ ′), where _q_ ′ := ⌊ _x_ / _y_ \+ 1/2⌋, _r_ ′ := _x_ − _y_ _q_ ′.
+
+  * `A90E` — `DIVMODC` ( _x_ _y_ – _q_ ″ _r_ ″), where _q_ ″ := ⌈ _x_ / _y_ ⌉, _r_ ″ := _x_ − _y_ _q_ ″.
+
+  * `A924` — same as `RSHIFT`: ( _x_ _y_ – ⌊ _x_ ⋅ 2 − _y_ ⌋) for 0 ≤ _y_ ≤ 256.
+
+  * `A934tt` — same as `RSHIFT tt+1`: ( _x_ – ⌊ _x_ ⋅ 2 − _t_ _t_ − 1⌋).
+
+  * `A938tt` — `MODPOW2 tt+1`: ( _x_ – _x_ mod 2 _t_ _t_ \+ 1).
+
+  * `A985` — `MULDIVR` ( _x_ _y_ _z_ – _q_ ′), where _q_ ′ = ⌊ _x_ _y_ / _z_ \+ 1/2⌋.
+
+  * `A988` — `MULMOD` ( _x_ _y_ _z_ – _r_ ), where _r_ = _x_ _y_ mod _z_ = _x_ _y_ − _q_ _z_ , _q_ = ⌊ _x_ _y_ / _z_ ⌋. This operation always succeeds for _z_ ≠ 0 and returns the correct value of _r_ , even if the intermediate result _x_ _y_ or the quotient _q_ do not fit into 257 bits.
+
+  * `A98C` — `MULDIVMOD` ( _x_ _y_ _z_ – _q_ _r_ ), where _q_ := ⌊ _x_ ⋅ _y_ / _z_ ⌋, _r_ := _x_ ⋅ _y_ mod _z_ (same as `/MOD` in Forth).
+
+  * `A9A4` — `MULRSHIFT` ( _x_ _y_ _z_ – ⌊ _x_ _y_ ⋅ 2 − _z_ ⌋) for 0 ≤ _z_ ≤ 256.
+
+  * `A9A5` — `MULRSHIFTR` ( _x_ _y_ _z_ – ⌊ _x_ _y_ ⋅ 2 − _z_ \+ 1/2⌋) for 0 ≤ _z_ ≤ 256.
+
+  * `A9B4tt` — `MULRSHIFT tt+1` ( _x_ _y_ – ⌊ _x_ _y_ ⋅ 2 − _t_ _t_ − 1⌋).
+
+  * `A9B5tt` — `MULRSHIFTR tt+1` ( _x_ _y_ – ⌊ _x_ _y_ ⋅ 2 − _t_ _t_ − 1 \+ 1/2⌋).
+
+  * `A9C4` — `LSHIFTDIV` ( _x_ _y_ _z_ – ⌊2 _z_ _x_ / _y_ ⌋) for 0 ≤ _z_ ≤ 256.
+
+  * `A9C5` — `LSHIFTDIVR` ( _x_ _y_ _z_ – ⌊2 _z_ _x_ / _y_ \+ 1/2⌋) for 0 ≤ _z_ ≤ 256.
+
+  * `A9D4tt` — `LSHIFTDIV tt+1` ( _x_ _y_ – ⌊2 _t_ _t_ \+ 1 _x_ / _y_ ⌋).
+
+  * `A9D5tt` — `LSHIFTDIVR tt+1` ( _x_ _y_ – ⌊2 _t_ _t_ \+ 1 _x_ / _y_ \+ 1/2⌋).
+
+The most useful of these operations are `DIV`, `DIVMOD`, `MOD`, `DIVR`,
+`DIVC`, `MODPOW2 t`, and `RSHIFTR t` (for integer arithmetic); and
+`MULDIVMOD`, `MULDIV`, `MULDIVR`, `LSHIFTDIVR t`, and `MULRSHIFTR t` (for
+fixed-point arithmetic).
+
+**Shifts, logical operations.**
+
+  * `AAcc` — `LSHIFT cc+1` ( _x_ – _x_ ⋅ 2 _c_ _c_ \+ 1), 0 ≤ _c_ _c_ ≤ 255.
+
+  * `AA00` — `LSHIFT 1`, equivalent to `MULCONST 2` or to Forth’s `2*`.
+
+  * `ABcc` — `RSHIFT cc+1` ( _x_ – ⌊ _x_ ⋅ 2 − _c_ _c_ − 1⌋), 0 ≤ _c_ _c_ ≤ 255.
+
+  * `AC` — `LSHIFT` ( _x_ _y_ – _x_ ⋅ 2 _y_ ), 0 ≤ _y_ ≤ 1023.
+
+  * `AD` — `RSHIFT` ( _x_ _y_ – ⌊ _x_ ⋅ 2 − _y_ ⌋), 0 ≤ _y_ ≤ 1023.
+
+  * `AE` — `POW2` ( _y_ – 2 _y_ ), 0 ≤ _y_ ≤ 1023, equivalent to `ONE`; `SWAP`; `LSHIFT`.
+
+  * `AF` — reserved.
+
+  * `B0` — `AND` ( _x_ _y_ – _x_ & _y_ ), bitwise “and” of two signed integers _x_ and _y_ , sign-extended to infinity.
+
+  * `B1` — `OR` ( _x_ _y_ – _x_ ∨ _y_ ), bitwise “or” of two integers.
+
+  * `B2` — `XOR` ( _x_ _y_ – _x_ ⊕ _y_ ), bitwise “xor” of two integers.
+
+  * `B3` — `NOT` ( _x_ – _x_ ⊕ − 1 = − 1 − _x_ ), bitwise “not” of an integer.
+
+  * `B4cc` — `FITS cc+1` ( _x_ – _x_ ), checks whether _x_ is a _c_ _c_ \+ 1-bit signed integer for 0 ≤ _c_ _c_ ≤ 255 (i.e., whether  − 2 _c_ _c_ ≤ _x_ < 2 _c_ _c_ ). If not, either triggers an integer overflow exception, or replaces _x_ with a `NaN` (quiet version).
+
+  * `B400` — `FITS 1` or `CHKBOOL` ( _x_ – _x_ ), checks whether _x_ is a “boolean value” (i.e., either 0 or -1).
+
+  * `B5cc` — `UFITS cc+1` ( _x_ – _x_ ), checks whether _x_ is a _c_ _c_ \+ 1-bit unsigned integer for 0 ≤ _c_ _c_ ≤ 255 (i.e., whether 0 ≤ _x_ < 2 _c_ _c_ \+ 1).
+
+  * `B500` — `UFITS 1` or `CHKBIT`, checks whether _x_ is a binary digit (i.e., zero or one).
+
+  * `B600` — `FITSX` ( _x_ _c_ – _x_ ), checks whether _x_ is a _c_ -bit signed integer for 0 ≤ _c_ ≤ 1023.
+
+  * `B601` — `UFITSX` ( _x_ _c_ – _x_ ), checks whether _x_ is a _c_ -bit unsigned integer for 0 ≤ _c_ ≤ 1023.
+
+  * `B602` — `BITSIZE` ( _x_ – _c_ ), computes smallest _c_ ≥ 0 such that _x_ fits into a _c_ -bit signed integer ( − 2 _c_ − 1 ≤ _c_ < 2 _c_ − 1).
+
+  * `B603` — `UBITSIZE` ( _x_ – _c_ ), computes smallest _c_ ≥ 0 such that _x_ fits into a _c_ -bit unsigned integer (0 ≤ _x_ < 2 _c_ ), or throws a range check exception.
+
+  * `B608` — `MIN` ( _x_ _y_ – _x_ or _y_ ), computes the minimum of two integers _x_ and _y_.
+
+  * `B609` — `MAX` ( _x_ _y_ – _x_ or _y_ ), computes the maximum of two integers _x_ and _y_.
+
+  * `B60A` — `MINMAX` or `INTSORT2` ( _x_ _y_ – _x_ _y_ or _y_ _x_ ), sorts two integers. Quiet version of this operation returns two `NaN`s if any of the arguments are `NaN`s.
+
+  * `B60B` — `ABS` ( _x_ – | _x_ |), computes the absolute value of an integer _x_.
+
+**Quiet arithmetic primitives.** We opted to make all arithmetic operations
+“non-quiet” (signaling) by default, and create their quiet counterparts by
+means of a prefix. Such an encoding is definitely sub-optimal. It is not yet
+clear whether it should be done in this way, or in the opposite way by making
+all arithmetic operations quiet by default, or whether quiet and non-quiet
+operations should be given opcodes of equal length; this can only be settled
+by practice.
+
+  * `B7xx` — `QUIET` prefix, transforming any arithmetic operation into its “quiet” variant, indicated by prefixing a `Q` to its mnemonic. Such operations return `NaN`s instead of throwing integer overflow exceptions if the results do not fit in _Integer_ s, or if one of their arguments is a `NaN`. Notice that this does not extend to shift amounts and other parameters that must be within a small range (e.g., 0–1023). Also notice that this does not disable type-checking exceptions if a value of a type other than _Integer_ is supplied.
+
+  * `B7A0` — `QADD` ( _x_ _y_ – _x_ \+ _y_ ), always works if _x_ and _y_ are _Integer_ s, but returns a `NaN` if the addition cannot be performed.
+
+  * `B7A8` — `QMUL` ( _x_ _y_ – _x_ _y_ ), returns the product of _x_ and _y_ if  − 2256 ≤ _x_ _y_ < 2256. Otherwise returns a `NaN`, even if _x_ = 0 and _y_ is a `NaN`.
+
+  * `B7A904` — `QDIV` ( _x_ _y_ – ⌊ _x_ / _y_ ⌋), returns a `NaN` if _y_ = 0, or if _y_ = − 1 and _x_ = − 2256, or if either of _x_ or _y_ is a `NaN`.
+
+  * `B7A98C` — `QMULDIVMOD` ( _x_ _y_ _z_ – _q_ _r_ ), where _q_ := ⌊ _x_ ⋅ _y_ / _z_ ⌋, _r_ := _x_ ⋅ _y_ mod _z_. If _z_ = 0, or if at least one of _x_ , _y_ , or _z_ is a `NaN`, both _q_ and _r_ are set to `NaN`. Otherwise the correct value of _r_ is always returned, but _q_ is replaced with `NaN` if _q_ < − 2256 or _q_ ≥ 2256.
+
+  * `B7B0` — `QAND` ( _x_ _y_ – _x_ & _y_ ), bitwise “and” (similar to `AND`), but returns a `NaN` if either _x_ or _y_ is a `NaN` instead of throwing an integer overflow exception. However, if one of the arguments is zero, and the other is a `NaN`, the result is zero.
+
+  * `B7B1` — `QOR` ( _x_ _y_ – _x_ ∨ _y_ ), bitwise “or”. If _x_ = − 1 or _y_ = − 1, the result is always  − 1, even if the other argument is a `NaN`.
+
+  * `B7B507` — `QUFITS 8` ( _x_ – _x_ ′), checks whether _x_ is an unsigned byte (i.e., whether 0 ≤ _x_ < 28), and replaces _x_ with a `NaN` if this is not the case; leaves _x_ intact otherwise (i.e., if _x_ is an unsigned byte or a `NaN`).
+
+## Comparison primitives
+
+**Integer comparison.** All integer comparison primitives return integer  − 1
+(“true”) or 0 (“false”) to indicate the result of the comparison. We do not
+define their “boolean circuit” counterparts, which would transfer control to
+`c0` or `c1` depending on the result of the comparison. If needed, such
+instructions can be simulated with the aid of `RETBOOL`.
+
+Quiet versions of integer comparison primitives are also available, encoded
+with the aid of the `QUIET` prefix (`B7`). If any of the integers being
+compared are `NaN`s, the result of a quiet comparison will also be a `NaN`
+(“undefined”), instead of a  − 1 (“yes”) or 0 (“no”), thus effectively
+supporting ternary logic.
+
+  * `B8` — `SGN` ( _x_ – sgn ( _x_ )), computes the sign of an integer _x_ :  − 1 if _x_ < 0, 0 if _x_ = 0, 1 if _x_ > 0.
+
+  * `B9` — `LESS` ( _x_ _y_ – _x_ < _y_ ), returns  − 1 if _x_ < _y_ , 0 otherwise.
+
+  * `BA` — `EQUAL` ( _x_ _y_ – _x_ = _y_ ), returns  − 1 if _x_ = _y_ , 0 otherwise.
+
+  * `BB` — `LEQ` ( _x_ _y_ – _x_ ≤ _y_ ).
+
+  * `BC` — `GREATER` ( _x_ _y_ – _x_ > _y_ ).
+
+  * `BD` — `NEQ` ( _x_ _y_ – _x_ ≠ _y_ ), equivalent to `EQUAL`; `NOT`.
+
+  * `BE` — `GEQ` ( _x_ _y_ – _x_ ≥ _y_ ), equivalent to `LESS`; `NOT`.
+
+  * `BF` — `CMP` ( _x_ _y_ – sgn ( _x_ − _y_ )), computes the sign of _x_ − _y_ :  − 1 if _x_ < _y_ , 0 if _x_ = _y_ , 1 if _x_ > _y_. No integer overflow can occur here unless _x_ or _y_ is a `NaN`.
+
+  * `C0yy` — `EQINT yy` ( _x_ – _x_ = _y_ _y_ ) for  − 27 ≤ _y_ _y_ < 27.
+
+  * `C000` — `ISZERO`, checks whether an integer is zero. Corresponds to Forth’s `0=`.
+
+  * `C1yy` — `LESSINT yy` ( _x_ – _x_ < _y_ _y_ ) for  − 27 ≤ _y_ _y_ < 27.
+
+  * `C100` — `ISNEG`, checks whether an integer is negative. Corresponds to Forth’s `0<`.
+
+  * `C101` — `ISNPOS`, checks whether an integer is non-positive.
+
+  * `C2yy` — `GTINT yy` ( _x_ – _x_ > _y_ _y_ ) for  − 27 ≤ _y_ _y_ < 27.
+
+  * `C200` — `ISPOS`, checks whether an integer is positive. Corresponds to Forth’s `0>`.
+
+  * `C2FF` — `ISNNEG`, checks whether an integer is non-negative.
+
+  * `C3yy` — `NEQINT yy` ( _x_ – _x_ ≠ _y_ _y_ ) for  − 27 ≤ _y_ _y_ < 27.
+
+  * `C4` — `ISNAN` ( _x_ – $x={\tt NaN}$), checks whether _x_ is a `NaN`.
+
+  * `C5` — `CHKNAN` ( _x_ – _x_ ), throws an arithmetic overflow exception if _x_ is a `NaN`.
+
+  * `C6` — reserved for integer comparison.
+
+**Other comparison.**
+
+Most of these “other comparison” primitives actually compare the data portions
+of _Slice_ s as bitstrings.
+
+  * `C700` — `SEMPTY` ( _s_ – _s_ = ∅), checks whether a _Slice _s__ is empty (i.e., contains no bits of data and no cell references).
+
+  * `C701` — `SDEMPTY` ( _s_ – _s_ ≈ ∅), checks whether _Slice _s__ has no bits of data.
+
+  * `C702` — `SREMPTY` ( _s_ – _r_ ( _s_ ) = 0), checks whether _Slice_ _s_ has no references.
+
+  * `C703` — `SDFIRST` ( _s_ – _s_ 0 = 1), checks whether the first bit of _Slice_ _s_ is a one.
+
+  * `C704` — `SDLEXCMP` ( _s_ _s_ ′ – _c_ ), compares the data of _s_ lexicographically with the data of _s_ ′, returning  − 1, 0, or 1 depending on the result.
+
+  * `C705` — `SDEQ` ( _s_ _s_ ′ – _s_ ≈ _s_ ′), checks whether the data parts of _s_ and _s_ ′ coincide, equivalent to `SDLEXCMP`; `ISZERO`.
+
+  * `C708` — `SDPFX` ( _s_ _s_ ′ – ?), checks whether _s_ is a prefix of _s_ ′.
+
+  * `C709` — `SDPFXREV` ( _s_ _s_ ′ – ?), checks whether _s_ ′ is a prefix of _s_ , equivalent to `SWAP`; `SDPFX`.
+
+  * `C70A` — `SDPPFX` ( _s_ _s_ ′ – ?), checks whether _s_ is a proper prefix of _s_ ′ (i.e., a prefix distinct from _s_ ′).
+
+  * `C70B` — `SDPPFXREV` ( _s_ _s_ ′ – ?), checks whether _s_ ′ is a proper prefix of _s_.
+
+  * `C70C` — `SDSFX` ( _s_ _s_ ′ – ?), checks whether _s_ is a suffix of _s_ ′.
+
+  * `C70D` — `SDSFXREV` ( _s_ _s_ ′ – ?), checks whether _s_ ′ is a suffix of _s_.
+
+  * `C70E` — `SDPSFX` ( _s_ _s_ ′ – ?), checks whether _s_ is a proper suffix of _s_ ′.
+
+  * `C70F` — `SDPSFXREV` ( _s_ _s_ ′ – ?), checks whether _s_ ′ is a proper suffix of _s_.
+
+  * `C710` — `SDCNTLEAD0` ( _s_ – _n_ ), returns the number of leading zeroes in _s_.
+
+  * `C711` — `SDCNTLEAD1` ( _s_ – _n_ ), returns the number of leading ones in _s_.
+
+  * `C712` — `SDCNTTRAIL0` ( _s_ – _n_ ), returns the number of trailing zeroes in _s_.
+
+  * `C713` — `SDCNTTRAIL1` ( _s_ – _n_ ), returns the number of trailing ones in _s_.
+
+## Cell primitives
+
+The cell primitives are mostly either _cell serialization primitives_ , which
+work with _Builder_ s, or _cell deserialization primitives_ , which work with
+_Slice_ s.
+
+**Cell serialization primitives.** [sp:prim.ser] All these primitives first
+check whether there is enough space in the Builder, and only then check the
+range of the value being serialized.
+
+  * `C8` — `NEWC` ( – _b_ ), creates a new empty _Builder_.
+
+  * `C9` — `ENDC` ( _b_ – _c_ ), converts a _Builder_ into an ordinary _Cell_.
+
+  * `CAcc` — `STI cc+1` ( _x_ _b_ – _b_ ′), stores a signed _c_ _c_ \+ 1-bit integer _x_ into _Builder_ _b_ for 0 ≤ _c_ _c_ ≤ 255, throws a range check exception if _x_ does not fit into _c_ _c_ \+ 1 bits.
+
+  * `CBcc` — `STU cc+1` ( _x_ _b_ – _b_ ′), stores an unsigned _c_ _c_ \+ 1-bit integer _x_ into _Builder_ _b_. In all other respects it is similar to `STI`.
+
+  * `CC` — `STREF` ( _c_ _b_ – _b_ ′), stores a reference to _Cell_ _c_ into _Builder_ _b_.
+
+  * `CD` — `STBREFR` or `ENDCST` ( _b_ _b_ ″ – _b_ ), equivalent to `ENDC`; `SWAP`; `STREF`.
+
+  * `CE` — `STSLICE` ( _s_ _b_ – _b_ ′), stores _Slice_ _s_ into _Builder_ _b_.
+
+  * `CF00` — `STIX` ( _x_ _b_ _l_ – _b_ ′), stores a signed _l_ -bit integer _x_ into _b_ for 0 ≤ _l_ ≤ 257.
+
+  * `CF01` — `STUX` ( _x_ _b_ _l_ – _b_ ′), stores an unsigned _l_ -bit integer _x_ into _b_ for 0 ≤ _l_ ≤ 256.
+
+  * `CF02` — `STIXR` ( _b_ _x_ _l_ – _b_ ′), similar to `STIX`, but with arguments in a different order.
+
+  * `CF03` — `STUXR` ( _b_ _x_ _l_ – _b_ ′), similar to `STUX`, but with arguments in a different order.
+
+  * `CF04` — `STIXQ` ( _x_ _b_ _l_ – _x_ _b_ _f_ or _b_ ′ 0), a quiet version of `STIX`. If there is no space in _b_ , sets _b_ ′ = _b_ and _f_ = − 1. If _x_ does not fit into _l_ bits, sets _b_ ′ = _b_ and _f_ = 1. If the operation succeeds, _b_ ′ is the new _Builder_ and _f_ = 0. However, 0 ≤ _l_ ≤ 257, with a range check exception if this is not so.
+
+  * `CF05` — `STUXQ` ( _x_ _b_ _l_ – _b_ ′ _f_ ).
+
+  * `CF06` — `STIXRQ` ( _b_ _x_ _l_ – _b_ _x_ _f_ or _b_ ′ 0).
+
+  * `CF07` — `STUXRQ` ( _b_ _x_ _l_ – _b_ _x_ _f_ or _b_ ′ 0).
+
+  * `CF08cc` — a longer version of `STI cc+1`.
+
+  * `CF09cc` — a longer version of `STU cc+1`.
+
+  * `CF0Acc` — `STIR cc+1` ( _b_ _x_ – _b_ ′), equivalent to `SWAP`; `STI cc+1`.
+
+  * `CF0Bcc` — `STUR cc+1` ( _b_ _x_ – _b_ ′), equivalent to `SWAP`; `STU cc+1`.
+
+  * `CF0Ccc` — `STIQ cc+1` ( _x_ _b_ – _x_ _b_ _f_ or _b_ ′ 0).
+
+  * `CF0Dcc` — `STUQ cc+1` ( _x_ _b_ – _x_ _b_ _f_ or _b_ ′ 0).
+
+  * `CF0Ecc` — `STIRQ cc+1` ( _b_ _x_ – _b_ _x_ _f_ or _b_ ′ 0).
+
+  * `CF0Fcc` — `STURQ cc+1` ( _b_ _x_ – _b_ _x_ _f_ or _b_ ′ 0).
+
+  * `CF10` — a longer version of `STREF` ( _c_ _b_ – _b_ ′).
+
+  * `CF11` — `STBREF` ( _b_ ′ _b_ – _b_ ″), equivalent to `SWAP`; `STBREFREV`.
+
+  * `CF12` — a longer version of `STSLICE` ( _s_ _b_ – _b_ ′).
+
+  * `CF13` — `STB` ( _b_ ′ _b_ – _b_ ″), appends all data from _Builder_ _b_ ′ to _Builder_ _b_.
+
+  * `CF14` — `STREFR` ( _b_ _c_ – _b_ ′).
+
+  * `CF15` — `STBREFR` ( _b_ _b_ ′ – _b_ ″), a longer encoding of `STBREFR`.
+
+  * `CF16` — `STSLICER` ( _b_ _s_ – _b_ ′).
+
+  * `CF17` — `STBR` ( _b_ _b_ ′ – _b_ ″), concatenates two _Builder_ s, equivalent to `SWAP`; `STB`.
+
+  * `CF18` — `STREFQ` ( _c_ _b_ – _c_ _b_ − 1 or _b_ ′ 0).
+
+  * `CF19` — `STBREFQ` ( _b_ ′ _b_ – _b_ ′ _b_ − 1 or _b_ ″ 0).
+
+  * `CF1A` — `STSLICEQ` ( _s_ _b_ – _s_ _b_ − 1 or _b_ ′ 0).
+
+  * `CF1B` — `STBQ` ( _b_ ′ _b_ – _b_ ′ _b_ − 1 or _b_ ″ 0).
+
+  * `CF1C` — `STREFRQ` ( _b_ _c_ – _b_ _c_ − 1 or _b_ ′ 0).
+
+  * `CF1D` — `STBREFRQ` ( _b_ _b_ ′ – _b_ _b_ ′ − 1 or _b_ ″ 0).
+
+  * `CF1E` — `STSLICERQ` ( _b_ _s_ – _b_ _s_ − 1 or _b_ ″ 0).
+
+  * `CF1F` — `STBRQ` ( _b_ _b_ ′ – _b_ _b_ ′ − 1 or _b_ ″ 0).
+
+  * `CF20` — `STREFCONST`, equivalent to `PUSHREF`; `STREFR`.
+
+  * `CF21` — `STREF2CONST`, equivalent to `STREFCONST`; `STREFCONST`.
+
+  * `CF23` — `ENDXC` ( _b_ _x_ – _c_ ), if _x_ ≠ 0, creates a _special_ or _exotic_ cell (cf. ) from _Builder_ _b_. The type of the exotic cell must be stored in the first 8 bits of _b_. If _x_ = 0, it is equivalent to `ENDC`. Otherwise some validity checks on the data and references of _b_ are performed before creating the exotic cell.
+
+  * `CF28` — `STILE4` ( _x_ _b_ – _b_ ′), stores a little-endian signed 32-bit integer.
+
+  * `CF29` — `STULE4` ( _x_ _b_ – _b_ ′), stores a little-endian unsigned 32-bit integer.
+
+  * `CF2A` — `STILE8` ( _x_ _b_ – _b_ ′), stores a little-endian signed 64-bit integer.
+
+  * `CF2B` — `STULE8` ( _x_ _b_ – _b_ ′), stores a little-endian unsigned 64-bit integer.
+
+  * `CF30` — `BDEPTH` ( _b_ – _x_ ), returns the depth of _Builder_ _b_. If no cell references are stored in _b_ , then _x_ = 0; otherwise _x_ is one plus the maximum of depths of cells referred to from _b_.
+
+  * `CF31` — `BBITS` ( _b_ – _x_ ), returns the number of data bits already stored in _Builder_ _b_.
+
+  * `CF32` — `BREFS` ( _b_ – _y_ ), returns the number of cell references already stored in _b_.
+
+  * `CF33` — `BBITREFS` ( _b_ – _x_ _y_ ), returns the numbers of both data bits and cell references in _b_.
+
+  * `CF35` — `BREMBITS` ( _b_ – _x_ ′), returns the number of data bits that can still be stored in _b_.
+
+  * `CF36` — `BREMREFS` ( _b_ – _y_ ′).
+
+  * `CF37` — `BREMBITREFS` ( _b_ – _x_ ′ _y_ ′).
+
+  * `CF38cc` — `BCHKBITS cc+1` ( _b_ –), checks whether _c_ _c_ \+ 1 bits can be stored into _b_ , where 0 ≤ _c_ _c_ ≤ 255.
+
+  * `CF39` — `BCHKBITS` ( _b_ _x_ – ), checks whether _x_ bits can be stored into _b_ , 0 ≤ _x_ ≤ 1023. If there is no space for _x_ more bits in _b_ , or if _x_ is not within the range 0…1023, throws an exception.
+
+  * `CF3A` — `BCHKREFS` ( _b_ _y_ – ), checks whether _y_ references can be stored into _b_ , 0 ≤ _y_ ≤ 7.
+
+  * `CF3B` — `BCHKBITREFS` ( _b_ _x_ _y_ – ), checks whether _x_ bits and _y_ references can be stored into _b_ , 0 ≤ _x_ ≤ 1023, 0 ≤ _y_ ≤ 7.
+
+  * `CF3Ccc` — `BCHKBITSQ cc+1` ( _b_ – ?), checks whether _c_ _c_ \+ 1 bits can be stored into _b_ , where 0 ≤ _c_ _c_ ≤ 255.
+
+  * `CF3D` — `BCHKBITSQ` ( _b_ _x_ – ?), checks whether _x_ bits can be stored into _b_ , 0 ≤ _x_ ≤ 1023.
+
+  * `CF3E` — `BCHKREFSQ` ( _b_ _y_ – ?), checks whether _y_ references can be stored into _b_ , 0 ≤ _y_ ≤ 7.
+
+  * `CF3F` — `BCHKBITREFSQ` ( _b_ _x_ _y_ – ?), checks whether _x_ bits and _y_ references can be stored into _b_ , 0 ≤ _x_ ≤ 1023, 0 ≤ _y_ ≤ 7.
+
+  * `CF40` — `STZEROES` ( _b_ _n_ – _b_ ′), stores _n_ binary zeroes into _Builder_ _b_.
+
+  * `CF41` — `STONES` ( _b_ _n_ – _b_ ′), stores _n_ binary ones into _Builder_ _b_.
+
+  * `CF42` — `STSAME` ( _b_ _n_ _x_ – _b_ ′), stores _n_ binary _x_ es (0 ≤ _x_ ≤ 1) into _Builder_ _b_.
+
+  * `CFC0_xysss` — `STSLICECONST sss` ( _b_ – _b_ ′), stores a constant subslice _s_ _s_ _s_ consisting of 0 ≤ _x_ ≤ 3 references and up to 8 _y_ \+ 1 data bits, with 0 ≤ _y_ ≤ 7. Completion bit is assumed.
+
+  * `CF81` — `STSLICECONST ‘0’` or `STZERO` ( _b_ – _b_ ′), stores one binary zero.
+
+  * `CF83` — `STSLICECONST ‘1’` or `STONE` ( _b_ – _b_ ′), stores one binary one.
+
+  * `CFA2` — equivalent to `STREFCONST`.
+
+  * `CFA3` — almost equivalent to `STSLICECONST ‘1’`; `STREFCONST`.
+
+  * `CFC2` — equivalent to `STREF2CONST`.
+
+  * `CFE2` — `STREF3CONST`.
+
+**Cell deserialization primitives.** [sp:prim.deser]
+
+  * `D0` — `CTOS` ( _c_ – _s_ ), converts a _Cell_ into a _Slice_. Notice that _c_ must be either an ordinary cell, or an exotic cell (cf. ) which is automatically _loaded_ to yield an ordinary cell _c_ ′, converted into a _Slice_ afterwards.
+
+  * `D1` — `ENDS` ( _s_ – ), removes a _Slice_ _s_ from the stack, and throws an exception if it is not empty.
+
+  * `D2cc` — `LDI cc+1` ( _s_ – _x_ _s_ ′), loads (i.e., parses) a signed _c_ _c_ \+ 1-bit integer _x_ from _Slice_ _s_ , and returns the remainder of _s_ as _s_ ′.
+
+  * `D3cc` — `LDU cc+1` ( _s_ – _x_ _s_ ′), loads an unsigned _c_ _c_ \+ 1-bit integer _x_ from _Slice_ _s_.
+
+  * `D4` — `LDREF` ( _s_ – _c_ _s_ ′), loads a cell reference _c_ from _s_.
+
+  * `D5` — `LDREFRTOS` ( _s_ – _s_ ′ _s_ ″), equivalent to `LDREF`; `SWAP`; `CTOS`.
+
+  * `D6cc` — `LDSLICE cc+1` ( _s_ – _s_ ″ _s_ ′), cuts the next _c_ _c_ \+ 1 bits of _s_ into a separate _Slice_ _s_ ″.
+
+  * `D700` — `LDIX` ( _s_ _l_ – _x_ _s_ ′), loads a signed _l_ -bit (0 ≤ _l_ ≤ 257) integer _x_ from _Slice_ _s_ , and returns the remainder of _s_ as _s_ ′.
+
+  * `D701` — `LDUX` ( _s_ _l_ – _x_ _s_ ′), loads an unsigned _l_ -bit integer _x_ from (the first _l_ bits of) _s_ , with 0 ≤ _l_ ≤ 256.
+
+  * `D702` — `PLDIX` ( _s_ _l_ – _x_ ), preloads a signed _l_ -bit integer from _Slice_ _s_ , for 0 ≤ _l_ ≤ 257.
+
+  * `D703` — `PLDUX` ( _s_ _l_ – _x_ ), preloads an unsigned _l_ -bit integer from _s_ , for 0 ≤ _l_ ≤ 256.
+
+  * `D704` — `LDIXQ` ( _s_ _l_ – _x_ _s_ ′ − 1 or _s_ 0), quiet version of `LDIX`: loads a signed _l_ -bit integer from _s_ similarly to `LDIX`, but returns a success flag, equal to  − 1 on success or to 0 on failure (if _s_ does not have _l_ bits), instead of throwing a cell underflow exception.
+
+  * `D705` — `LDUXQ` ( _s_ _l_ – _x_ _s_ ′ − 1 or _s_ 0), quiet version of `LDUX`.
+
+  * `D706` — `PLDIXQ` ( _s_ _l_ – _x_ − 1 or 0), quiet version of `PLDIX`.
+
+  * `D707` — `PLDUXQ` ( _s_ _l_ – _x_ − 1 or 0), quiet version of `PLDUX`.
+
+  * `D708cc` — `LDI cc+1` ( _s_ – _x_ _s_ ′), a longer encoding for `LDI`.
+
+  * `D709cc` — `LDU cc+1` ( _s_ – _x_ _s_ ′), a longer encoding for `LDU`.
+
+  * `D70Acc` — `PLDI cc+1` ( _s_ – _x_ ), preloads a signed _c_ _c_ \+ 1-bit integer from _Slice_ _s_.
+
+  * `D70Bcc` — `PLDU cc+1` ( _s_ – _x_ ), preloads an unsigned _c_ _c_ \+ 1-bit integer from _s_.
+
+  * `D70Ccc` — `LDIQ cc+1` ( _s_ – _x_ _s_ ′ − 1 or _s_ 0), a quiet version of `LDI`.
+
+  * `D70Dcc` — `LDUQ cc+1` ( _s_ – _x_ _s_ ′ − 1 or _s_ 0), a quiet version of `LDU`.
+
+  * `D70Ecc` — `PLDIQ cc+1` ( _s_ – _x_ − 1 or 0), a quiet version of `PLDI`.
+
+  * `D70Fcc` — `PLDUQ cc+1` ( _s_ – _x_ − 1 or 0), a quiet version of `PLDU`.
+
+  * `D714_c` — `PLDUZ 32(c+1)` ( _s_ – _s_ _x_ ), preloads the first 32( _c_ \+ 1) bits of _Slice_ _s_ into an unsigned integer _x_ , for 0 ≤ _c_ ≤ 7. If _s_ is shorter than necessary, missing bits are assumed to be zero. This operation is intended to be used along with `IFBITJMP` and similar instructions.
+
+  * `D718` — `LDSLICEX` ( _s_ _l_ – _s_ ″ _s_ ′), loads the first 0 ≤ _l_ ≤ 1023 bits from _Slice_ _s_ into a separate _Slice_ _s_ ″, returning the remainder of _s_ as _s_ ′.
+
+  * `D719` — `PLDSLICEX` ( _s_ _l_ – _s_ ″), returns the first 0 ≤ _l_ ≤ 1023 bits of _s_ as _s_ ″.
+
+  * `D71A` — `LDSLICEXQ` ( _s_ _l_ – _s_ ″ _s_ ′ − 1 or _s_ 0), a quiet version of `LDSLICEX`.
+
+  * `D71B` — `PLDSLICEXQ` ( _s_ _l_ – _s_ ′ − 1 or 0), a quiet version of `LDSLICEXQ`.
+
+  * `D71Ccc` — `LDSLICE cc+1` ( _s_ – _s_ ″ _s_ ′), a longer encoding for `LDSLICE`.
+
+  * `D71Dcc` — `PLDSLICE cc+1` ( _s_ – _s_ ″), returns the first 0 < _c_ _c_ \+ 1 ≤ 256 bits of _s_ as _s_ ″.
+
+  * `D71Ecc` — `LDSLICEQ cc+1` ( _s_ – _s_ ″ _s_ ′ − 1 or _s_ 0), a quiet version of `LDSLICE`.
+
+  * `D71Fcc` — `PLDSLICEQ cc+1` ( _s_ – _s_ ″ − 1 or 0), a quiet version of `PLDSLICE`.
+
+  * `D720` — `SDCUTFIRST` ( _s_ _l_ – _s_ ′), returns the first 0 ≤ _l_ ≤ 1023 bits of _s_. It is equivalent to `PLDSLICEX`.
+
+  * `D721` — `SDSKIPFIRST` ( _s_ _l_ – _s_ ′), returns all but the first 0 ≤ _l_ ≤ 1023 bits of _s_. It is equivalent to `LDSLICEX`; `NIP`.
+
+  * `D722` — `SDCUTLAST` ( _s_ _l_ – _s_ ′), returns the last 0 ≤ _l_ ≤ 1023 bits of _s_.
+
+  * `D723` — `SDSKIPLAST` ( _s_ _l_ – _s_ ′), returns all but the last 0 ≤ _l_ ≤ 1023 bits of _s_.
+
+  * `D724` — `SDSUBSTR` ( _s_ _l_ _l_ ′ – _s_ ′), returns 0 ≤ _l_ ′ ≤ 1023 bits of _s_ starting from offset 0 ≤ _l_ ≤ 1023, thus extracting a bit substring out of the data of _s_.
+
+  * `D726` — `SDBEGINSX` ( _s_ _s_ ′ – _s_ ″), checks whether _s_ begins with (the data bits of) _s_ ′, and removes _s_ ′ from _s_ on success. On failure throws a cell deserialization exception. Primitive `SDPFXREV` can be considered a quiet version of `SDBEGINSX`.
+
+  * `D727` — `SDBEGINSXQ` ( _s_ _s_ ′ – _s_ ″ − 1 or _s_ 0), a quiet version of `SDBEGINSX`.
+
+  * `D72A_xsss` — `SDBEGINS` ( _s_ – _s_ ″), checks whether _s_ begins with constant bitstring _s_ _s_ _s_ of length 8 _x_ \+ 3 (with continuation bit assumed), where 0 ≤ _x_ ≤ 127, and removes _s_ _s_ _s_ from _s_ on success.
+
+  * `D72802` — `SDBEGINS ‘0’` ( _s_ – _s_ ″), checks whether _s_ begins with a binary zero.
+
+  * `D72806` — `SDBEGINS ‘1’` ( _s_ – _s_ ″), checks whether _s_ begins with a binary one.
+
+  * `D72E_xsss` — `SDBEGINSQ` ( _s_ – _s_ ″ − 1 or _s_ 0), a quiet version of `SDBEGINS`.
+
+  * `D730` — `SCUTFIRST` ( _s_ _l_ _r_ – _s_ ′), returns the first 0 ≤ _l_ ≤ 1023 bits and first 0 ≤ _r_ ≤ 4 references of _s_.
+
+  * `D731` — `SSKIPFIRST` ( _s_ _l_ _r_ – _s_ ′).
+
+  * `D732` — `SCUTLAST` ( _s_ _l_ _r_ – _s_ ′), returns the last 0 ≤ _l_ ≤ 1023 data bits and last 0 ≤ _r_ ≤ 4 references of _s_.
+
+  * `D733` — `SSKIPLAST` ( _s_ _l_ _r_ – _s_ ′).
+
+  * `D734` — `SUBSLICE` ( _s_ _l_ _r_ _l_ ′ _r_ ′ – _s_ ′), returns 0 ≤ _l_ ′ ≤ 1023 bits and 0 ≤ _r_ ′ ≤ 4 references from _Slice_ _s_ , after skipping the first 0 ≤ _l_ ≤ 1023 bits and first 0 ≤ _r_ ≤ 4 references.
+
+  * `D736` — `SPLIT` ( _s_ _l_ _r_ – _s_ ′ _s_ ″), splits the first 0 ≤ _l_ ≤ 1023 data bits and first 0 ≤ _r_ ≤ 4 references from _s_ into _s_ ′, returning the remainder of _s_ as _s_ ″.
+
+  * `D737` — `SPLITQ` ( _s_ _l_ _r_ – _s_ ′ _s_ ″ − 1 or _s_ 0), a quiet version of `SPLIT`.
+
+  * `D739` — `XCTOS` ( _c_ – _s_ ?), transforms an ordinary or exotic cell into a _Slice_ , as if it were an ordinary cell. A flag is returned indicating whether _c_ is exotic. If that be the case, its type can later be deserialized from the first eight bits of _s_.
+
+  * `D73A` — `XLOAD` ( _c_ – _c_ ′), loads an exotic cell _c_ and returns an ordinary cell _c_ ′. If _c_ is already ordinary, does nothing. If _c_ cannot be loaded, throws an exception.
+
+  * `D73B` — `XLOADQ` ( _c_ – _c_ ′ − 1 or _c_ 0), loads an exotic cell _c_ as `XLOAD`, but returns 0 on failure.
+
+  * `D741` — `SCHKBITS` ( _s_ _l_ – ), checks whether there are at least _l_ data bits in _Slice_ _s_. If this is not the case, throws a cell deserialisation (i.e., cell underflow) exception.
+
+  * `D742` — `SCHKREFS` ( _s_ _r_ – ), checks whether there are at least _r_ references in _Slice_ _s_.
+
+  * `D743` — `SCHKBITREFS` ( _s_ _l_ _r_ – ), checks whether there are at least _l_ data bits and _r_ references in _Slice_ _s_.
+
+  * `D745` — `SCHKBITSQ` ( _s_ _l_ – ?), checks whether there are at least _l_ data bits in _Slice_ _s_.
+
+  * `D746` — `SCHKREFSQ` ( _s_ _r_ – ?), checks whether there are at least _r_ references in _Slice_ _s_.
+
+  * `D747` — `SCHKBITREFSQ` ( _s_ _l_ _r_ – ?), checks whether there are at least _l_ data bits and _r_ references in _Slice_ _s_.
+
+  * `D748` — `PLDREFVAR` ( _s_ _n_ – _c_ ), returns the _n_ -th cell reference of _Slice_ _s_ for 0 ≤ _n_ ≤ 3.
+
+  * `D749` — `SBITS` ( _s_ – _l_ ), returns the number of data bits in _Slice_ _s_.
+
+  * `D74A` — `SREFS` ( _s_ – _r_ ), returns the number of references in _Slice_ _s_.
+
+  * `D74B` — `SBITREFS` ( _s_ – _l_ _r_ ), returns both the number of data bits and the number of references in _s_.
+
+  * `D74E_n` — `PLDREFIDX n` ( _s_ – _c_ ), returns the _n_ -th cell reference of _Slice_ _s_ , where 0 ≤ _n_ ≤ 3.
+
+  * `D74C` — `PLDREF` ( _s_ – _c_ ), preloads the first cell reference of a _Slice_.
+
+  * `D750` — `LDILE4` ( _s_ – _x_ _s_ ′), loads a little-endian signed 32-bit integer.
+
+  * `D751` — `LDULE4` ( _s_ – _x_ _s_ ′), loads a little-endian unsigned 32-bit integer.
+
+  * `D752` — `LDILE8` ( _s_ – _x_ _s_ ′), loads a little-endian signed 64-bit integer.
+
+  * `D753` — `LDULE8` ( _s_ – _x_ _s_ ′), loads a little-endian unsigned 64-bit integer.
+
+  * `D754` — `PLDILE4` ( _s_ – _x_ ), preloads a little-endian signed 32-bit integer.
+
+  * `D755` — `PLDULE4` ( _s_ – _x_ ), preloads a little-endian unsigned 32-bit integer.
+
+  * `D756` — `PLDILE8` ( _s_ – _x_ ), preloads a little-endian signed 64-bit integer.
+
+  * `D757` — `PLDULE8` ( _s_ – _x_ ), preloads a little-endian unsigned 64-bit integer.
+
+  * `D758` — `LDILE4Q` ( _s_ – _x_ _s_ ′ − 1 or _s_ 0), quietly loads a little-endian signed 32-bit integer.
+
+  * `D759` — `LDULE4Q` ( _s_ – _x_ _s_ ′ − 1 or _s_ 0), quietly loads a little-endian unsigned 32-bit integer.
+
+  * `D75A` — `LDILE8Q` ( _s_ – _x_ _s_ ′ − 1 or _s_ 0), quietly loads a little-endian signed 64-bit integer.
+
+  * `D75B` — `LDULE8Q` ( _s_ – _x_ _s_ ′ − 1 or _s_ 0), quietly loads a little-endian unsigned 64-bit integer.
+
+  * `D75C` — `PLDILE4Q` ( _s_ – _x_ − 1 or 0), quietly preloads a little-endian signed 32-bit integer.
+
+  * `D75D` — `PLDULE4Q` ( _s_ – _x_ − 1 or 0), quietly preloads a little-endian unsigned 32-bit integer.
+
+  * `D75E` — `PLDILE8Q` ( _s_ – _x_ − 1 or 0), quietly preloads a little-endian signed 64-bit integer.
+
+  * `D75F` — `PLDULE8Q` ( _s_ – _x_ − 1 or 0), quietly preloads a little-endian unsigned 64-bit integer.
+
+  * `D760` — `LDZEROES` ( _s_ – _n_ _s_ ′), returns the count _n_ of leading zero bits in _s_ , and removes these bits from _s_.
+
+  * `D761` — `LDONES` ( _s_ – _n_ _s_ ′), returns the count _n_ of leading one bits in _s_ , and removes these bits from _s_.
+
+  * `D762` — `LDSAME` ( _s_ _x_ – _n_ _s_ ′), returns the count _n_ of leading bits equal to 0 ≤ _x_ ≤ 1 in _s_ , and removes these bits from _s_.
+
+  * `D764` — `SDEPTH` ( _s_ – _x_ ), returns the depth of _Slice_ _s_. If _s_ has no references, then _x_ = 0; otherwise _x_ is one plus the maximum of depths of cells referred to from _s_.
+
+  * `D765` — `CDEPTH` ( _c_ – _x_ ), returns the depth of _Cell_ _c_. If _c_ has no references, then _x_ = 0; otherwise _x_ is one plus the maximum of depths of cells referred to from _c_. If _c_ is a _Null_ instead of a _Cell_ , returns zero.
+
+## Continuation and control flow primitives
+
+**Unconditional control flow primitives.**
+
+  * `D8` — `EXECUTE` or `CALLX` ( _c_ – ), _calls_ or _executes_ continuation _c_ (i.e., ${\tt cc}\leftarrow c\circ_0{\tt cc}$).
+
+  * `D9` — `JMPX` ( _c_ – ), _jumps_ , or transfers control, to continuation _c_ (i.e., ${\tt cc}\leftarrow c\circ_0{\tt c0}$, or rather ${\tt cc}\leftarrow(c\circ_0{\tt c0})\circ_1{\tt c1}$). The remainder of the previous current continuation `cc` is discarded.
+
+  * `DApr` — `CALLXARGS p,r` ( _c_ – ), _calls_ continuation _c_ with _p_ parameters and expecting _r_ return values, 0 ≤ _p_ ≤ 15, 0 ≤ _r_ ≤ 15.
+
+  * `DB0p` — `CALLXARGS p,-1` ( _c_ – ), _calls_ continuation _c_ with 0 ≤ _p_ ≤ 15 parameters, expecting an arbitrary number of return values.
+
+  * `DB1p` — `JMPXARGS p` ( _c_ – ), _jumps_ to continuation _c_ , passing only the top 0 ≤ _p_ ≤ 15 values from the current stack to it (the remainder of the current stack is discarded).
+
+  * `DB2r` — `RETARGS r`, _returns_ to `c0`, with 0 ≤ _r_ ≤ 15 return values taken from the current stack.
+
+  * `DB30` — `RET` or `RETTRUE`, _returns_ to the continuation at `c0` (i.e., performs ${\tt cc}\leftarrow{\tt c0}$). The remainder of the current continuation `cc` is discarded. Approximately equivalent to `PUSH c0`; `JMPX`.
+
+  * `DB31` — `RETALT` or `RETFALSE`, _returns_ to the continuation at `c1` (i.e., ${\tt cc}\leftarrow{\tt c1}$). Approximately equivalent to `PUSH c1`; `JMPX`.
+
+  * `DB32` — `BRANCH` or `RETBOOL` ( _f_ – ), performs `RETTRUE` if integer _f_ ≠ 0, or `RETFALSE` if _f_ = 0.
+
+  * `DB34` — `CALLCC` ( _c_ – ), _call with current continuation_ , transfers control to _c_ , pushing the old value of `cc` into _c_ ’s stack (instead of discarding it or writing it into new `c0`).
+
+  * `DB35` — `JMPXDATA` ( _c_ – ), similar to `CALLCC`, but the remainder of the current continuation (the old value of `cc`) is converted into a _Slice_ before pushing it into the stack of _c_.
+
+  * `DB36pr` — `CALLCCARGS p,r` ( _c_ – ), similar to `CALLXARGS`, but pushes the old value of `cc` (along with the top 0 ≤ _p_ ≤ 15 values from the original stack) into the stack of newly-invoked continuation _c_ , setting `cc.nargs` to  − 1 ≤ _r_ ≤ 14.
+
+  * `DB38` — `CALLXVARARGS` ( _c_ _p_ _r_ – ), similar to `CALLXARGS`, but takes  − 1 ≤ _p_ , _r_ ≤ 254 from the stack. The next three operations also take _p_ and _r_ from the stack, both in the range  − 1…254.
+
+  * `DB39` — `RETVARARGS` ( _p_ _r_ – ), similar to `RETARGS`.
+
+  * `DB3A` — `JMPXVARARGS` ( _c_ _p_ _r_ – ), similar to `JMPXARGS`.
+
+  * `DB3B` — `CALLCCVARARGS` ( _c_ _p_ _r_ – ), similar to `CALLCCARGS`.
+
+  * `DB3C` — `CALLREF`, equivalent to `PUSHREFCONT`; `CALLX`.
+
+  * `DB3D` — `JMPREF`, equivalent to `PUSHREFCONT`; `JMPX`.
+
+  * `DB3E` — `JMPREFDATA`, equivalent to `PUSHREFCONT`; `JMPXDATA`.
+
+  * `DB3F` — `RETDATA`, equivalent to `PUSH c0`; `JMPXDATA`. In this way, the remainder of the current continuation is converted into a _Slice_ and returned to the caller.
+
+**Conditional control flow primitives.** [sp:prim.cond.flow]
+
+  * `DC` — `IFRET` ( _f_ – ), performs a `RET`, but only if integer _f_ is non-zero. If _f_ is a `NaN`, throws an integer overflow exception.
+
+  * `DD` — `IFNOTRET` ( _f_ – ), performs a `RET`, but only if integer _f_ is zero.
+
+  * `DE` — `IF` ( _f_ _c_ – ), performs `EXECUTE` for _c_ (i.e., _executes_ _c_ ), but only if integer _f_ is non-zero. Otherwise simply discards both values.
+
+  * `DF` — `IFNOT` ( _f_ _c_ – ), executes continuation _c_ , but only if integer _f_ is zero. Otherwise simply discards both values.
+
+  * `E0` — `IFJMP` ( _f_ _c_ – ), jumps to _c_ (similarly to `JMPX`), but only if _f_ is non-zero.
+
+  * `E1` — `IFNOTJMP` ( _f_ _c_ – ), jumps to _c_ (similarly to `JMPX`), but only if _f_ is zero.
+
+  * `E2` — `IFELSE` ( _f_ _c_ _c_ ′ – ), if integer _f_ is non-zero, executes _c_ , otherwise executes _c_ ′. Equivalent to `CONDSELCHK`; `EXECUTE`.
+
+  * `E300` — `IFREF` ( _f_ – ), equivalent to `PUSHREFCONT`; `IF`, with the optimization that the cell reference is not actually loaded into a _Slice_ and then converted into an ordinary _Continuation_ if _f_ = 0. Similar remarks apply to the next three primitives.
+
+  * `E301` — `IFNOTREF` ( _f_ – ), equivalent to `PUSHREFCONT`; `IFNOT`.
+
+  * `E302` — `IFJMPREF` ( _f_ – ), equivalent to `PUSHREFCONT`; `IFJMP`.
+
+  * `E303` — `IFNOTJMPREF` ( _f_ – ), equivalent to `PUSHREFCONT`; `IFNOTJMP`.
+
+  * `E304` — `CONDSEL` ( _f_ _x_ _y_ – _x_ or _y_ ), if integer _f_ is non-zero, returns _x_ , otherwise returns _y_. Notice that no type checks are performed on _x_ and _y_ ; as such, it is more like a conditional stack operation. Roughly equivalent to `ROT`; `ISZERO`; `INC`; `ROLLX`; `NIP`.
+
+  * `E305` — `CONDSELCHK` ( _f_ _x_ _y_ – _x_ or _y_ ), same as `CONDSEL`, but first checks whether _x_ and _y_ have the same type.
+
+  * `E308` — `IFRETALT` ( _f_ –), performs `RETALT` if integer _f_ ≠ 0.
+
+  * `E309` — `IFNOTRETALT` ( _f_ –), performs `RETALT` if integer _f_ = 0.
+
+  * `E30D` — `IFREFELSE` ( _f_ _c_ –), equivalent to `PUSHREFCONT`; `SWAP`; `IFELSE`, with the optimization that the cell reference is not actually loaded into a _Slice_ and then converted into an ordinary _Continuation_ if _f_ = 0. Similar remarks apply to the next two primitives: _Cell_ s are converted into _Continuation_ s only when necessary.
+
+  * `E30E` — `IFELSEREF` ( _f_ _c_ –), equivalent to `PUSHREFCONT`; `IFELSE`.
+
+  * `E30F` — `IFREFELSEREF` ( _f_ –), equivalent to `PUSHREFCONT`; `PUSHREFCONT`; `IFELSE`.
+
+  * `E310`–`E31F` — reserved for loops with break operators, cf. below.
+
+  * `E39_n` — `IFBITJMP n` ( _x_ _c_ – _x_ ), checks whether bit 0 ≤ _n_ ≤ 31 is set in integer _x_ , and if so, performs `JMPX` to continuation _c_. Value _x_ is left in the stack.
+
+  * `E3B_n` — `IFNBITJMP n` ( _x_ _c_ – _x_ ), jumps to _c_ if bit 0 ≤ _n_ ≤ 31 is not set in integer _x_.
+
+  * `E3D_n` — `IFBITJMPREF n` ( _x_ – _x_ ), performs a `JMPREF` if bit 0 ≤ _n_ ≤ 31 is set in integer _x_.
+
+  * `E3F_n` — `IFNBITJMPREF n` ( _x_ – _x_ ), performs a `JMPREF` if bit 0 ≤ _n_ ≤ 31 is not set in integer _x_.
+
+**Control flow primitives: loops.** [sp:prim.loop] Most of the loop primitives
+listed below are implemented with the aid of extraordinary continuations, such
+as `ec_until` (cf. ), with the loop body and the original current continuation
+`cc` stored as the arguments to this extraordinary continuation. Typically a
+suitable extraordinary continuation is constructed, and then saved into the
+loop body continuation savelist as `c0`; after that, the modified loop body
+continuation is loaded into `cc` and executed in the usual fashion. All of
+these loop primitives have `BRK` versions, adapted for breaking out of a loop;
+they additionally set `c1` to the original current continuation (or original
+`c0` for `ENDBRK` versions), and save the old `c1` into the savelist of the
+original current continuation (or of the original `c0` for `ENDBRK` versions).
+
+  * `E4` — `REPEAT` ( _n_ _c_ – ), executes continuation _c_ _n_ times, if integer _n_ is non-negative. If _n_ ≥ 231 or _n_ < − 231, generates a range check exception. Notice that a `RET` inside the code of _c_ works as a `continue`, not as a `break`. One should use either alternative (experimental) loops or alternative `RETALT` (along with a `SETEXITALT` before the loop) to `break` out of a loop.
+
+  * `E5` — `REPEATEND` ( _n_ – ), similar to `REPEAT`, but it is applied to the current continuation `cc`.
+
+  * `E6` — `UNTIL` ( _c_ – ), executes continuation _c_ , then pops an integer _x_ from the resulting stack. If _x_ is zero, performs another iteration of this loop. The actual implementation of this primitive involves an extraordinary continuation `ec_until` (cf. ) with its arguments set to the body of the loop (continuation _c_ ) and the original current continuation `cc`. This extraordinary continuation is then saved into the savelist of _c_ as $c.{\tt c0}$ and the modified _c_ is then executed. The other loop primitives are implemented similarly with the aid of suitable extraordinary continuations.
+
+  * `E7` — `UNTILEND` ( – ), similar to `UNTIL`, but executes the current continuation `cc` in a loop. When the loop exit condition is satisfied, performs a `RET`.
+
+  * `E8` — `WHILE` ( _c_ ′ _c_ – ), executes _c_ ′ and pops an integer _x_ from the resulting stack. If _x_ is zero, exists the loop and transfers control to the original `cc`. If _x_ is non-zero, executes _c_ , and then begins a new iteration.
+
+  * `E9` — `WHILEEND` ( _c_ ′ – ), similar to `WHILE`, but uses the current continuation `cc` as the loop body.
+
+  * `EA` — `AGAIN` ( _c_ – ), similar to `REPEAT`, but executes _c_ infinitely many times. A `RET` only begins a new iteration of the infinite loop, which can be exited only by an exception, or a `RETALT` (or an explicit `JMPX`).
+
+  * `EB` — `AGAINEND` ( – ), similar to `AGAIN`, but performed with respect to the current continuation `cc`.
+
+  * `E314` — `REPEATBRK` ( _n_ _c_ – ), similar to `REPEAT`, but also sets `c1` to the original `cc` after saving the old value of `c1` into the savelist of the original `cc`. In this way `RETALT` could be used to break out of the loop body.
+
+  * `E315` — `REPEATENDBRK` ( _n_ – ), similar to `REPEATEND`, but also sets `c1` to the original `c0` after saving the old value of `c1` into the savelist of the original `c0`. Equivalent to `SAMEALTSAVE`; `REPEATEND`.
+
+  * `E316` — `UNTILBRK` ( _c_ – ), similar to `UNTIL`, but also modifies `c1` in the same way as `REPEATBRK`.
+
+  * `E317` — `UNTILENDBRK` ( – ), equivalent to `SAMEALTSAVE`; `UNTILEND`.
+
+  * `E318` — `WHILEBRK` ( _c_ ′ _c_ – ), similar to `WHILE`, but also modifies `c1` in the same way as `REPEATBRK`.
+
+  * `E319` — `WHILEENDBRK` ( _c_ – ), equivalent to `SAMEALTSAVE`; `WHILEEND`.
+
+  * `E31A` — `AGAINBRK` ( _c_ – ), similar to `AGAIN`, but also modifies `c1` in the same way as `REPEATBRK`.
+
+  * `E31B` — `AGAINENDBRK` ( – ), equivalent to `SAMEALTSAVE`; `AGAINEND`.
+
+[sp:cont.stk.manip] **Manipulating the stack of continuations.**
+
+  * `ECrn` — `SETCONTARGS r,n` ( _x_ 1 _x_ 2… _x_ _r_ _c_ – _c_ ′), similar to `SETCONTARGS r`, but sets $c.{\tt nargs}$ to the final size of the stack of _c_ ′ plus _n_. In other words, transforms _c_ into a _closure_ or a _partially applied function_ , with 0 ≤ _n_ ≤ 14 arguments missing.
+
+  * `EC0n` — `SETNUMARGS n` or `SETCONTARGS 0,n` ( _c_ – _c_ ′), sets $c.{\tt nargs}$ to _n_ plus the current depth of _c_ ’s stack, where 0 ≤ _n_ ≤ 14. If $c.{\tt nargs}$ is already set to a non-negative value, does nothing.
+
+  * `ECrF` — `SETCONTARGS r` or `SETCONTARGS r,-1` ( _x_ 1 _x_ 2… _x_ _r_ _c_ – _c_ ′), pushes 0 ≤ _r_ ≤ 15 values _x_ 1… _x_ _r_ into the stack of (a copy of) the continuation _c_ , starting with _x_ 1. If the final depth of _c_ ’s stack turns out to be greater than $c.{\tt nargs}$, a stack overflow exception is generated.
+
+  * `ED0p` — `RETURNARGS p` ( – ), leaves only the top 0 ≤ _p_ ≤ 15 values in the current stack (somewhat similarly to `ONLYTOPX`), with all the unused bottom values not discarded, but saved into continuation `c0` in the same way as `SETCONTARGS` does.
+
+  * `ED10` — `RETURNVARARGS` ( _p_ – ), similar to `RETURNARGS`, but with Integer 0 ≤ _p_ ≤ 255 taken from the stack.
+
+  * `ED11` — `SETCONTVARARGS` ( _x_ 1 _x_ 2… _x_ _r_ _c_ _r_ _n_ – _c_ ′), similar to `SETCONTARGS`, but with 0 ≤ _r_ ≤ 255 and  − 1 ≤ _n_ ≤ 255 taken from the stack.
+
+  * `ED12` — `SETNUMVARARGS` ( _c_ _n_ – _c_ ′), where  − 1 ≤ _n_ ≤ 255. If _n_ = − 1, this operation does nothing ( _c_ ′ = _c_ ). Otherwise its action is similar to `SETNUMARGS n`, but with _n_ taken from the stack.
+
+**Creating simple continuations and closures.** [sp:prim.bless.cont]
+
+  * `ED1E` — `BLESS` ( _s_ – _c_ ), transforms a _Slice_ _s_ into a simple ordinary continuation _c_ , with $c.{\tt code}=s$ and an empty stack and savelist.
+
+  * `ED1F` — `BLESSVARARGS` ( _x_ 1… _x_ _r_ _s_ _r_ _n_ – _c_ ), equivalent to `ROT`; `BLESS`; `ROTREV`; `SETCONTVARARGS`.
+
+  * `EErn` — `BLESSARGS r,n` ( _x_ 1… _x_ _r_ _s_ – _c_ ), where 0 ≤ _r_ ≤ 15,  − 1 ≤ _n_ ≤ 14, equivalent to `BLESS`; `SETCONTARGS r,n`. The value of _n_ is represented inside the instruction by the 4-bit integer _n_ mod 16.
+
+  * `EE0n` — `BLESSNUMARGS n` or `BLESSARGS 0,n` ( _s_ – _c_ ), also transforms a _Slice_ _s_ into a _Continuation_ _c_ , but sets $c.{\tt nargs}$ to 0 ≤ _n_ ≤ 14.
+
+**Operations with continuation savelists and control registers.**
+
+  * `ED4i` — `PUSH c(i)` or `PUSHCTR c(i)` ( – _x_ ), pushes the current value of control register `c(i)`. If the control register is not supported in the current codepage, or if it does not have a value, an exception is triggered.
+
+  * `ED44` — `PUSH c4` or `PUSHROOT`, pushes the “global data root” cell reference, thus enabling access to persistent smart-contract data.
+
+  * `ED5i` — `POP c(i)` or `POPCTR c(i)` ( _x_ – ), pops a value _x_ from the stack and stores it into control register `c(i)`, if supported in the current codepage. Notice that if a control register accepts only values of a specific type, a type-checking exception may occur.
+
+  * `ED54` — `POP c4` or `POPROOT`, sets the “global data root” cell reference, thus allowing modification of persistent smart-contract data.
+
+  * `ED6i` — `SETCONT c(i)` or `SETCONTCTR c(i)` ( _x_ _c_ – _c_ ′), stores _x_ into the savelist of continuation _c_ as `c(i)`, and returns the resulting continuation _c_ ′. Almost all operations with continuations may be expressed in terms of `SETCONTCTR`, `POPCTR`, and `PUSHCTR`.
+
+  * `ED7i` — `SETRETCTR c(i)` ( _x_ – ), equivalent to `PUSH c0`; `SETCONTCTR c(i)`; `POP c0`.
+
+  * `ED8i` — `SETALTCTR c(i)` ( _x_ – ), equivalent to `PUSH c1`; `SETCONTCTR c(i)`; `POP c0`.
+
+  * `ED9i` — `POPSAVE c(i)` or `POPCTRSAVE c(i)` ( _x_ –), similar to `POP c(i)`, but also saves the old value of `c(i)` into continuation `c0`. Equivalent (up to exceptions) to `SAVECTR c(i)`; `POP c(i)`.
+
+  * `EDAi` — `SAVE c(i)` or `SAVECTR c(i)` ( – ), saves the current value of `c(i)` into the savelist of continuation `c0`. If an entry for `c(i)` is already present in the savelist of `c0`, nothing is done. Equivalent to `PUSH c(i)`; `SETRETCTR c(i)`.
+
+  * `EDBi` — `SAVEALT c(i)` or `SAVEALTCTR c(i)` ( – ), similar to `SAVE c(i)`, but saves the current value of `c(i)` into the savelist of `c1`, not `c0`.
+
+  * `EDCi` — `SAVEBOTH c(i)` or `SAVEBOTHCTR c(i)` ( – ), equivalent to `DUP`; `SAVE c(i)`; `SAVEALT c(i)`.
+
+  * `EDE0` — `PUSHCTRX` ( _i_ – _x_ ), similar to `PUSHCTR c(i)`, but with _i_ , 0 ≤ _i_ ≤ 255, taken from the stack. Notice that this primitive is one of the few “exotic” primitives, which are not polymorphic like stack manipulation primitives, and at the same time do not have well-defined types of parameters and return values, because the type of _x_ depends on _i_.
+
+  * `EDE1` — `POPCTRX` ( _x_ _i_ – ), similar to `POPCTR c(i)`, but with 0 ≤ _i_ ≤ 255 from the stack.
+
+  * `EDE2` — `SETCONTCTRX` ( _x_ _c_ _i_ – _c_ ′), similar to `SETCONTCTR c(i)`, but with 0 ≤ _i_ ≤ 255 from the stack.
+
+  * `EDF0` — `COMPOS` or `BOOLAND` ( _c_ _c_ ′ – _c_ ″), computes the composition _c_ ∘0 _c_ ′, which has the meaning of “perform _c_ , and, if successful, perform _c_ ′” (if _c_ is a boolean circuit) or simply “perform _c_ , then _c_ ′”. Equivalent to `SWAP`; `SETCONT c0`.
+
+  * `EDF1` — `COMPOSALT` or `BOOLOR` ( _c_ _c_ ′ – _c_ ″), computes the alternative composition _c_ ∘1 _c_ ′, which has the meaning of “perform _c_ , and, if not successful, perform _c_ ′” (if _c_ is a boolean circuit). Equivalent to `SWAP`; `SETCONT c1`.
+
+  * `EDF2` — `COMPOSBOTH` ( _c_ _c_ ′ – _c_ ″), computes ( _c_ ∘0 _c_ ′)∘1 _c_ ′, which has the meaning of “compute boolean circuit _c_ , then compute _c_ ′, regardless of the result of _c_ ”.
+
+  * `EDF3` — `ATEXIT` ( _c_ – ), sets ${\tt c0}\leftarrow c\circ_0{\tt c0}$. In other words, _c_ will be executed before exiting current subroutine.
+
+  * `EDF4` — `ATEXITALT` ( _c_ – ), sets ${\tt c1}\leftarrow c\circ_1{\tt c1}$. In other words, _c_ will be executed before exiting current subroutine by its alternative return path.
+
+  * `EDF5` — `SETEXITALT` ( _c_ – ), sets ${\tt c1}\leftarrow (c\circ_0{\tt c0})\circ_1{\tt c1}$. In this way, a subsequent `RETALT` will first execute _c_ , then transfer control to the original `c0`. This can be used, for instance, to exit from nested loops.
+
+  * `EDF6` — `THENRET` ( _c_ – _c_ ′), computes $c':=c\circ_0{\tt c0}$
+
+  * `EDF7` — `THENRETALT` ( _c_ – _c_ ′), computes $c':=c\circ_0{\tt c1}$
+
+  * `EDF8` — `INVERT` ( – ), interchanges `c0` and `c1`.
+
+  * `EDF9` — `BOOLEVAL` ( _c_ – ?), performs ${\tt cc}\leftarrow \bigl(c\circ_0(({\tt PUSH}\,-1)\circ_0{\tt cc})\bigr)\circ_1(({\tt PUSH}\,0)\circ_0{\tt cc})$. If _c_ represents a boolean circuit, the net effect is to evaluate it and push either  − 1 or 0 into the stack before continuing.
+
+  * `EDFA` — `SAMEALT` ( – ), sets _c_ 1 := _c_ 0. Equivalent to `PUSH c0`; `POP c1`.
+
+  * `EDFB` — `SAMEALTSAVE` ( – ), sets _c_ 1 := _c_ 0, but first saves the old value of _c_ 1 into the savelist of _c_ 0. Equivalent to `SAVE c1`; `SAMEALT`.
+
+  * `EErn` — `BLESSARGS r,n` ( _x_ 1… _x_ _r_ _s_ – _c_ ), described in .
+
+**Dictionary subroutine calls and jumps.** [sp:prim.dict.calls]
+
+  * `F0n` — `CALL n` or `CALLDICT n` ( – _n_ ), calls the continuation in `c3`, pushing integer 0 ≤ _n_ ≤ 255 into its stack as an argument. Approximately equivalent to `PUSHINT n`; `PUSH c3`; `EXECUTE`.
+
+  * `F12_n` — `CALL n` for 0 ≤ _n_ < 214 ( – _n_ ), an encoding of `CALL n` for larger values of _n_.
+
+  * `F16_n` — `JMP n` or `JMPDICT n` ( – _n_ ), jumps to the continuation in `c3`, pushing integer 0 ≤ _n_ < 214 as its argument. Approximately equivalent to `PUSHINT n`; `PUSH c3`; `JMPX`.
+
+  * `F1A_n` — `PREPARE n` or `PREPAREDICT n` ( – _n_ _c_ ), equivalent to `PUSHINT n`; `PUSH c3`, for 0 ≤ _n_ < 214. In this way, `CALL n` is approximately equivalent to `PREPARE n`; `EXECUTE`, and `JMP n` is approximately equivalent to `PREPARE n`; `JMPX`. One might use, for instance, `CALLARGS` or `CALLCC` instead of `EXECUTE` here.
+
+## Exception generating and handling primitives
+
+**Throwing exceptions.**
+
+  * `F22_nn` — `THROW nn` ( – 0 _n_ _n_ ), throws exception 0 ≤ _n_ _n_ ≤ 63 with parameter zero. In other words, it transfers control to the continuation in `c2`, pushing 0 and _n_ _n_ into its stack, and discarding the old stack altogether.
+
+  * `F26_nn` — `THROWIF nn` ( _f_ – ), throws exception 0 ≤ _n_ _n_ ≤ 63 with parameter zero only if integer _f_ ≠ 0.
+
+  * `F2A_nn` — `THROWIFNOT nn` ( _f_ – ), throws exception 0 ≤ _n_ _n_ ≤ 63 with parameter zero only if integer _f_ = 0.
+
+  * `F2C4_nn` — `THROW nn` for 0 ≤ _n_ _n_ < 211, an encoding of `THROW nn` for larger values of _n_ _n_.
+
+  * `F2CC_nn` — `THROWARG nn` ( _x_ – _x_ _n_ _n_ ), throws exception 0 ≤ _n_ _n_ < 211 with parameter _x_ , by copying _x_ and _n_ _n_ into the stack of ${\tt c2}$ and transferring control to `c2`.
+
+  * `F2D4_nn` — `THROWIF nn` ( _f_ – ) for 0 ≤ _n_ _n_ < 211.
+
+  * `F2DC_nn` — `THROWARGIF nn` ( _x_ _f_ – ), throws exception 0 ≤ _n_ _n_ < 211 with parameter _x_ only if integer _f_ ≠ 0.
+
+  * `F2E4_nn` — `THROWIFNOT nn` ( _f_ – ) for 0 ≤ _n_ _n_ < 211.
+
+  * `F2EC_nn` — `THROWARGIFNOT nn` ( _x_ _f_ – ), throws exception 0 ≤ _n_ _n_ < 211 with parameter _x_ only if integer _f_ = 0.
+
+  * `F2F0` — `THROWANY` ( _n_ – 0 _n_ ), throws exception 0 ≤ _n_ < 216 with parameter zero. Approximately equivalent to `PUSHINT 0`; `SWAP`; `THROWARGANY`.
+
+  * `F2F1` — `THROWARGANY` ( _x_ _n_ – _x_ _n_ ), throws exception 0 ≤ _n_ < 216 with parameter _x_ , transferring control to the continuation in `c2`. Approximately equivalent to `PUSH c2`; `JMPXARGS 2`.
+
+  * `F2F2` — `THROWANYIF` ( _n_ _f_ – ), throws exception 0 ≤ _n_ < 216 with parameter zero only if _f_ ≠ 0.
+
+  * `F2F3` — `THROWARGANYIF` ( _x_ _n_ _f_ – ), throws exception 0 ≤ _n_ < 216 with parameter _x_ only if _f_ ≠ 0.
+
+  * `F2F4` — `THROWANYIFNOT` ( _n_ _f_ – ), throws exception 0 ≤ _n_ < 216 with parameter zero only if _f_ = 0.
+
+  * `F2F5` — `THROWARGANYIFNOT` ( _x_ _n_ _f_ – ), throws exception 0 ≤ _n_ < 216 with parameter _x_ only if _f_ = 0.
+
+**Catching and handling exceptions.**
+
+  * `F2FF` — `TRY` ( _c_ _c_ ′ – ), sets `c2` to _c_ ′, first saving the old value of `c2` both into the savelist of _c_ ′ and into the savelist of the current continuation, which is stored into $c.{\tt c0}$ and $c'.{\tt c0}$. Then runs _c_ similarly to `EXECUTE`. If _c_ does not throw any exceptions, the original value of `c2` is automatically restored on return from _c_. If an exception occurs, the execution is transferred to _c_ ′, but the original value of `c2` is restored in the process, so that _c_ ′ can re-throw the exception by `THROWANY` if it cannot handle it by itself.
+
+  * `F3pr` — `TRYARGS p,r` ( _c_ _c_ ′ – ), similar to `TRY`, but with `CALLARGS p,r` internally used instead of `EXECUTE`. In this way, all but the top 0 ≤ _p_ ≤ 15 stack elements will be saved into current continuation’s stack, and then restored upon return from either _c_ or _c_ ′, with the top 0 ≤ _r_ ≤ 15 values of the resulting stack of _c_ or _c_ ′ copied as return values.
+
+## Dictionary manipulation primitives
+
+[p:prim.dict]
+
+TVM’s dictionary support is discussed at length in . The basic operations with
+dictionaries are listed in , while the taxonomy of dictionary manipulation
+primitives is provided in . Here we use the concepts and notation introduced
+in those sections.
+
+Dictionaries admit two different representations as TVM stack values:
+
+  * A _Slice_ _s_ with a serialization of a TL-B value of type _HashmapE_ ( _n_ , _X_ ). In other words, _s_ consists either of one bit equal to zero (if the dictionary is empty), or of one bit equal to one and a reference to a _Cell_ containing the root of the binary tree, i.e., a serialized value of type _Hashmap_ ( _n_ , _X_ ).
+
+  * A “maybe _Cell_ ” _c_?, i.e., a value that is either a _Cell_ (containing a serialized value of type _Hashmap_ ( _n_ , _X_ ) as before) or a _Null_ (corresponding to an empty dictionary). When a “maybe _Cell_ ” _c_? is used to represent a dictionary, we usually denote it by _D_ in the stack notation.
+
+Most of the dictionary primitives listed below accept and return dictionaries
+in the second form, which is more convenient for stack manipulation. However,
+serialized dictionaries inside larger TL-B objects use the first
+representation.
+
+Opcodes starting with `F4` and `F5` are reserved for dictionary operations.
+
+[sp:prim.dict.create] **Dictionary creation.**
+
+  * `6D` — `NEWDICT` ( – _D_ ), returns a new empty dictionary. It is an alternative mnemonics for `PUSHNULL`, cf. .
+
+  * `6E` — `DICTEMPTY` ( _D_ – ?), checks whether dictionary _D_ is empty, and returns  − 1 or 0 accordingly. It is an alternative mnemonics for `ISNULL`, cf. .
+
+**Dictionary serialization and deserialization.**
+
+  * `CE` — `STDICTS` ( _s_ _b_ – _b_ ′), stores a _Slice_ -represented dictionary _s_ into _Builder_ _b_. It is actually a synonym for `STSLICE`.
+
+  * `F400` — `STDICT` or `STOPTREF` ( _D_ _b_ – _b_ ′), stores dictionary _D_ into _Builder_ _b_ , returing the resulting _Builder_ _b_ ′. In other words, if _D_ is a cell, performs `STONE` and `STREF`; if _D_ is _Null_ , performs `NIP` and `STZERO`; otherwise throws a type checking exception.
+
+  * `F401` — `SKIPDICT` or `SKIPOPTREF` ( _s_ – _s_ ′), equivalent to `LDDICT`; `NIP`.
+
+  * `F402` — `LDDICTS` ( _s_ – _s_ ′ _s_ ″), loads (parses) a ( _Slice_ -represented) dictionary _s_ ′ from _Slice_ _s_ , and returns the remainder of _s_ as _s_ ″. This is a “split function” for all _HashmapE_ ( _n_ , _X_ ) dictionary types.
+
+  * `F403` — `PLDDICTS` ( _s_ – _s_ ′), preloads a ( _Slice_ -represented) dictionary _s_ ′ from _Slice_ _s_. Approximately equivalent to `LDDICTS`; `DROP`.
+
+  * `F404` — `LDDICT` or `LDOPTREF` ( _s_ – _D_ _s_ ′), loads (parses) a dictionary _D_ from _Slice_ _s_ , and returns the remainder of _s_ as _s_ ′. May be applied to dictionaries or to values of arbitrary $(\texttt{\^{}}Y)^?$ types.
+
+  * `F405` — `PLDDICT` or `PLDOPTREF` ( _s_ – _D_ ), preloads a dictionary _D_ from _Slice_ _s_. Approximately equivalent to `LDDICT`; `DROP`.
+
+  * `F406` — `LDDICTQ` ( _s_ – _D_ _s_ ′ − 1 or _s_ 0), a quiet version of `LDDICT`.
+
+  * `F407` — `PLDDICTQ` ( _s_ – _D_ − 1 or 0), a quiet version of `PLDDICT`.
+
+[sp:prim.dict.get] **Get dictionary operations.**
+
+  * `F40A` — `DICTGET` ( _k_ _D_ _n_ – _x_ − 1 or 0), looks up key _k_ (represented by a _Slice_ , the first 0 ≤ _n_ ≤ 1023 data bits of which are used as a key) in dictionary _D_ of type _HashmapE_ ( _n_ , _X_ ) with _n_ -bit keys. On success, returns the value found as a _Slice_ _x_.
+
+  * `F40B` — `DICTGETREF` ( _k_ _D_ _n_ – _c_ − 1 or 0), similar to `DICTGET`, but with a `LDREF`; `ENDS` applied to _x_ on success. This operation is useful for dictionaries of type $\textit{HashmapE}(n,\texttt{\^{}}Y)$.
+
+  * `F40C` — `DICTIGET` ( _i_ _D_ _n_ – _x_ − 1 or 0), similar to `DICTGET`, but with a signed (big-endian) _n_ -bit _Integer_ _i_ as a key. If _i_ does not fit into _n_ bits, returns 0. If _i_ is a `NaN`, throws an integer overflow exception.
+
+  * `F40D` — `DICTIGETREF` ( _i_ _D_ _n_ – _c_ − 1 or 0), combines `DICTIGET` with `DICTGETREF`: it uses signed _n_ -bit _Integer_ _i_ as a key and returns a _Cell_ instead of a _Slice_ on success.
+
+  * `F40E` — `DICTUGET` ( _i_ _D_ _n_ – _x_ − 1 or 0), similar to `DICTIGET`, but with _unsigned_ (big-endian) _n_ -bit _Integer_ _i_ used as a key.
+
+  * `F40F` — `DICTUGETREF` ( _i_ _D_ _n_ – _c_ − 1 or 0), similar to `DICTIGETREF`, but with an unsigned _n_ -bit _Integer_ key _i_.
+
+[sp:prim.dict.set] **Set /Replace/Add dictionary operations.** The mnemonics
+of the following dictionary primitives are constructed in a systematic fashion
+according to the regular expression `DICT`[,`I`, `U`](`SET`, `REPLACE`,
+`ADD`)[`GET`][`REF`] depending on the type of the key used (a _Slice_ or a
+signed or unsigned _Integer_ ), the dictionary operation to be performed, and
+the way the values are accepted and returned (as _Cell_ s or as _Slice_ s).
+Therefore, we provide a detailed description only for some primitives,
+assuming that this information is sufficient for the reader to understand the
+precise action of the remaining primitives.
+
+  * `F412` — `DICTSET` ( _x_ _k_ _D_ _n_ – _D_ ′), sets the value associated with _n_ -bit key _k_ (represented by a _Slice_ as in `DICTGET`) in dictionary _D_ (also represented by a _Slice_ ) to value _x_ (again a _Slice_ ), and returns the resulting dictionary as _D_ ′.
+
+  * `F413` — `DICTSETREF` ( _c_ _k_ _D_ _n_ – _D_ ′), similar to `DICTSET`, but with the value set to a reference to _Cell_ _c_.
+
+  * `F414` — `DICTISET` ( _x_ _i_ _D_ _n_ – _D_ ′), similar to `DICTSET`, but with the key represented by a (big-endian) signed _n_ -bit integer _i_. If _i_ does not fit into _n_ bits, a range check exception is generated.
+
+  * `F415` — `DICTISETREF` ( _c_ _i_ _D_ _n_ – _D_ ′), similar to `DICTSETREF`, but with the key a signed _n_ -bit integer as in `DICTISET`.
+
+  * `F416` — `DICTUSET` ( _x_ _i_ _D_ _n_ – _D_ ′), similar to `DICTISET`, but with _i_ an _unsigned_ _n_ -bit integer.
+
+  * `F417` — `DICTUSETREF` ( _c_ _i_ _D_ _n_ – _D_ ′), similar to `DICTISETREF`, but with _i_ unsigned.
+
+  * `F41A` — `DICTSETGET` ( _x_ _k_ _D_ _n_ – _D_ ′ _y_ − 1 or _D_ ′ 0), combines `DICTSET` with `DICTGET`: it sets the value corresponding to key _k_ to _x_ , but also returns the old value _y_ associated with the key in question, if present.
+
+  * `F41B` — `DICTSETGETREF` ( _c_ _k_ _D_ _n_ – _D_ ′ _c_ ′ − 1 or _D_ ′ 0), combines `DICTSETREF` with `DICTGETREF` similarly to `DICTSETGET`.
+
+  * `F41C` — `DICTISETGET` ( _x_ _i_ _D_ _n_ – _D_ ′ _y_ − 1 or _D_ ′ 0), similar to `DICTSETGET`, but with the key represented by a big-endian signed _n_ -bit _Integer_ _i_.
+
+  * `F41D` — `DICTISETGETREF` ( _c_ _i_ _D_ _n_ – _D_ ′ _c_ ′ − 1 or _D_ ′ 0), a version of `DICTSETGETREF` with signed _Integer_ _i_ as a key.
+
+  * `F41E` — `DICTUSETGET` ( _x_ _i_ _D_ _n_ – _D_ ′ _y_ − 1 or _D_ ′ 0), similar to `DICTISETGET`, but with _i_ an unsigned _n_ -bit integer.
+
+  * `F41F` — `DICTUSETGETREF` ( _c_ _i_ _D_ _n_ – _D_ ′ _c_ ′ − 1 or _D_ ′ 0).
+
+  * `F422` — `DICTREPLACE` ( _x_ _k_ _D_ _n_ – _D_ ′ − 1 or _D_ 0), a Replace operation, which is similar to `DICTSET`, but sets the value of key _k_ in dictionary _D_ to _x_ only if the key _k_ was already present in _D_.
+
+  * `F423` — `DICTREPLACEREF` ( _c_ _k_ _D_ _n_ – _D_ ′ − 1 or _D_ 0), a Replace counterpart of `DICTSETREF`.
+
+  * `F424` — `DICTIREPLACE` ( _x_ _i_ _D_ _n_ – _D_ ′ − 1 or _D_ 0), a version of `DICTREPLACE` with signed _n_ -bit _Integer_ _i_ used as a key.
+
+  * `F425` — `DICTIREPLACEREF` ( _c_ _i_ _D_ _n_ – _D_ ′ − 1 or _D_ 0).
+
+  * `F426` — `DICTUREPLACE` ( _x_ _i_ _D_ _n_ – _D_ ′ − 1 or _D_ 0).
+
+  * `F427` — `DICTUREPLACEREF` ( _c_ _i_ _D_ _n_ – _D_ ′ − 1 or _D_ 0).
+
+  * `F42A` — `DICTREPLACEGET` ( _x_ _k_ _D_ _n_ – _D_ ′ _y_ − 1 or _D_ 0), a Replace counterpart of `DICTSETGET`: on success, also returns the old value associated with the key in question.
+
+  * `F42B` — `DICTREPLACEGETREF` ( _c_ _k_ _D_ _n_ – _D_ ′ _c_ ′ − 1 or _D_ 0).
+
+  * `F42C` — `DICTIREPLACEGET` ( _x_ _i_ _D_ _n_ – _D_ ′ _y_ − 1 or _D_ 0).
+
+  * `F42D` — `DICTIREPLACEGETREF` ( _c_ _i_ _D_ _n_ – _D_ ′ _c_ ′ − 1 or _D_ 0).
+
+  * `F42E` — `DICTUREPLACEGET` ( _x_ _i_ _D_ _n_ – _D_ ′ _y_ − 1 or _D_ 0).
+
+  * `F42F` — `DICTUREPLACEGETREF` ( _c_ _i_ _D_ _n_ – _D_ ′ _c_ ′ − 1 or _D_ 0).
+
+  * `F432` — `DICTADD` ( _x_ _k_ _D_ _n_ – _D_ ′ − 1 or _D_ 0), an Add counterpart of `DICTSET`: sets the value associated with key _k_ in dictionary _D_ to _x_ , but only if it is not already present in _D_.
+
+  * `F433` — `DICTADDREF` ( _c_ _k_ _D_ _n_ – _D_ ′ − 1 or _D_ 0).
+
+  * `F434` — `DICTIADD` ( _x_ _i_ _D_ _n_ – _D_ ′ − 1 or _D_ 0).
+
+  * `F435` — `DICTIADDREF` ( _c_ _i_ _D_ _n_ – _D_ ′ − 1 or _D_ 0).
+
+  * `F436` — `DICTUADD` ( _x_ _i_ _D_ _n_ – _D_ ′ − 1 or _D_ 0).
+
+  * `F437` — `DICTUADDREF` ( _c_ _i_ _D_ _n_ – _D_ ′ − 1 or _D_ 0).
+
+  * `F43A` — `DICTADDGET` ( _x_ _k_ _D_ _n_ – _D_ ′ − 1 or _D_ _y_ 0), an Add counterpart of `DICTSETGET`: sets the value associated with key _k_ in dictionary _D_ to _x_ , but only if key _k_ is not already present in _D_. Otherwise, just returns the old value _y_ without changing the dictionary.
+
+  * `F43B` — `DICTADDGETREF` ( _c_ _k_ _D_ _n_ – _D_ ′ − 1 or _D_ _c_ ′ 0), an Add counterpart of `DICTSETGETREF`.
+
+  * `F43C` — `DICTIADDGET` ( _x_ _i_ _D_ _n_ – _D_ ′ − 1 or _D_ _y_ 0).
+
+  * `F43D` — `DICTIADDGETREF` ( _c_ _i_ _D_ _n_ – _D_ ′ − 1 or _D_ _c_ ′ 0).
+
+  * `F43E` — `DICTUADDGET` ( _x_ _i_ _D_ _n_ – _D_ ′ − 1 or _D_ _y_ 0).
+
+  * `F43F` — `DICTUADDGETREF` ( _c_ _i_ _D_ _n_ – _D_ ′ − 1 or _D_ _c_ ′ 0).
+
+[sp:prim.dict.set.builder] **Builder-accepting variants of Set dictionary
+operations.** The following primitives accept the new value as a _Builder_ _b_
+instead of a _Slice_ _x_ , which often is more convenient if the value needs
+to be serialized from several components computed in the stack. (This is
+reflected by appending a `B` to the mnemonics of the corresponding Set
+primitives that work with _Slice_ s.) The net effect is roughly equivalent to
+converting _b_ into a _Slice_ by `ENDC`; `CTOS` and executing the
+corresponding primitive listed in .
+
+  * `F441` — `DICTSETB` ( _b_ _k_ _D_ _n_ – _D_ ′).
+
+  * `F442` — `DICTISETB` ( _b_ _i_ _D_ _n_ – _D_ ′).
+
+  * `F443` — `DICTUSETB` ( _b_ _i_ _D_ _n_ – _D_ ′).
+
+  * `F445` — `DICTSETGETB` ( _b_ _k_ _D_ _n_ – _D_ ′ _y_ − 1 or _D_ ′ 0).
+
+  * `F446` — `DICTISETGETB` ( _b_ _i_ _D_ _n_ – _D_ ′ _y_ − 1 or _D_ ′ 0).
+
+  * `F447` — `DICTUSETGETB` ( _b_ _i_ _D_ _n_ – _D_ ′ _y_ − 1 or _D_ ′ 0).
+
+  * `F449` — `DICTREPLACEB` ( _b_ _k_ _D_ _n_ – _D_ ′ − 1 or _D_ 0).
+
+  * `F44A` — `DICTIREPLACEB` ( _b_ _i_ _D_ _n_ – _D_ ′ − 1 or _D_ 0).
+
+  * `F44B` — `DICTUREPLACEB` ( _b_ _i_ _D_ _n_ – _D_ ′ − 1 or _D_ 0).
+
+  * `F44D` — `DICTREPLACEGETB` ( _b_ _k_ _D_ _n_ – _D_ ′ _y_ − 1 or _D_ 0).
+
+  * `F44E` — `DICTIREPLACEGETB` ( _b_ _i_ _D_ _n_ – _D_ ′ _y_ − 1 or _D_ 0).
+
+  * `F44F` — `DICTUREPLACEGETB` ( _b_ _i_ _D_ _n_ – _D_ ′ _y_ − 1 or _D_ 0).
+
+  * `F451` — `DICTADDB` ( _b_ _k_ _D_ _n_ – _D_ ′ − 1 or _D_ 0).
+
+  * `F452` — `DICTIADDB` ( _b_ _i_ _D_ _n_ – _D_ ′ − 1 or _D_ 0).
+
+  * `F453` — `DICTUADDB` ( _b_ _i_ _D_ _n_ – _D_ ′ − 1 or _D_ 0).
+
+  * `F455` — `DICTADDGETB` ( _b_ _k_ _D_ _n_ – _D_ ′ − 1 or _D_ _y_ 0).
+
+  * `F456` — `DICTIADDGETB` ( _b_ _i_ _D_ _n_ – _D_ ′ − 1 or _D_ _y_ 0).
+
+  * `F457` — `DICTUADDGETB` ( _b_ _i_ _D_ _n_ – _D_ ′ − 1 or _D_ _y_ 0).
+
+[sp:prim.dict.delete] **Delete dictionary operations.**
+
+  * `F459` — `DICTDEL` ( _k_ _D_ _n_ – _D_ ′ − 1 or _D_ 0), deletes _n_ -bit key, represented by a _Slice_ _k_ , from dictionary _D_. If the key is present, returns the modified dictionary _D_ ′ and the success flag  − 1. Otherwise, returns the original dictionary _D_ and 0.
+
+  * `F45A` — `DICTIDEL` ( _i_ _D_ _n_ – _D_ ′ ?), a version of `DICTDEL` with the key represented by a signed _n_ -bit _Integer_ _i_. If _i_ does not fit into _n_ bits, simply returns _D_ 0 (“key not found, dictionary unmodified”).
+
+  * `F45B` — `DICTUDEL` ( _i_ _D_ _n_ – _D_ ′ ?), similar to `DICTIDEL`, but with _i_ an unsigned _n_ -bit integer.
+
+  * `F462` — `DICTDELGET` ( _k_ _D_ _n_ – _D_ ′ _x_ − 1 or _D_ 0), deletes _n_ -bit key, represented by a _Slice_ _k_ , from dictionary _D_. If the key is present, returns the modified dictionary _D_ ′, the original value _x_ associated with the key _k_ (represented by a _Slice_ ), and the success flag  − 1. Otherwise, returns the original dictionary _D_ and 0.
+
+  * `F463` — `DICTDELGETREF` ( _k_ _D_ _n_ – _D_ ′ _c_ − 1 or _D_ 0), similar to `DICTDELGET`, but with `LDREF`; `ENDS` applied to _x_ on success, so that the value returned _c_ is a _Cell_.
+
+  * `F464` — `DICTIDELGET` ( _i_ _D_ _n_ – _D_ ′ _x_ − 1 or _D_ 0), a variant of primitive `DICTDELGET` with signed _n_ -bit integer _i_ as a key.
+
+  * `F465` — `DICTIDELGETREF` ( _i_ _D_ _n_ – _D_ ′ _c_ − 1 or _D_ 0), a variant of primitive `DICTIDELGET` returning a _Cell_ instead of a _Slice._
+
+  * `F466` — `DICTUDELGET` ( _i_ _D_ _n_ – _D_ ′ _x_ − 1 or _D_ 0), a variant of primitive `DICTDELGET` with unsigned _n_ -bit integer _i_ as a key.
+
+  * `F467` — `DICTUDELGETREF` ( _i_ _D_ _n_ – _D_ ′ _c_ − 1 or _D_ 0), a variant of primitive `DICTUDELGET` returning a _Cell_ instead of a _Slice._
+
+**“Maybe reference” dictionary operations.** The following operations assume
+that a dictionary is used to store values _c_? of type $\textit{Cell\/}^?$ (“
+_Maybe Cell_ ”), which can be used in particular to store dictionaries as
+values in other dictionaries. The representation is as follows: if _c_? is a
+_Cell_ , it is stored as a value with no data bits and exactly one reference
+to this _Cell_. If _c_? is _Null_ , then the corresponding key must be absent
+from the dictionary altogether.
+
+  * `F469` — `DICTGETOPTREF` ( _k_ _D_ _n_ – _c_?), a variant of `DICTGETREF` that returns _Null_ instead of the value _c_? if the key _k_ is absent from dictionary _D_.
+
+  * `F46A` — `DICTIGETOPTREF` ( _i_ _D_ _n_ – _c_?), similar to `DICTGETOPTREF`, but with the key given by signed _n_ -bit _Integer_ _i_. If the key _i_ is out of range, also returns _Null_.
+
+  * `F46B` — `DICTUGETOPTREF` ( _i_ _D_ _n_ – _c_?), similar to `DICTGETOPTREF`, but with the key given by unsigned _n_ -bit _Integer_ _i_.
+
+  * `F46D` — `DICTSETGETOPTREF` ( _c_? _k_ _D_ _n_ – _D_ ′ _c̃_?), a variant of both `DICTGETOPTREF` and `DICTSETGETREF` that sets the value corresponding to key _k_ in dictionary _D_ to _c_? (if _c_? is _Null_ , then the key is deleted instead), and returns the old value _c̃_? (if the key _k_ was absent before, returns _Null_ instead).
+
+  * `F46E` — `DICTISETGETOPTREF` ( _c_? _i_ _D_ _n_ – _D_ ′ _c̃_?), similar to primitive `DICTSETGETOPTREF`, but using signed _n_ -bit _Integer_ _i_ as a key. If _i_ does not fit into _n_ bits, throws a range checking exception.
+
+  * `F46F` — `DICTUSETGETOPTREF` ( _c_? _i_ _D_ _n_ – _D_ ′ _c̃_?), similar to primitive `DICTSETGETOPTREF`, but using unsigned _n_ -bit _Integer_ _i_ as a key.
+
+**Prefix code dictionary operations.** These are some basic operations for
+constructing prefix code dictionaries (cf. ). The primary application for
+prefix code dictionaries is deserializing TL-B serialized data structures, or,
+more generally, parsing prefix codes. Therefore, most prefix code dictionaries
+will be constant and created at compile time, not by the following primitives.
+
+Some Get operations for prefix code dictionaries may be found in . Other
+prefix code dictionary operations include:
+
+  * `F470` — `PFXDICTSET` ( _x_ _k_ _D_ _n_ – _D_ ′ − 1 or _D_ 0).
+
+  * `F471` — `PFXDICTREPLACE` ( _x_ _k_ _D_ _n_ – _D_ ′ − 1 or _D_ 0).
+
+  * `F472` — `PFXDICTADD` ( _x_ _k_ _D_ _n_ – _D_ ′ − 1 or _D_ 0).
+
+  * `F473` — `PFXDICTDEL` ( _k_ _D_ _n_ – _D_ ′ − 1 or _D_ 0).
+
+These primitives are completely similar to their non-prefix code counterparts
+`DICTSET` etc (cf. ), with the obvious difference that even a Set may fail in
+a prefix code dictionary, so a success flag must be returned by `PFXDICTSET`
+as well.
+
+**Variants of GetNext and GetPrev operations.**
+
+  * `F474` — `DICTGETNEXT` ( _k_ _D_ _n_ – _x_ ′ _k_ ′ − 1 or 0), computes the minimal key _k_ ′ in dictionary _D_ that is lexicographically greater than _k_ , and returns _k_ ′ (represented by a _Slice_ ) along with associated value _x_ ′ (also represented by a _Slice_ ).
+
+  * `F475` — `DICTGETNEXTEQ` ( _k_ _D_ _n_ – _x_ ′ _k_ ′ − 1 or 0), similar to `DICTGETNEXT`, but computes the minimal key _k_ ′ that is lexicographically greater than or equal to _k_.
+
+  * `F476` — `DICTGETPREV` ( _k_ _D_ _n_ – _x_ ′ _k_ ′ − 1 or 0), similar to `DICTGETNEXT`, but computes the maximal key _k_ ′ lexicographically smaller than _k_.
+
+  * `F477` — `DICTGETPREVEQ` ( _k_ _D_ _n_ – _x_ ′ _k_ ′ − 1 or 0), similar to `DICTGETPREV`, but computes the maximal key _k_ ′ lexicographically smaller than or equal to _k_.
+
+  * `F478` — `DICTIGETNEXT` ( _i_ _D_ _n_ – _x_ ′ _i_ ′ − 1 or 0), similar to `DICTGETNEXT`, but interprets all keys in dictionary _D_ as big-endian signed _n_ -bit integers, and computes the minimal key _i_ ′ that is larger than _Integer_ _i_ (which does not necessarily fit into _n_ bits).
+
+  * `F479` — `DICTIGETNEXTEQ` ( _i_ _D_ _n_ – _x_ ′ _i_ ′ − 1 or 0).
+
+  * `F47A` — `DICTIGETPREV` ( _i_ _D_ _n_ – _x_ ′ _i_ ′ − 1 or 0).
+
+  * `F47B` — `DICTIGETPREVEQ` ( _i_ _D_ _n_ – _x_ ′ _i_ ′ − 1 or 0).
+
+  * `F47C` — `DICTUGETNEXT` ( _i_ _D_ _n_ – _x_ ′ _i_ ′ − 1 or 0), similar to `DICTGETNEXT`, but interprets all keys in dictionary _D_ as big-endian unsigned _n_ -bit integers, and computes the minimal key _i_ ′ that is larger than _Integer_ _i_ (which does not necessarily fit into _n_ bits, and is not necessarily non-negative).
+
+  * `F47D` — `DICTUGETNEXTEQ` ( _i_ _D_ _n_ – _x_ ′ _i_ ′ − 1 or 0).
+
+  * `F47E` — `DICTUGETPREV` ( _i_ _D_ _n_ – _x_ ′ _i_ ′ − 1 or 0).
+
+  * `F47F` — `DICTUGETPREVEQ` ( _i_ _D_ _n_ – _x_ ′ _i_ ′ − 1 or 0).
+
+**GetMin , GetMax, RemoveMin, RemoveMax operations.**
+
+  * `F482` — `DICTMIN` ( _D_ _n_ – _x_ _k_ − 1 or 0), computes the minimal key _k_ (represented by a _Slice_ with _n_ data bits) in dictionary _D_ , and returns _k_ along with the associated value _x_.
+
+  * `F483` — `DICTMINREF` ( _D_ _n_ – _c_ _k_ − 1 or 0), similar to `DICTMIN`, but returns the only reference in the value as a _Cell_ _c_.
+
+  * `F484` — `DICTIMIN` ( _D_ _n_ – _x_ _i_ − 1 or 0), somewhat similar to `DICTMIN`, but computes the minimal key _i_ under the assumption that all keys are big-endian signed _n_ -bit integers. Notice that the key and value returned may differ from those computed by `DICTMIN` and `DICTUMIN`.
+
+  * `F485` — `DICTIMINREF` ( _D_ _n_ – _c_ _i_ − 1 or 0).
+
+  * `F486` — `DICTUMIN` ( _D_ _n_ – _x_ _i_ − 1 or 0), similar to `DICTMIN`, but returns the key as an unsigned _n_ -bit _Integer_ _i_.
+
+  * `F487` — `DICTUMINREF` ( _D_ _n_ – _c_ _i_ − 1 or 0).
+
+  * `F48A` — `DICTMAX` ( _D_ _n_ – _x_ _k_ − 1 or 0), computes the maximal key _k_ (represented by a _Slice_ with _n_ data bits) in dictionary _D_ , and returns _k_ along with the associated value _x_.
+
+  * `F48B` — `DICTMAXREF` ( _D_ _n_ – _c_ _k_ − 1 or 0).
+
+  * `F48C` — `DICTIMAX` ( _D_ _n_ – _x_ _i_ − 1 or 0).
+
+  * `F48D` — `DICTIMAXREF` ( _D_ _n_ – _c_ _i_ − 1 or 0).
+
+  * `F48E` — `DICTUMAX` ( _D_ _n_ – _x_ _i_ − 1 or 0).
+
+  * `F48F` — `DICTUMAXREF` ( _D_ _n_ – _c_ _i_ − 1 or 0).
+
+  * `F492` — `DICTREMMIN` ( _D_ _n_ – _D_ ′ _x_ _k_ − 1 or _D_ 0), computes the minimal key _k_ (represented by a _Slice_ with _n_ data bits) in dictionary _D_ , removes _k_ from the dictionary, and returns _k_ along with the associated value _x_ and the modified dictionary _D_ ′.
+
+  * `F493` — `DICTREMMINREF` ( _D_ _n_ – _D_ ′ _c_ _k_ − 1 or _D_ 0), similar to `DICTREMMIN`, but returns the only reference in the value as a _Cell_ _c_.
+
+  * `F494` — `DICTIREMMIN` ( _D_ _n_ – _D_ ′ _x_ _i_ − 1 or _D_ 0), somewhat similar to `DICTREMMIN`, but computes the minimal key _i_ under the assumption that all keys are big-endian signed _n_ -bit integers. Notice that the key and value returned may differ from those computed by `DICTREMMIN` and `DICTUREMMIN`.
+
+  * `F495` — `DICTIREMMINREF` ( _D_ _n_ – _D_ ′ _c_ _i_ − 1 or _D_ 0).
+
+  * `F496` — `DICTUREMMIN` ( _D_ _n_ – _D_ ′ _x_ _i_ − 1 or _D_ 0), similar to `DICTREMMIN`, but returns the key as an unsigned _n_ -bit _Integer_ _i_.
+
+  * `F497` — `DICTUREMMINREF` ( _D_ _n_ – _D_ ′ _c_ _i_ − 1 or _D_ 0).
+
+  * `F49A` — `DICTREMMAX` ( _D_ _n_ – _D_ ′ _x_ _k_ − 1 or _D_ 0), computes the maximal key _k_ (represented by a _Slice_ with _n_ data bits) in dictionary _D_ , removes _k_ from the dictionary, and returns _k_ along with the associated value _x_ and the modified dictionary _D_ ′.
+
+  * `F49B` — `DICTREMMAXREF` ( _D_ _n_ – _D_ ′ _c_ _k_ − 1 or _D_ 0).
+
+  * `F49C` — `DICTIREMMAX` ( _D_ _n_ – _D_ ′ _x_ _i_ − 1 or _D_ 0).
+
+  * `F49D` — `DICTIREMMAXREF` ( _D_ _n_ – _D_ ′ _c_ _i_ − 1 or _D_ 0).
+
+  * `F49E` — `DICTUREMMAX` ( _D_ _n_ – _D_ ′ _x_ _i_ − 1 or _D_ 0).
+
+  * `F49F` — `DICTUREMMAXREF` ( _D_ _n_ – _D_ ′ _c_ _i_ − 1 or _D_ 0).
+
+[sp:prim.dict.get.spec] **Special Get dictionary and prefix code dictionary
+operations, and constant dictionaries.**
+
+  * `F4A0` — `DICTIGETJMP` ( _i_ _D_ _n_ – ), similar to `DICTIGET` (cf. ), but with _x_ `BLESS`ed into a continuation with a subsequent `JMPX` to it on success. On failure, does nothing. This is useful for implementing `switch`/`case` constructions.
+
+  * `F4A1` — `DICTUGETJMP` ( _i_ _D_ _n_ – ), similar to `DICTIGETJMP`, but performs `DICTUGET` instead of `DICTIGET`.
+
+  * `F4A2` — `DICTIGETEXEC` ( _i_ _D_ _n_ – ), similar to `DICTIGETJMP`, but with `EXECUTE` instead of `JMPX`.
+
+  * `F4A3` — `DICTUGETEXEC` ( _i_ _D_ _n_ – ), similar to `DICTUGETJMP`, but with `EXECUTE` instead of `JMPX`.
+
+  * `F4A6_n` — `DICTPUSHCONST n` ( – _D_ _n_ ), pushes a non-empty constant dictionary _D_ (as a $\textit{Cell\/}^?$) along with its key length 0 ≤ _n_ ≤ 1023, stored as a part of the instruction. The dictionary itself is created from the first of remaining references of the current continuation. In this way, the complete `DICTPUSHCONST` instruction can be obtained by first serializing `xF4A8_`, then the non-empty dictionary itself (one `1` bit and a cell reference), and then the unsigned 10-bit integer _n_ (as if by a `STU 10` instruction). An empty dictionary can be pushed by a `NEWDICT` primitive (cf. ) instead.
+
+  * `F4A8` — `PFXDICTGETQ` ( _s_ _D_ _n_ – _s_ ′ _x_ _s_ ″ − 1 or _s_ 0), looks up the unique prefix of _Slice_ _s_ present in the prefix code dictionary (cf. ) represented by $\textit{Cell\/}^?$ _D_ and 0 ≤ _n_ ≤ 1023. If found, the prefix of _s_ is returned as _s_ ′, and the corresponding value (also a _Slice_ ) as _x_. The remainder of _s_ is returned as a _Slice_ _s_ ″. If no prefix of _s_ is a key in prefix code dictionary _D_ , returns the unchanged _s_ and a zero flag to indicate failure.
+
+  * `F4A9` — `PFXDICTGET` ( _s_ _D_ _n_ – _s_ ′ _x_ _s_ ″), similar to `PFXDICTGET`, but throws a cell deserialization failure exception on failure.
+
+  * `F4AA` — `PFXDICTGETJMP` ( _s_ _D_ _n_ – _s_ ′ _s_ ″ or _s_ ), similar to `PFXDICTGETQ`, but on success `BLESS`es the value _x_ into a _Continuation_ and transfers control to it as if by a `JMPX`. On failure, returns _s_ unchanged and continues execution.
+
+  * `F4AB` — `PFXDICTGETEXEC` ( _s_ _D_ _n_ – _s_ ′ _s_ ″), similar to `PFXDICTGETJMP`, but `EXEC`utes the continuation found instead of jumping to it. On failure, throws a cell deserialization exception.
+
+  * `F4AE_n` — `PFXDICTCONSTGETJMP n` or `PFXDICTSWITCH n` ( _s_ – _s_ ′ _s_ ″ or _s_ ), combines `DICTPUSHCONST n` for 0 ≤ _n_ ≤ 1023 with `PFXDICTGETJMP`.
+
+  * `F4BC` — `DICTIGETJMPZ` ( _i_ _D_ _n_ – _i_ or nothing), a variant of `DICTIGETJMP` that returns index _i_ on failure.
+
+  * `F4BD` — `DICTUGETJMPZ` ( _i_ _D_ _n_ – _i_ or nothing), a variant of `DICTUGETJMP` that returns index _i_ on failure.
+
+  * `F4BE` — `DICTIGETEXECZ` ( _i_ _D_ _n_ – _i_ or nothing), a variant of `DICTIGETEXEC` that returns index _i_ on failure.
+
+  * `F4BF` — `DICTUGETEXECZ` ( _i_ _D_ _n_ – _i_ or nothing), a variant of `DICTUGETEXEC` that returns index _i_ on failure.
+
+[sp:prim.dict.get] **SubDict dictionary operations.**
+
+  * `F4B1` — `SUBDICTGET` ( _k_ _l_ _D_ _n_ – _D_ ′), constructs a subdictionary consisting of all keys beginning with prefix _k_ (represented by a _Slice_ , the first 0 ≤ _l_ ≤ _n_ ≤ 1023 data bits of which are used as a key) of length _l_ in dictionary _D_ of type _HashmapE_ ( _n_ , _X_ ) with _n_ -bit keys. On success, returns the new subdictionary of the same type _HashmapE_ ( _n_ , _X_ ) as a _Slice_ _D_ ′.
+
+  * `F4B2` — `SUBDICTIGET` ( _x_ _l_ _D_ _n_ – _D_ ′), variant of `SUBDICTGET` with the prefix represented by a signed big-endian _l_ -bit _Integer_ _x_ , where necessarily _l_ ≤ 257.
+
+  * `F4B3` — `SUBDICTUGET` ( _x_ _l_ _D_ _n_ – _D_ ′), variant of `SUBDICTGET` with the prefix represented by an unsigned big-endian _l_ -bit _Integer_ _x_ , where necessarily _l_ ≤ 256.
+
+  * `F4B5` — `SUBDICTRPGET` ( _k_ _l_ _D_ _n_ – _D_ ′), similar to `SUBDICTGET`, but removes the common prefix _k_ from all keys of the new dictionary _D_ ′, which becomes of type _HashmapE_ ( _n_ − _l_ , _X_ ).
+
+  * `F4B6` — `SUBDICTIRPGET` ( _x_ _l_ _D_ _n_ – _D_ ′), variant of `SUBDICTRPGET` with the prefix represented by a signed big-endian _l_ -bit _Integer_ _x_ , where necessarily _l_ ≤ 257.
+
+  * `F4B7` — `SUBDICTURPGET` ( _x_ _l_ _D_ _n_ – _D_ ′), variant of `SUBDICTRPGET` with the prefix represented by an unsigned big-endian _l_ -bit _Integer_ _x_ , where necessarily _l_ ≤ 256.
+
+  * `F4BC`–`F4BF` — used by `DICT…Z` primitives in .
+
+## Application-specific primitives
+
+[p:prim.app] Opcode range `F8`…`FB` is reserved for the _application-specific
+primitives_. When TVM is used to execute TON Blockchain smart contracts, these
+application-specific primitives are in fact TON Blockchain-specific.
+
+**External actions and access to blockchain configuration data.** Some of the
+primitives listed below pretend to produce some externally visible actions,
+such as sending a message to another smart contract. In fact, the execution of
+a smart contract in TVM never has any effect apart from a modification of the
+TVM state. All external actions are collected into a linked list stored in
+special register `c5` (“output actions”). Additionally, some primitives use
+the data kept in the first component of the _Tuple_ stored in `c7` (“root of
+temporary data”, cf. ). Smart contracts are free to modify any other data kept
+in the cell `c7`, provided the first reference remains intact (otherwise some
+application-specific primitives would be likely to throw exceptions when
+invoked).
+
+Most of the primitives listed below use 16-bit opcodes.
+
+**Gas-related primitives.** Of the following primitives, only the first two
+are “pure” in the sense that they do not use `c5` or `c7`.
+
+  * `F800` — `ACCEPT`, sets current gas limit _g_ _l_ to its maximal allowed value _g_ _m_ , and resets the gas credit _g_ _c_ to zero (cf. ), decreasing the value of _g_ _r_ by _g_ _c_ in the process. In other words, the current smart contract agrees to buy some gas to finish the current transaction. This action is required to process external messages, which bring no value (hence no gas) with themselves.
+
+  * `F801` — `SETGASLIMIT` ( _g_ – ), sets current gas limit _g_ _l_ to the minimum of _g_ and _g_ _m_ , and resets the gas credit _g_ _c_ to zero. If the gas consumed so far (including the present instruction) exceeds the resulting value of _g_ _l_ , an (unhandled) out of gas exception is thrown before setting new gas limits. Notice that `SETGASLIMIT` with an argument _g_ ≥ 263 − 1 is equivalent to `ACCEPT`.
+
+  * `F802` — `BUYGAS` ( _x_ – ), computes the amount of gas that can be bought for _x_ nanograms, and sets _g_ _l_ accordingly in the same way as `SETGASLIMIT`.
+
+  * `F804` — `GRAMTOGAS` ( _x_ – _g_ ), computes the amount of gas that can be bought for _x_ nanograms. If _x_ is negative, returns 0. If _g_ exceeds 263 − 1, it is replaced with this value.
+
+  * `F805` — `GASTOGRAM` ( _g_ – _x_ ), computes the price of _g_ gas in nanograms.
+
+  * `F806`–`F80E` — Reserved for gas-related primitives.
+
+  * `F80F` — `COMMIT` ( – ), commits the current state of registers `c4` (“persistent data”) and `c5` (“actions”) so that the current execution is considered “successful” with the saved values even if an exception is thrown later.
+
+**Pseudo-random number generator primitives.** The pseudo-random number
+generator uses the random seed (parameter #6, cf. ), an unsigned 256-bit
+_Integer_ , and (sometimes) other data kept in `c7`. The initial value of the
+random seed before a smart contract is executed in TON Blockchain is a hash of
+the smart contract address and the global block random seed. If there are
+several runs of the same smart contract inside a block, then all of these runs
+will have the same random seed. This can be fixed, for example, by running
+`LTIME; ADDRAND` before using the pseudo-random number generator for the first
+time.
+
+  * `F810` — `RANDU256` ( – _x_ ), generates a new pseudo-random unsigned 256-bit _Integer_ _x_. The algorithm is as follows: if _r_ is the old value of the random seed, considered as a 32-byte array (by constructing the big-endian representation of an unsigned 256-bit integer), then its $\operatorname{\mathrm{sha512}}(r)$ is computed; the first 32 bytes of this hash are stored as the new value _r_ ′ of the random seed, and the remaining 32 bytes are returned as the next random value _x_.
+
+  * `F811` — `RAND` ( _y_ – _z_ ), generates a new pseudo-random integer _z_ in the range 0… _y_ − 1 (or _y_ … − 1, if _y_ < 0). More precisely, an unsigned random value _x_ is generated as in `RAND256U`; then _z_ := ⌊ _x_ _y_ /2256⌋ is computed. Equivalent to `RANDU256; MULRSHIFT 256`.
+
+  * `F814` — `SETRAND` ( _x_ – ), sets the random seed to unsigned 256-bit _Integer_ _x_.
+
+  * `F815` — `ADDRAND` ( _x_ – ), mixes unsigned 256-bit _Integer_ _x_ into the random seed _r_ by setting the random seed to $\operatorname{\mathrm{sha256}}$ of the concatenation of two 32-byte strings: the first with the big-endian representation of the old seed _r_ , and the second with the big-endian representation of _x_.
+
+  * `F810`–`F81F` — Reserved for pseudo-random number generator primitives.
+
+**Configuration primitives.** [sp:prim.conf.param] The following primitives
+read configuration data provided in the _Tuple_ stored in the first component
+of the _Tuple_ at `c7`. Whenever TVM is invoked for executing TON Blockchain
+smart contracts, this _Tuple_ is initialized by a _SmartContractInfo_
+structure; configuration primitives assume that it has remained intact.
+
+  * `F82i` — `GETPARAM i` ( – _x_ ), returns the _i_ -th parameter from the _Tuple_ provided at `c7` for 0 ≤ _i_ < 16. Equivalent to `PUSH c7`; `FIRST`; `INDEX i`. If one of these internal operations fails, throws an appropriate type checking or range checking exception.
+
+  * `F823` — `NOW` ( – _x_ ), returns the current Unix time as an _Integer_. If it is impossible to recover the requested value starting from `c7`, throws a type checking or range checking exception as appropriate. Equivalent to `GETPARAM 3`.
+
+  * `F824` — `BLOCKLT` ( – _x_ ), returns the starting logical time of the current block. Equivalent to `GETPARAM 4`.
+
+  * `F825` — `LTIME` ( – _x_ ), returns the logical time of the current transaction. Equivalent to `GETPARAM 5`.
+
+  * `F826` — `RANDSEED` ( – _x_ ), returns the current random seed as an unsigned 256-bit _Integer_. Equivalent to `GETPARAM 6`.
+
+  * `F827` — `BALANCE` ( – _t_ ), returns the remaining balance of the smart contract as a _Tuple_ consisting of an _Integer_ (the remaining Gram balance in nanograms) and a _Maybe Cell_ (a dictionary with 32-bit keys representing the balance of “extra currencies”). Equivalent to `GETPARAM 7`. Note that `RAW` primitives such as `SENDRAWMSG` do not update this field.
+
+  * `F828` — `MYADDR` ( – _s_ ), returns the internal address of the current smart contract as a _Slice_ with a `MsgAddressInt`. If necessary, it can be parsed further using primitives such as `PARSESTDADDR` or `REWRITESTDADDR`. Equivalent to `GETPARAM 8`.
+
+  * `F829` — `CONFIGROOT` ( – _D_ ), returns the _Maybe Cell_ _D_ with the current global configuration dictionary. Equivalent to `GETPARAM 9`.
+
+  * `F830` — `CONFIGDICT` ( – _D_ 32), returns the global configuration dictionary along with its key length (32). Equivalent to `CONFIGROOT`; `PUSHINT 32`.
+
+  * `F832` — `CONFIGPARAM` ( _i_ – _c_ − 1 or 0), returns the value of the global configuration parameter with integer index _i_ as a _Cell_ _c_ , and a flag to indicate success. Equivalent to `CONFIGDICT`; `DICTIGETREF`.
+
+  * `F833` — `CONFIGOPTPARAM` ( _i_ – _c_?), returns the value of the global configuration parameter with integer index _i_ as a _Maybe Cell_ _c_?. Equivalent to `CONFIGDICT`; `DICTIGETOPTREF`.
+
+  * `F820`—`F83F` — Reserved for configuration primitives.
+
+**Global variable primitives.** The “global variables” may be helpful in
+implementing some high-level smart-contract languages. They are in fact stored
+as components of the _Tuple_ at `c7`: the _k_ -th global variable simply is
+the _k_ -th component of this _Tuple_ , for 1 ≤ _k_ ≤ 254. By convention, the
+0-th component is used for the “configuration parameters” of , so it is not
+available as a global variable.
+
+  * `F840` — `GETGLOBVAR` ( _k_ – _x_ ), returns the _k_ -th global variable for 0 ≤ _k_ < 255. Equivalent to `PUSH c7`; `SWAP`; `INDEXVARQ` (cf. ).
+
+  * `F85_k` — `GETGLOB k` ( – _x_ ), returns the _k_ -th global variable for 1 ≤ _k_ ≤ 31. Equivalent to `PUSH c7`; `INDEXQ k`.
+
+  * `F860` — `SETGLOBVAR` ( _x_ _k_ – ), assigns _x_ to the _k_ -th global variable for 0 ≤ _k_ < 255. Equivalent to `PUSH c7`; `ROTREV`; `SETINDEXVARQ`; `POP c7`.
+
+  * `F87_k` — `SETGLOB k` ( _x_ – ), assigns _x_ to the _k_ -th global variable for 1 ≤ _k_ ≤ 31. Equivalent to `PUSH c7`; `SWAP`; `SETINDEXQ k`; `POP c7`.
+
+**Hashing and cryptography primitives.**
+
+  * `F900` — `HASHCU` ( _c_ – _x_ ), computes the representation hash (cf. ) of a _Cell_ _c_ and returns it as a 256-bit unsigned integer _x_. Useful for signing and checking signatures of arbitrary entities represented by a tree of cells.
+
+  * `F901` — `HASHSU` ( _s_ – _x_ ), computes the hash of a _Slice_ _s_ and returns it as a 256-bit unsigned integer _x_. The result is the same as if an ordinary cell containing only data and references from _s_ had been created and its hash computed by `HASHCU`.
+
+  * `F902` — `SHA256U` ( _s_ – _x_ ), computes $\operatorname{\mathrm{sha256}}$ of the data bits of _Slice_ _s_. If the bit length of _s_ is not divisible by eight, throws a cell underflow exception. The hash value is returned as a 256-bit unsigned integer _x_.
+
+  * `F910` — `CHKSIGNU` ( _h_ _s_ _k_ – ?), checks the Ed25519-signature _s_ of a hash _h_ (a 256-bit unsigned integer, usually computed as the hash of some data) using public key _k_ (also represented by a 256-bit unsigned integer). The signature _s_ must be a _Slice_ containing at least 512 data bits; only the first 512 bits are used. The result is  − 1 if the signature is valid, 0 otherwise. Notice that `CHKSIGNU` is equivalent to `ROT`; `NEWB`; `STU 256`; `ENDB`; `NEWC`; `ROTREV`; `CHKSIGNS`, i.e., to `CHKSIGNS` with the first argument _d_ set to 256-bit _Slice_ containing _h_. Therefore, if _h_ is computed as the hash of some data, these data are hashed _twice_ , the second hashing occurring inside `CHKSIGNS`.
+
+  * `F911` — `CHKSIGNS` ( _d_ _s_ _k_ – ?), checks whether _s_ is a valid Ed25519-signature of the data portion of _Slice_ _d_ using public key _k_ , similarly to `CHKSIGNU`. If the bit length of _Slice_ _d_ is not divisible by eight, throws a cell underflow exception. The verification of Ed25519 signatures is the standard one, with $\operatorname{\mathrm{sha256}}$ used to reduce _d_ to the 256-bit number that is actually signed.
+
+  * `F912`–`F93F` — Reserved for hashing and cryptography primitives.
+
+**Miscellaneous primitives.**
+
+  * `F940` — `CDATASIZEQ` ( _c_ _n_ – _x_ _y_ _z_ − 1 or 0), recursively computes the count of distinct cells _x_ , data bits _y_ , and cell references _z_ in the dag rooted at _Cell_ _c_ , effectively returning the total storage used by this dag taking into account the identification of equal cells. The values of _x_ , _y_ , and _z_ are computed by a depth-first traversal of this dag, with a hash table of visited cell hashes used to prevent visits of already-visited cells. The total count of visited cells _x_ cannot exceed non-negative _Integer_ _n_ ; otherwise the computation is aborted before visiting the ( _n_ \+ 1)-st cell and a zero is returned to indicate failure. If _c_ is _Null_ , returns _x_ = _y_ = _z_ = 0.
+
+  * `F941` — `CDATASIZE` ( _c_ _n_ – _x_ _y_ _z_ ), a non-quiet version of `CDATASIZEQ` that throws a cell overflow exception (8) on failure.
+
+  * `F942` — `SDATASIZEQ` ( _s_ _n_ – _x_ _y_ _z_ − 1 or 0), similar to `CDATASIZEQ`, but accepting a _Slice_ _s_ instead of a _Cell_. The returned value of _x_ does not take into account the cell that contains the slice _s_ itself; however, the data bits and the cell references of _s_ are accounted for in _y_ and _z_.
+
+  * `F943` — `SDATASIZE` ( _s_ _n_ – _x_ _y_ _z_ ), a non-quiet version of `SDATASIZEQ` that throws a cell overflow exception (8) on failure.
+
+  * `F944`–`F97F` — Reserved for miscellaneous TON-specific primitives that do not fall into any other specific category.
+
+**Currency manipulation primitives.**
+
+  * `FA00` — `LDGRAMS` or `LDVARUINT16` ( _s_ – _x_ _s_ ′), loads (deserializes) a `Gram` or `VarUInteger 16` amount from _CellSlice_ _s_ , and returns the amount as _Integer_ _x_ along with the remainder _s_ ′ of _s_. The expected serialization of _x_ consists of a 4-bit unsigned big-endian integer _l_ , followed by an 8 _l_ -bit unsigned big-endian representation of _x_. The net effect is approximately equivalent to `LDU 4`; `SWAP`; `LSHIFT 3`; `LDUX`.
+
+  * `FA01` — `LDVARINT16` ( _s_ – _x_ _s_ ′), similar to `LDVARUINT16`, but loads a _signed_ _Integer_ _x_. Approximately equivalent to `LDU 4`; `SWAP`; `LSHIFT 3`; `LDIX`.
+
+  * `FA02` — `STGRAMS` or `STVARUINT16` ( _b_ _x_ – _b_ ′), stores (serializes) an _Integer_ _x_ in the range 0…2120 − 1 into _Builder_ _b_ , and returns the resulting _Builder_ _b_ ′. The serialization of _x_ consists of a 4-bit unsigned big-endian integer _l_ , which is the smallest integer _l_ ≥ 0, such that _x_ < 28 _l_ , followed by an 8 _l_ -bit unsigned big-endian representation of _x_. If _x_ does not belong to the supported range, a range check exception is thrown.
+
+  * `FA03` — `STVARINT16` ( _b_ _x_ – _b_ ′), similar to `STVARUINT16`, but serializes a _signed_ _Integer_ _x_ in the range  − 2119…2119 − 1.
+
+  * `FA04` — `LDVARUINT32` ( _s_ – _x_ _s_ ′), loads (deserializes) a `VarUInteger 32` from _CellSlice_ _s_ , and returns the deserialized value as an _Integer_ 0 ≤ _x_ < 2248. The expected serialization of _x_ consists of a 5-bit unsigned big-endian integer _l_ , followed by an 8 _l_ -bit unsigned big-endian representation of _x_. The net effect is approximately equivalent to `LDU 5`; `SWAP`; `SHIFT 3`; `LDUX`.
+
+  * `FA05` — `LDVARINT32` ( _s_ – _x_ _s_ ′), deserializes a `VarInteger 32` from _CellSlice_ _s_ , and returns the deserialized value as an _Integer_ − 2247 ≤ _x_ < 2247.
+
+  * `FA06` — `STVARUINT32` ( _b_ _x_ – _b_ ′), serializes an _Integer_ 0 ≤ _x_ < 2248 as a `VarUInteger 32`.
+
+  * `FA07` — `STVARINT32` ( _b_ _x_ – _b_ ′), serializes an _Integer_ − 2247 ≤ _x_ < 2247 as a `VarInteger 32`.
+
+  * `FA08`–`FA1F` — Reserved for currency manipulation primitives.
+
+**Message and address manipulation primitives.** The message and address
+manipulation primitives listed below serialize and deserialize values
+according to the following TL-B scheme (cf. ):
+
+    
+    
+    addr_none$00 = MsgAddressExt;
+    addr_extern$01 len:(## 9) external_address:(bits len) 
+                 = MsgAddressExt;
+    anycast_info$_ depth:(#<= 30) { depth >= 1 }
+       rewrite_pfx:(bits depth) = Anycast;
+    addr_std$10 anycast:(Maybe Anycast) 
+       workchain_id:int8 address:bits256  = MsgAddressInt;
+    addr_var$11 anycast:(Maybe Anycast) addr_len:(## 9) 
+       workchain_id:int32 address:(bits addr_len) = MsgAddressInt;
+    _ _:MsgAddressInt = MsgAddress;
+    _ _:MsgAddressExt = MsgAddress;
+    
+    int_msg_info$0 ihr_disabled:Bool bounce:Bool bounced:Bool
+      src:MsgAddress dest:MsgAddressInt 
+      value:CurrencyCollection ihr_fee:Grams fwd_fee:Grams
+      created_lt:uint64 created_at:uint32 = CommonMsgInfoRelaxed;
+    ext_out_msg_info$11 src:MsgAddress dest:MsgAddressExt
+      created_lt:uint64 created_at:uint32 = CommonMsgInfoRelaxed;
+
+A deserialized `MsgAddress` is represented by a _Tuple_ _t_ as follows:
+
+  * `addr_none` is represented by _t_ = (0), i.e., a _Tuple_ containing exactly one _Integer_ equal to zero.
+
+  * `addr_extern` is represented by _t_ = (1, _s_ ), where _Slice_ _s_ contains the field `external_address`. In other words, _t_ is a pair (a _Tuple_ consisting of two entries), containing an _Integer_ equal to one and _Slice_ _s_.
+
+  * `addr_std` is represented by _t_ = (2, _u_ , _x_ , _s_ ), where _u_ is either a _Null_ (if `anycast` is absent) or a _Slice_ _s_ ′ containing `rewrite_pfx` (if `anycast` is present). Next, _Integer_ _x_ is the `workchain_id`, and _Slice_ _s_ contains the `address`.
+
+  * `addr_var` is represented by _t_ = (3, _u_ , _x_ , _s_ ), where _u_ , _x_ , and _s_ have the same meaning as for `addr_std`.
+
+The following primitives, which use the above conventions, are defined:
+
+  * `FA40` — `LDMSGADDR` ( _s_ – _s_ ′ _s_ ″), loads from _CellSlice_ _s_ the only prefix that is a valid `MsgAddress`, and returns both this prefix _s_ ′ and the remainder _s_ ″ of _s_ as _CellSlice_ s.
+
+  * `FA41` — `LDMSGADDRQ` ( _s_ – _s_ ′ _s_ ″ − 1 or _s_ 0), a quiet version of `LDMSGADDR`: on success, pushes an extra  − 1; on failure, pushes the original _s_ and a zero.
+
+  * `FA42` — `PARSEMSGADDR` ( _s_ – _t_ ), decomposes _CellSlice_ _s_ containing a valid `MsgAddress` into a _Tuple_ _t_ with separate fields of this `MsgAddress`. If _s_ is not a valid `MsgAddress`, a cell deserialization exception is thrown.
+
+  * `FA43` — `PARSEMSGADDRQ` ( _s_ – _t_ − 1 or 0), a quiet version of `PARSEMSGADDR`: returns a zero on error instead of throwing an exception.
+
+  * `FA44` — `REWRITESTDADDR` ( _s_ – _x_ _y_ ), parses _CellSlice_ _s_ containing a valid `MsgAddressInt` (usually a `msg_addr_std`), applies rewriting from the `anycast` (if present) to the same-length prefix of the address, and returns both the workchain _x_ and the 256-bit address _y_ as _Integer_ s. If the address is not 256-bit, or if _s_ is not a valid serialization of `MsgAddressInt`, throws a cell deserialization exception.
+
+  * `FA45` — `REWRITESTDADDRQ` ( _s_ – _x_ _y_ − 1 or 0), a quiet version of primitive `REWRITESTDADDR`.
+
+  * `FA46` — `REWRITEVARADDR` ( _s_ – _x_ _s_ ′), a variant of `REWRITESTDADDR` that returns the (rewritten) address as a _Slice_ s, even if it is not exactly 256 bit long (represented by a `msg_addr_var`).
+
+  * `FA47` — `REWRITEVARADDRQ` ( _s_ – _x_ _s_ ′ − 1 or 0), a quiet version of primitive `REWRITEVARADDR`.
+
+  * `FA48`–`FA5F` — Reserved for message and address manipulation primitives.
+
+**Outbound message and output action primitives.**
+
+  * `FB00` — `SENDRAWMSG` ( _c_ _x_ – ), sends a raw message contained in _Cell _c__ , which should contain a correctly serialized object `Message X`, with the only exception that the source address is allowed to have dummy value `addr_none` (to be automatically replaced with the current smart-contract address), and `ihr_fee`, `fwd_fee`, `created_lt` and `created_at` fields can have arbitrary values (to be rewritten with correct values during the action phase of the current transaction). Integer parameter _x_ contains the flags. Currently _x_ = 0 is used for ordinary messages; _x_ = 128 is used for messages that are to carry all the remaining balance of the current smart contract (instead of the value originally indicated in the message); _x_ = 64 is used for messages that carry all the remaining value of the inbound message in addition to the value initially indicated in the new message (if bit 0 is not set, the gas fees are deducted from this amount); _x_ ′ = _x_ \+ 1 means that the sender wants to pay transfer fees separately; _x_ ′ = _x_ \+ 2 means that any errors arising while processing this message during the action phase should be ignored. Finally, _x_ ′ = _x_ \+ 32 means that the current account must be destroyed if its resulting balance is zero. This flag is usually employed together with  \+ 128.
+
+  * `FB02` — `RAWRESERVE` ( _x_ _y_ – ), creates an output action which would reserve exactly _x_ nanograms (if _y_ = 0), at most _x_ nanograms (if _y_ = 2), or all but _x_ nanograms (if _y_ = 1 or _y_ = 3), from the remaining balance of the account. It is roughly equivalent to creating an outbound message carrying _x_ nanograms (or _b_ − _x_ nanograms, where _b_ is the remaining balance) to oneself, so that the subsequent output actions would not be able to spend more money than the remainder. Bit  \+ 2 in _y_ means that the external action does not fail if the specified amount cannot be reserved; instead, all remaining balance is reserved. Bit  \+ 8 in _y_ means _x_ ← − _x_ before performing any further actions. Bit  \+ 4 in _y_ means that _x_ is increased by the original balance of the current account (before the compute phase), including all extra currencies, before performing any other checks and actions. Currently _x_ must be a non-negative integer, and _y_ must be in the range 0…15.
+
+  * `FB03` — `RAWRESERVEX` ( _x_ _D_ _y_ – ), similar to `RAWRESERVE`, but also accepts a dictionary _D_ (represented by a _Cell_ or _Null_ ) with extra currencies. In this way currencies other than Grams can be reserved.
+
+  * `FB04` — `SETCODE` ( _c_ – ), creates an output action that would change this smart contract code to that given by _Cell_ _c_. Notice that this change will take effect only after the successful termination of the current run of the smart contract.
+
+  * `FB06` — `SETLIBCODE` ( _c_ _x_ – ), creates an output action that would modify the collection of this smart contract libraries by adding or removing library with code given in _Cell_ _c_. If _x_ = 0, the library is actually removed if it was previously present in the collection (if not, this action does nothing). If _x_ = 1, the library is added as a private library, and if _x_ = 2, the library is added as a public library (and becomes available to all smart contracts if the current smart contract resides in the masterchain); if the library was present in the collection before, its public/private status is changed according to _x_. Values of _x_ other than 0…2 are invalid.
+
+  * `FB07` — `CHANGELIB` ( _h_ _x_ – ), creates an output action similarly to `SETLIBCODE`, but instead of the library code accepts its hash as an unsigned 256-bit integer _h_. If _x_ ≠ 0 and the library with hash _h_ is absent from the library collection of this smart contract, this output action will fail.
+
+  * `FB08`–`FB3F` — Reserved for output action primitives.
+
+## Debug primitives
+
+[p:prim.debug] Opcodes beginning with `FE` are reserved for the _debug
+primitives_. These primitives have known fixed operation length, and behave as
+(multibyte) NOP operations. In particular, they never change the stack
+contents, and never throw exceptions, unless there are not enough bits to
+completely decode the opcode. However, when invoked in a TVM instance with
+debug mode enabled, these primitives can produce specific output into the text
+debug log of the TVM instance, never affecting the TVM state (so that from the
+perspective of TVM the behavior of debug primitives in debug mode is exactly
+the same). For instance, a debug primitive might dump all or some of the
+values near the top of the stack, display the current state of TVM and so on.
+
+**Debug primitives as multibyte NOPs.**
+
+  * `FEnn` — `DEBUG nn`, for 0 ≤ _n_ _n_ < 240, is a two-byte NOP.
+
+  * `FEFnssss` — `DEBUGSTR ssss`, for 0 ≤ _n_ < 16, is an ( _n_ \+ 3)-byte NOP, with the ( _n_ \+ 1)-byte “contents string” _s_ _s_ _s_ _s_ skipped as well.
+
+**Debug primitives as operations without side-effect.** Next we describe the
+debug primitives that might (and actually are) implemented in a version of
+TVM. Notice that another TVM implementation is free to use these codes for
+other debug purposes, or treat them as multibyte NOPs. Whenever these
+primitives need some arguments from the stack, they inspect these arguments,
+but leave them intact in the stack. If there are insufficient values in the
+stack, or they have incorrect types, debug primitives may output error
+messages into the debug log, or behave as NOPs, but they cannot throw
+exceptions.
+
+  * `FE00` — `DUMPSTK`, dumps the stack (at most the top 255 values) and shows the total stack depth.
+
+  * `FE0n` — `DUMPSTKTOP n`, 1 ≤ _n_ < 15, dumps the top _n_ values from the stack, starting from the deepest of them. If there are _d_ < _n_ values available, dumps only _d_ values.
+
+  * `FE10` — `HEXDUMP`, dumps `s0` in hexadecimal form, be it a _Slice_ or an _Integer_.
+
+  * `FE11` — `HEXPRINT`, similar to `HEXDUMP`, except the hexadecimal representation of `s0` is not immediately output, but rather concatenated to an output text buffer.
+
+  * `FE12` — `BINDUMP`, dumps `s0` in binary form, similarly to `HEXDUMP`.
+
+  * `FE13` — `BINPRINT`, outputs the binary representation of `s0` to a text buffer.
+
+  * `FE14` — `STRDUMP`, dumps the _Slice_ at `s0` as an UTF-8 string.
+
+  * `FE15` — `STRPRINT`, similar to `STRDUMP`, but outputs the string into a text buffer (without carriage return).
+
+  * `FE1E` — `DEBUGOFF`, disables all debug output until it is re-enabled by a `DEBUGON`. More precisely, this primitive increases an internal counter, which disables all debug operations (except `DEBUGOFF` and `DEBUGON`) when strictly positive.
+
+  * `FE1F` — `DEBUGON`, enables debug output (in a debug version of TVM).
+
+  * `FE2n` — `DUMP s(n)`, 0 ≤ _n_ < 15, dumps `s`( _n_ ).
+
+  * `FE3n` — `PRINT s(n)`, 0 ≤ _n_ < 15, concatenates the text representation of `s`( _n_ ) (without any leading or trailing spaces or carriage returns) to a text buffer which will be output before the output of any other debug operation.
+
+  * `FEC0–FEEF` — Use these opcodes for custom/experimental debug operations.
+
+  * `FEFnssss` — `DUMPTOSFMT ssss`, dumps `s0` formatted according to the ( _n_ \+ 1)-byte string _s_ _s_ _s_ _s_. This string might contain (a prefix of) the name of a TL-B type supported by the debugger. If the string begins with a zero byte, simply outputs it (without the first byte) into the debug log. If the string begins with a byte equal to one, concatenates it to a buffer, which will be output before the output of any other debug operation (effectively outputs a string without a carriage return).
+
+  * `FEFn00ssss` — `LOGSTR ssss`, string _s_ _s_ _s_ _s_ is _n_ bytes long.
+
+  * `FEF000` — `LOGFLUSH`, flushes all pending debug output from the buffer into the debug log.
+
+  * `FEFn01ssss` — `PRINTSTR ssss`, string _s_ _s_ _s_ _s_ is _n_ bytes long.
+
+## Codepage primitives
+
+[p:prim.codepage] The following primitives, which begin with byte `FF`,
+typically are used at the very beginning of a smart contract’s code or a
+library subroutine to select another TVM codepage. Notice that we expect all
+codepages to contain these primitives with the same codes, otherwise switching
+back to another codepage might be impossible (cf. ).
+
+  * `FFnn` — `SETCP nn`, selects TVM codepage 0 ≤ _n_ _n_ < 240. If the codepage is not supported, throws an invalid opcode exception.
+
+  * `FF00` — `SETCP0`, selects TVM (test) codepage zero as described in this document.
+
+  * `FFFz` — `SETCP z-16`, selects TVM codepage _z_ − 16 for 1 ≤ _z_ ≤ 15. Negative codepages  − 13… − 1 are reserved for restricted versions of TVM needed to validate runs of TVM in other codepages as explained in . Negative codepage  − 14 is reserved for experimental codepages, not necessarily compatible between different TVM implementations, and should be disabled in the production versions of TVM.
+
+  * `FFF0` — `SETCPX` ( _c_ – ), selects codepage _c_ with  − 215 ≤ _c_ < 215 passed in the top of the stack.
+
+# Formal properties and specifications of TVM
+
+This appendix discusses certain formal properties of TVM that are necessary
+for executing smart contracts in the TON Blockchain and validating such
+executions afterwards.
+
+## Serialization of the TVM state
+
+Recall that a virtual machine used for executing smart contracts in a
+blockchain must be _deterministic_ , otherwise the validation of each
+execution would require the inclusion of all intermediate steps of the
+execution into a block, or at least of the choices made when indeterministic
+operations have been performed.
+
+Furthermore, the _state_ of such a virtual machine must be (uniquely)
+serializable, so that even if the state itself is not usually included in a
+block, its _hash_ is still well-defined and can be included into a block for
+verification purposes.
+
+**TVM stack values.** TVM stack values can be serialized as follows:
+
+    
+    
+    vm_stk_tinyint#01 value:int64 = VmStackValue;
+    vm_stk_int#0201_ value:int257 = VmStackValue;
+    vm_stk_nan#02FF = VmStackValue;
+    vm_stk_cell#03 cell:^Cell = VmStackValue;
+    _ cell:^Cell st_bits:(## 10) end_bits:(## 10) 
+      { st_bits <= end_bits } 
+      st_ref:(#<= 4) end_ref:(#<= 4) 
+      { st_ref <= end_ref } = VmCellSlice;
+    vm_stk_slice#04 _:VmCellSlice  = VmStackValue;
+    vm_stk_builder#05 cell:^Cell = VmStackValue;
+    vm_stk_cont#06 cont:VmCont = VmStackValue;
+
+Of these, `vm_stk_tinyint` is never used by TVM in codepage zero; it is used
+only in restricted modes.
+
+**TVM stack.** The TVM stack can be serialized as follows:
+
+    
+    
+    vm_stack#_ depth:(## 24) stack:(VmStackList depth) = VmStack;
+    vm_stk_cons#_ {n:#} head:VmStackValue tail:^(VmStackList n) 
+      = VmStackList (n + 1);
+    vm_stk_nil#_ = VmStackList 0;
+
+**TVM control registers.** Control registers in TVM can be serialized as
+follows:
+
+    
+    
+    _ cregs:(HashmapE 4 VmStackValue) = VmSaveList;
+
+**TVM gas limits.** Gas limits in TVM can be serialized as follows:
+
+    
+    
+    gas_limits#_ remaining:int64 _:^[ 
+      max_limit:int64 cur_limit:int64 credit:int64 ]
+      = VmGasLimits;
+
+**TVM library environment.** The TVM library environment can be serialized as
+follows:
+
+    
+    
+    _ libraries:(HashmapE 256 ^Cell) = VmLibraries;
+
+**TVM continuations.** Continuations in TVM can be serialized as follows:
+
+    
+    
+    vmc_std$00 nargs:(## 22) stack:(Maybe VmStack) save:VmSaveList
+       cp:int16 code:VmCellSlice = VmCont;
+    vmc_envelope$01 nargs:(## 22) stack:(Maybe VmStack) 
+       save:VmSaveList next:^VmCont = VmCont;
+    vmc_quit$1000 exit_code:int32 = VmCont;
+    vmc_quit_exc$1001 = VmCont;
+    vmc_until$1010 body:^VmCont after:^VmCont = VmCont;
+    vmc_again$1011 body:^VmCont = VmCont;
+    vmc_while_cond$1100 cond:^VmCont body:^VmCont 
+       after:^VmCont = VmCont;
+    vmc_while_body$1101 cond:^VmCont body:^VmCont
+       after:^VmCont = VmCont;
+    vmc_pushint$1111 value:int32 next:^VmCont = VmCont;
+
+**TVM state.** The total state of TVM can be serialized as follows:
+
+    
+    
+    vms_init$00 cp:int16 step:int32 gas:GasLimits 
+      stack:(Maybe VmStack) save:VmSaveList code:VmCellSlice
+      lib:VmLibraries = VmState;
+    vms_exception$01 cp:int16 step:int32 gas:GasLimits 
+      exc_no:int32 exc_arg:VmStackValue 
+      save:VmSaveList lib:VmLibraries = VmState;
+    vms_running$10 cp:int16 step:int32 gas:GasLimits stack:VmStack
+      save:VmSaveList code:VmCellSlice lib:VmLibraries
+      = VmState;
+    vms_finished$11 cp:int16 step:int32 gas:GasLimits 
+      exit_code:int32 no_gas:Boolean stack:VmStack 
+      save:VmSaveList lib:VmLibraries = VmState;
+
+When TVM is initialized, its state is described by a `vms_init`, usually with
+`step` set to zero. The step function of TVM does nothing to a `vms_finished`
+state, and transforms all other states into `vms_running`, `vms_exception`, or
+`vms_finished`, with `step` increased by one.
+
+## Step function of TVM
+
+A formal specification of TVM would be completed by the definition of a _step
+function_ _f_ : _VmState_ → _VmState_. This function deterministically
+transforms a valid VM state into a valid subsequent VM state, and is allowed
+to throw exceptions or return an invalid subsequent state if the original
+state was invalid.
+
+**A high-level definition of the step function.** We might present a very long
+formal definition of the TVM step function in a high-level functional
+programming language. Such a specification, however, would mostly be useful as
+a reference for the (human) developers. We have chosen another approach,
+better adapted to automated formal verification by computers.
+
+**An operational definition of the step function.** Notice that the step
+function _f_ is a well-defined computable function from trees of cells into
+trees of cells. As such, it can be computed by a universal Turing machine.
+Then a program _P_ computing _f_ on such a machine would provide a machine-
+checkable specification of the step function _f_. This program _P_ effectively
+is an _emulator_ of TVM on this Turing machine.
+
+**A reference implementation of the TVM emulator inside TVM.** We see that the
+step function of TVM may be defined by a reference implementation of a TVM
+emulator on another machine. An obvious idea is to use TVM itself, since it is
+well-adapted to working with trees of cells. However, an emulator of TVM
+inside itself is not very useful if we have doubts about a particular
+implementation of TVM and want to check it. For instance, if such an emulator
+interpreted a `DICTISET` instruction simply by invoking this instruction
+itself, then a bug in the underlying implementation of TVM would remain
+unnoticed.
+
+**Reference implementation inside a minimal version of TVM.** We see that
+using TVM itself as a host machine for a reference implementation of TVM
+emulator would yield little insight. A better idea is to define a _stripped-
+down version of TVM_ , which supports only the bare minimum of primitives and
+64-bit integer arithmetic, and provide a reference implementation _P_ of the
+TVM step function _f_ for this stripped-down version of TVM.
+
+In that case, one must carefully implement and check only a handful of
+primitives to obtain a stripped-down version of TVM, and compare the reference
+implementation _P_ running on this stripped-down version to the full custom
+TVM implementation being verified. In particular, if there are any doubts
+about the validity of a specific run of a custom TVM implementation, they can
+now be easily resolved with the aid of the reference implementation.
+
+**Relevance for the TON Blockchain.** The TON Blockchain adopts this approach
+to validate the runs of TVM (e.g., those used for processing inbound messages
+by smart contracts) when the validators’ results do not match one another. In
+this case, a reference implementation of TVM, stored inside the masterchain as
+a configurable parameter (thus defining the current revision of TVM), is used
+to obtain the correct result.
+
+**Codepage − 1.**[sp:cp.minusone] _Codepage − 1_ of TVM is reserved for the
+stripped-down version of TVM. Its main purpose is to execute the reference
+implementation of the step function of the full TVM. This codepage contains
+only special versions of arithmetic primitives working with “tiny integers”
+(64-bit signed integers); therefore, TVM’s 257-bit _Integer_ arithmetic must
+be defined in terms of 64-bit arithmetic. Elliptic curve cryptography
+primitives are also implemented directly in codepage  − 1, without using any
+third-party libraries. Finally, a reference implementation of the
+$\operatorname{\mathrm{sha256}}$ hash function is also provided in codepage  −
+1.
+
+**Codepage − 2.** This bootstrapping process could be iterated even further,
+by providing an emulator of the stripped-down version of TVM written for an
+even simpler version of TVM that supports only boolean values (or integers 0
+and 1)—a “codepage  − 2”. All 64-bit arithmetic used in codepage  − 1 would
+then need to be defined by means of boolean operations, thus providing a
+reference implementation for the stripped-down version of TVM used in codepage
+− 1. In this way, if some of the TON Blockchain validators did not agree on
+the results of their 64-bit arithmetic, they could regress to this reference
+implementation to find the correct answer.30
+
+# Code density of stack and register machines
+
+[app:code.density]
+
+This appendix extends the general consideration of stack manipulation
+primitives provided in , explaining the choice of such primitives for TVM,
+with a comparison of stack machines and register machines in terms of the
+quantity of primitives used and the code density. We do this by comparing the
+machine code that might be generated by an optimizing compiler for the same
+source files, for different (abstract) stack and register machines.
+
+It turns out that the stack machines (at least those equipped with the basic
+stack manipulation primitives described in ) have far superior code density.
+Furthermore, the stack machines have excellent extendability with respect to
+additional arithmetic and arbitrary data processing operations, especially if
+one considers machine code automatically generated by optimizing compilers.
+
+## Sample leaf function
+
+We start with a comparison of machine code generated by an (imaginary)
+optimizing compiler for several abstract register and stack machines,
+corresponding to the same high-level language source code that contains the
+definition of a leaf function (i.e., a function that does not call any other
+functions). For both the register machines and stack machines, we observe the
+notation and conventions introduced in .
+
+[sp:cmp1.source] **Sample source file for a leaf function.** The source file
+we consider contains one function _f_ that takes six (integer) arguments, _a_
+, _b_ , _c_ , _d_ , _e_ , _f_ , and returns two (integer) values, _x_ and _y_
+, which are the solutions of the system of two linear equations  
+$$\begin{cases} ax+by&=e\\\ cx+dy&=f \end{cases}$$  
+The source code of the function, in a programming language similar to C, might
+look as follows:
+
+    
+    
+    (int, int) f(int a, int b, int c, int d, int e, int f) {
+      int D = a*d - b*c;
+      int Dx = e*d - b*f;
+      int Dy = a*f - e*c;
+      return (Dx / D, Dy / D);
+    }
+
+We assume (cf. ) that the register machines we consider accept the six
+parameters _a_ … _f_ in registers `r0`…`r5`, and return the two values _x_ and
+_y_ in `r0` and `r1`. We also assume that the register machines have 16
+registers, and that the stack machine can directly access `s0` to `s15` by its
+stack manipulation primitives; the stack machine will accept the parameters in
+`s5` to `s0`, and return the two values in `s0` and `s1`, somewhat similarly
+to the register machine. Finally, we assume at first that the register machine
+is allowed to destroy values in all registers (which is slightly unfair
+towards the stack machine); this assumption will be revisited later.
+
+[sp:cmp1.3addr] **Three-address register machine.** The machine code (or
+rather the corresponding assembly code) for a three-address register machine
+(cf. ) might look as follows:
+
+    
+    
+    IMUL r6,r0,r3  // r6 := r0 * r3 = ad
+    IMUL r7,r1,r2  // r7 := bc
+    SUB r6,r6,r7   // r6 := ad-bc = D
+    IMUL r3,r4,r3  // r3 := ed
+    IMUL r1,r1,r5  // r1 := bf
+    SUB r3,r3,r1   // r3 := ed-bf = Dx
+    IMUL r1,r0,r5  // r1 := af
+    IMUL r7,r4,r2  // r7 := ec
+    SUB r1,r1,r7   // r1 := af-ec = Dy
+    IDIV r0,r3,r6  // x := Dx/D
+    IDIV r1,r1,r6  // y := Dy/D
+    RET
+
+We have used 12 operations and at least 23 bytes (each operation uses 3 × 4 =
+12 bits to indicate the three registers involved, and at least 4 bits to
+indicate the operation performed; thus we need two or three bytes to encode
+each operation). A more realistic estimate would be 34 (three bytes for each
+arithmetic operation) or 31 bytes (two bytes for addition and subtraction,
+three bytes for multiplication and division).
+
+[sp:cmp1.2addr] **Two-address register machine.** The machine code for a two-
+address register machine might look as follows:
+
+    
+    
+    MOV r6,r0   // r6 := r0 = a
+    MOV r7,r1   // r7 := b
+    IMUL r6,r3  // r6 := r6*r3 = ad
+    IMUL r7,r2  // r7 := bc
+    IMUL r3,r4  // r3 := de
+    IMUL r1,r5  // r1 := bf
+    SUB r6,r7   // r6 := ad-bc = D
+    IMUL r5,r0  // r5 := af
+    SUB r3,r1   // r3 := de-bf = Dx
+    IMUL r2,r4  // r2 := ce
+    MOV r0,r3   // r0 := Dx
+    SUB r5,r2   // r5 := af-ce = Dy
+    IDIV r0,r6  // r0 := x = Dx/D
+    MOV r1,r5   // r1 := Dy
+    IDIV r1,r6  // r1 := Dy/D
+    RET
+
+We have used 16 operations; optimistically assuming each of them (with the
+exception of `RET`) can be encoded by two bytes, this code would require 31
+bytes.31
+
+[sp:cmp1.1addr] **One-address register machine.** The machine code for a one-
+address register machine might look as follows:
+
+    
+    
+    MOV r8,r0  // r8 := r0 = a
+    XCHG r1    // r0 <-> r1; r0 := b, r1 := a
+    MOV r6,r0  // r6 := b
+    IMUL r2    // r0 := r0*r2; r0 := bc
+    MOV r7,r0  // r7 := bc
+    MOV r0,r8  // r0 := a
+    IMUL r3    // r0 := ad
+    SUB r7     // r0 := ad-bc = D
+    XCHG r1    // r1 := D,  r0 := b
+    IMUL r5    // r0 := bf
+    XCHG r3    // r0 := d,  r3 := bf
+    IMUL r4    // r0 := de
+    SUB r3     // r0 := de-bf = Dx
+    IDIV r1    // r0 := Dx/D = x
+    XCHG r2    // r0 := c,  r2 := x
+    IMUL r4    // r0 := ce
+    XCHG r5    // r0 := f,  r5 := ce
+    IMUL r8    // r0 := af
+    SUB r5     // r0 := af-ce = Dy
+    IDIV r1    // r0 := Dy/D = y
+    MOV r1,r0  // r1 := y
+    MOV r0,r2  // r0 := x
+    RET
+
+We have used 23 operations; if we assume one-byte encoding for all arithmetic
+operations and `XCHG`, and two-byte encodings for `MOV`, the total size of the
+code will be 29 bytes. Notice, however, that to obtain the compact code shown
+above we had to choose a specific order of computation, and made heavy use of
+the commutativity of multiplication. (For example, we compute _b_ _c_ before
+_a_ _f_ , and _a_ _f_ − _b_ _c_ immediately after _a_ _f_.) It is not clear
+whether a compiler would be able to make all such optimizations by itself.
+
+[sp:cmp1.stack.base] **Stack machine with basic stack primitives.** The
+machine code for a stack machine equipped with basic stack manipulation
+primitives described in might look as follows:
+
+    
+    
+    PUSH s5    // a b c d e f a
+    PUSH s3    // a b c d e f a d
+    IMUL       // a b c d e f ad
+    PUSH s5    // a b c d e f ad b
+    PUSH s5    // a b c d e f ad b c
+    IMUL       // a b c d e f ad bc
+    SUB        // a b c d e f ad-bc
+    XCHG s3    // a b c ad-bc e f d
+    PUSH s2    // a b c ad-bc e f d e
+    IMUL       // a b c ad-bc e f de
+    XCHG s5    // a de c ad-bc e f b
+    PUSH s1    // a de c ad-bc e f b f
+    IMUL       // a de c ad-bc e f bf
+    XCHG s1,s5 // a f c ad-bc e de bf
+    SUB        // a f c ad-bc e de-bf
+    XCHG s3    // a f de-bf ad-bc e c
+    IMUL       // a f de-bf ad-bc ec
+    XCHG s3    // a ec de-bf ad-bc f
+    XCHG s1,s4 // ad-bc ec de-bf a f
+    IMUL       // D ec Dx af
+    XCHG s1    // D ec af Dx
+    XCHG s2    // D Dx af ec
+    SUB        // D Dx Dy
+    XCHG s1    // D Dy Dx
+    PUSH s2    // D Dy Dx D
+    IDIV       // D Dy x
+    XCHG s2    // x Dy D
+    IDIV       // x y
+    RET
+
+We have used 29 operations; assuming one-byte encodings for all stack
+operations involved (including `XCHG s1,s(i)`), we have used 29 code bytes as
+well. Notice that with one-byte encoding, the “unsystematic” operation `ROT`
+(equivalent to `XCHG s1; XCHG s2`) would reduce the operation and byte count
+to 28. This shows that such “unsystematic” operations, borrowed from Forth,
+may indeed reduce the code size on some occasions.
+
+Notice as well that we have implicitly used the commutativity of
+multiplication in this code, computing _d_ _e_ − _b_ _f_ instead of _e_ _d_ −
+_b_ _f_ as specified in high-level language source code. If we were not
+allowed to do so, an extra `XCHG s1` would need to be inserted before the
+third `IMUL`, increasing the total size of the code by one operation and one
+byte.
+
+The code presented above might have been produced by a rather unsophisticated
+compiler that simply computed all expressions and subexpressions in the order
+they appear, then rearranged the arguments near the top of the stack before
+each operation as outlined in . The only “manual” optimization done here
+involves computing _e_ _c_ before _a_ _f_ ; one can check that the other order
+would lead to slightly shorter code of 28 operations and bytes (or 29, if we
+are not allowed to use the commutativity of multiplication), but the `ROT`
+optimization would not be applicable.
+
+**Stack machine with compound stack primitives.** A stack machine with
+compound stack primitives (cf. ) would not significantly improve code density
+of the code presented above, at least in terms of bytes used. The only
+difference is that, if we were not allowed to use commutativity of
+multiplication, the extra `XCHG s1` inserted before the third `IMUL` might be
+combined with two previous operations `XCHG s3`, `PUSH s2` into one compound
+operation `PUXC s2,s3`; we provide the resulting code below. To make this less
+redundant, we show a version of the code that computes subexpression _a_ _f_
+before _e_ _c_ as specified in the original source file. We see that this
+replaces six operations (starting from line 15) with five other operations,
+and disables the `ROT` optimization:
+
+    
+    
+    PUSH s5    // a b c d e f a
+    PUSH s3    // a b c d e f a d
+    IMUL       // a b c d e f ad
+    PUSH s5    // a b c d e f ad b
+    PUSH s5    // a b c d e f ad b c
+    IMUL       // a b c d e f ad bc
+    SUB        // a b c d e f ad-bc
+    PUXC s2,s3 // a b c ad-bc e f e d
+    IMUL       // a b c ad-bc e f ed
+    XCHG s5    // a ed c ad-bc e f b
+    PUSH s1    // a ed c ad-bc e f b f
+    IMUL       // a ed c ad-bc e f bf
+    XCHG s1,s5 // a f c ad-bc e ed bf
+    SUB        // a f c ad-bc e ed-bf
+    XCHG s4    // a ed-bf c ad-bc e f
+    XCHG s1,s5 // e Dx c D a f
+    IMUL       // e Dx c D af
+    XCHG s2    // e Dx af D c
+    XCHG s1,s4 // D Dx af e c
+    IMUL       // D Dx af ec
+    SUB        // D Dx Dy
+    XCHG s1    // D Dy Dx
+    PUSH s2    // D Dy Dx D
+    IDIV       // D Dy x
+    XCHG s2    // x Dy D
+    IDIV       // x y
+    RET
+
+We have used a total of 27 operations and 28 bytes, the same as the previous
+version (with the `ROT` optimization). However, we did not use the
+commutativity of multiplication here, so we can say that compound stack
+manipulation primitives enable us to reduce the code size from 29 to 28 bytes.
+
+Yet again, notice that the above code might have been generated by an
+unsophisticated compiler. Manual optimizations might lead to more compact
+code; for instance, we could use compound operations such as `XCHG3` to
+prepare in advance not only the correct values of `s0` and `s1` for the next
+arithmetic operation, but also the value of `s2` for the arithmetic operation
+after that. The next section provides an example of such an optimization.
+
+[sp:cmp1.stack.comp] **Stack machine with compound stack primitives and
+manually optimized code.** The previous version of code for a stack machine
+with compound stack primitives can be manually optimized as follows.
+
+By interchanging `XCHG` operations with preceding `XCHG`, `PUSH`, and
+arithmetic operations whenever possible, we obtain code fragment `XCHG s2,s6`;
+`XCHG s1,s0`; `XCHG s0,s5`, which can then be replaced by compound operation
+`XCHG3 s6,s0,s5`. This compound operation would admit a two-byte encoding,
+thus leading to 27-byte code using only 21 operations:
+
+    
+    
+    PUSH2 s5,s2    // a b c d e f a d
+    IMUL           // a b c d e f ad
+    PUSH2 s5,s4    // a b c d e f ad b c
+    IMUL           // a b c d e f ad bc
+    SUB            // a b c d e f ad-bc
+    PUXC s2,s3     // a b c ad-bc e f e d
+    IMUL           // a b c D e f ed
+    XCHG3 s6,s0,s5 //  (same as XCHG s2,s6; XCHG s1,s0; XCHG s0,s5)
+                   // e f c D a ed b
+    PUSH s5        // e f c D a ed b f
+    IMUL           // e f c D a ed bf
+    SUB            // e f c D a ed-bf
+    XCHG s4        // e Dx c D a f
+    IMUL           // e Dx c D af
+    XCHG2 s4,s2    // D Dx af e c
+    IMUL           // D Dx af ec
+    SUB            // D Dx Dy
+    XCPU s1,s2     // D Dy Dx D
+    IDIV           // D Dy x
+    XCHG s2        // x Dy D
+    IDIV           // x y
+    RET
+
+It is interesting to note that this version of stack machine code contains
+only 9 stack manipulation primitives for 11 arithmetic operations. It is not
+clear, however, whether an optimizing compiler would be able to reorganize the
+code in such a manner by itself.
+
+## Comparison of machine code for sample leaf function
+
+[sp:cmp1.summary] Table summarizes the properties of machine code
+corresponding to the same source file described in , generated for a
+hypothetical three-address register machine (cf. ), with both “optimistic” and
+“realistic” instruction encodings; a two-address machine (cf. ); a one-address
+machine (cf. ); and a stack machine, similar to TVM, using either only the
+basic stack manipulation primitives (cf. ) or both the basic and the composite
+stack primitives (cf. ).
+
+The meaning of the columns in Table is as follows:
+
+  * “Operations” — The quantity of instructions used, split into “data” (i.e., register move and exchange instructions for register machines, and stack manipulation instructions for stack machines) and “arithmetic” (instructions for adding, subtracting, multiplying and dividing integer numbers). The “total” is one more than the sum of these two, because there is also a one-byte `RET` instruction at the end of machine code.
+
+  * “Code bytes” — The total amount of code bytes used.
+
+  * “Opcode space” — The portion of “opcode space” (i.e., of possible choices for the first byte of the encoding of an instruction) used by data and arithmetic instructions in the assumed instruction encoding. For example, the “optimistic” encoding for the three-address machine assumes two-byte encodings for all arithmetic instructions _op_ `r(i), r(j), r(k)`. Each arithmetic instruction would then consume portion 16/256 = 1/16 of the opcode space. Notice that for the stack machine we have assumed one-byte encodings for `XCHG s(i)`, `PUSH s(i)` and `POP s(i)` in all cases, augmented by `XCHG s1,s(i)` for the basic stack instructions case only. As for the compound stack operations, we have assumed two-byte encodings for `PUSH3`, `XCHG3`, `XCHG2`, `XCPU`, `PUXC`, `PUSH2`, but not for `XCHG s1,s(i)`.
+
+The “code bytes” column reflects the density of the code for the specific
+sample source. However, “opcode space” is also important, because it reflects
+the extendability of the achieved density to other classes of operations
+(e.g., if one were to complement arithmetic operations with string
+manipulation operations and so on). Here the “arithmetic” subcolumn is more
+important than the “data” subcolumn, because no further data manipulation
+operations would be required for such extensions.
+
+We see that the three-address register machine with the “optimistic” encoding,
+assuming two-byte encodings for all three-register arithmetic operations,
+achieves the best code density, requiring only 23 bytes. However, this comes
+at a price: each arithmetic operation consumes 1/16 of the opcode space, so
+the four operations already use a quarter of the opcode space. At most 11
+other operations, arithmetic or not, might be added to this architecture while
+preserving such high code density. On the other hand, when we consider the
+“realistic” encoding for the three-address machine, using two-byte encodings
+only for the most frequently used addition/subtraction operations (and longer
+encodings for less frequently used multiplication/division operations,
+reflecting the fact that the possible extension operations would likely fall
+in this class), then the three-address machine ceases to offer such attractive
+code density.
+
+In fact, the two-address machine becomes equally attractive at this point: it
+is capable of achieving the same code size of 31 bytes as the three-address
+machine with the “realistic” encoding, using only 6/256 of the opcode space
+for this! However, 31 bytes is the worst result in this table.
+
+The one-address machine uses 29 bytes, slightly less than the two-address
+machine. However, it utilizes a quarter of the opcode space for its arithmetic
+operations, hampering its extendability. In this respect it is similar to the
+three-address machine with the “optimistic” encoding, but requires 29 bytes
+instead of 23! So there is no reason to use the one-address machine at all, in
+terms of extendability (reflected by opcode space used for arithmetic
+operations) compared to code density.
+
+Finally, the stack machine wins the competition in terms of code density (27
+or 28 bytes), losing only to the three-address machine with the “optimistic”
+encoding (which, however, is terrible in terms of extendability).
+
+To summarize: the two-address machine and stack machine achieve the best
+extendability with respect to additional arithmetic or data processing
+instructions (using only 1/256 of code space for each such instruction), while
+the stack machine additionally achieves the best code density by a small
+margin. The stack machine utilizes a significant part of its code space (more
+than a quarter) for data (i.e., stack) manipulation instructions; however,
+this does not seriously hamper extendability, because the stack manipulation
+instructions occupy a constant part of the opcode stace, regardless of all
+other instructions and extensions.
+
+While one might still be tempted to use a two-address register machine, we
+will explain shortly (cf. ) why the two-address register machine offers worse
+code density and extendability in practice than it appears based on this
+table.
+
+As for the choice between a stack machine with only basic stack manipulation
+primitives or one supporting compound stack primitives as well, the case for
+the more sophisticated stack machine appears to be weaker: it offers only one
+or two fewer bytes of code at the expense of using considerably more opcode
+space for stack manipulation, and the optimized code using these additional
+instructions is hard for programmers to write and for compilers to
+automatically generate.
+
+**Register calling conventions: some registers must be preserved by
+functions.** Up to this point, we have considered the machine code of only one
+function, without taking into account the interplay between this function and
+other functions in the same program.
+
+Usually a program consists of more than one function, and when a function is
+not a “simple” or “leaf” function, it must call other functions. Therefore, it
+becomes important whether a called function preserves all or at least some
+registers. If it preserves all registers except those used to return results,
+the caller can safely keep its local and temporary variables in certain
+registers; however, the callee needs to save all the registers it will use for
+its temporary values somewhere (usually into the stack, which also exists on
+register machines), and then restore the original values. On the other hand,
+if the called function is allowed to destroy all registers, it can be written
+in the manner described in , , and , but the caller will now be responsible
+for saving all its temporary values into the stack before the call, and
+restoring these values afterwards.
+
+In most cases, calling conventions for register machines require preservation
+of some but not all registers. We will assume that _m_ ≤ _n_ registers will be
+preserved by functions (unless they are used for return values), and that
+these registers are `r`( _n_ − _m_ )…`r`( _n_ − 1). Case _m_ = 0 corresponds
+to the case “the callee is free to destroy all registers” considered so far;
+it is quite painful for the caller. Case _m_ = _n_ corresponds to the case
+“the callee must preserve all registers”; it is quite painful for the callee,
+as we will see in a moment. Usually a value of _m_ around _n_ /2 is used in
+practice.
+
+The following sections consider cases _m_ = 0, _m_ = 8, and _m_ = 16 for our
+register machines with _n_ = 16 registers.
+
+**Case _m_ = 0: no registers to preserve.** This case has been considered and
+summarized in and Table above.
+
+[sp:cmp1.16] **Case _m_ = _n_ = 16: all registers must be preserved.** This
+case is the most painful one for the called function. It is especially
+difficult for leaf functions like the one we have been considering, which do
+not benefit at all from the fact that other functions preserve some registers
+when called—they do not call any functions, but instead must preserve all
+registers themselves.
+
+In order to estimate the consequences of assuming _m_ = _n_ = 16, we will
+assume that all our register machines are equipped with a stack, and with one-
+byte instructions `PUSH r(i)` and `POP r(i)`, which push or pop a register
+into/from the stack. For example, the three-address machine code provided in
+destroys the values in registers `r2`, `r3`, `r6`, and `r7`; this means that
+the code of this function must be augmented by four instructions `PUSH r2`;
+`PUSH r3`; `PUSH r6`; `PUSH r7` at the beginning, and by four instructions
+`POP r7`; `POP r6`; `POP r3`; `POP r2` right before the `RET` instruction, in
+order to restore the original values of these registers from the stack. These
+four additional `PUSH`/`POP` pairs would increase the operation count and code
+size in bytes by 4 × 2 = 8. A similar analysis can be done for other register
+machines as well, leading to Table .
+
+We see that under these assumptions the stack machines are the obvious winners
+in terms of code density, and are in the winning group with respect to
+extendability.
+
+[sp:cmp1.8] **Case _m_ = 8, _n_ = 16: registers `r8`…`r15` must be
+preserved.** The analysis of this case is similar to the previous one. The
+results are summarized in Table .
+
+Notice that the resulting table is very similar to Table , apart from the
+“Opcode space” columns and the row for the one-address machine. Therefore, the
+conclusions of still apply in this case, with some minor modifications. We
+must emphasize, however, that _these conclusions are valid only for leaf
+functions, i.e., functions that do not call other functions_. Any program
+aside from the very simplest will have many non-leaf functions, especially if
+we are minimizing resulting machine code size (which prevents inlining of
+functions in most cases).
+
+[sp:cmp1.fair] **A fairer comparison using a binary code instead of a byte
+code.** The reader may have noticed that our preceding discussion of _k_
+-address register machines and stack machines depended very much on our
+insistence that complete instructions be encoded by an integer number of
+bytes. If we had been allowed to use a “bit” or “binary code” instead of a
+byte code for encoding instructions, we could more evenly balance the opcode
+space used by different machines. For instance, the opcode of `SUB` for a
+three-address machine had to be either 4-bit (good for code density, bad for
+opcode space) or 12-bit (very bad for code density), because the complete
+instruction has to occupy a multiple of eight bits (e.g., 16 or 24 bits), and
+3 ⋅ 4 = 12 of those bits have to be used for the three register names.
+
+Therefore, let us get rid of this restriction.
+
+Now that we can use any number of bits to encode an instruction, we can choose
+all opcodes of the same length for all the machines considered. For instance,
+all arithmetic instructions can have 8-bit opcodes, as the stack machine does,
+using 1/256 of the opcode space each; then the three-address register machine
+will use 20 bits to encode each complete arithmetic instruction. All `MOV`s,
+`XCHG`s, `PUSH`es, and `POP`s on register machines can be assumed to have
+4-bit opcodes, because this is what we do for the most common stack
+manipulation primitives on a stack machine. The results of these changes are
+shown in Table .
+
+We can see that the performance of the various machines is much more balanced,
+with the stack machine still the winner in terms of the code density, but with
+the three-address machine enjoying the second place it really merits. If we
+were to consider the decoding speed and the possibility of parallel execution
+of instructions, we would have to choose the three-address machine, because it
+uses only 12 instructions instead of 21.
+
+## Sample non-leaf function
+
+[sect:sample.nonleaf] This section compares the machine code for different
+register machines for a sample non-leaf function. Again, we assume that either
+_m_ = 0, _m_ = 8, or _m_ = 16 registers are preserved by called functions,
+with _m_ = 8 representing the compromise made by most modern compilers and
+operating systems.
+
+[sp:cmp2.source] **Sample source code for a non-leaf function.** A sample
+source file may be obtained by replacing the built-in integer type with a
+custom _Rational_ type, represented by a pointer to an object in memory, in
+our function for solving systems of two linear equations (cf. ):
+
+    
+    
+    struct Rational;
+    typedef struct Rational *num;
+    extern num r_add(num, num);
+    extern num r_sub(num, num);
+    extern num r_mul(num, num);
+    extern num r_div(num, num);
+    
+    (num, num) r_f(num a, num b, num c, num d, num e, num f) {
+      num D = r_sub(r_mul(a, d), r_mul(b, c));   // a*d-b*c
+      num Dx = r_sub(r_mul(e, d), r_mul(b, f));  // e*d-b*f
+      num Dy = r_sub(r_mul(a, f), r_mul(e, c));  // a*f-e*c
+      return (r_div(Dx, D), r_div(Dy, D));      // Dx/D, Dy/D
+    }
+
+We will ignore all questions related to allocating new objects of type
+_Rational_ in memory (e.g., in heap), and to preventing memory leaks. We may
+assume that the called subroutines `r_sub`, `r_mul`, and so on allocate new
+objects simply by advancing some pointer in a pre-allocated buffer, and that
+unused objects are later freed by a garbage collector, external to the code
+being analysed.
+
+Rational numbers will now be represented by pointers, addresses, or
+references, which will fit into registers of our hypothetical register
+machines or into the stack of our stack machines. If we want to use TVM as an
+instance of these stack machines, we should use values of type _Cell_ to
+represent such references to objects of type _Rational_ in memory.
+
+We assume that subroutines (or functions) are called by a special `CALL`
+instruction, which is encoded by three bytes, including the specification of
+the function to be called (e.g., the index in a “global function table”).
+
+[sp:cmp2.2addr.0] **Three-address and two-address register machines, _m_ = 0
+preserved registers.** Because our sample function does not use built-in
+arithmetic instructions at all, compilers for our hypothetical three-address
+and two-address register machines will produce the same machine code. Apart
+from the previously introduced `PUSH r(i)` and `POP r(i)` one-byte
+instructions, we assume that our two- and three-address machines support the
+following two-byte instructions: `MOV r(i),s(j)`, `MOV s(j),r(i)`, and `XCHG
+r(i),s(j)`, for 0 ≤ _i_ , _j_ ≤ 15. Such instructions occupy only 3/256 of the
+opcode space, so their addition seems quite natural.
+
+We first assume that _m_ = 0 (i.e., that all subroutines are free to destroy
+the values of all registers). In this case, our machine code for `r_f` does
+not have to preserve any registers, but has to save all registers containing
+useful values into the stack before calling any subroutines. A size-optimizing
+compiler might produce the following code:
+
+    
+    
+    PUSH r4     // STACK: e
+    PUSH r1     // STACK: e b
+    PUSH r0     //     .. e b a
+    PUSH r6     //     .. e b a f
+    PUSH r2     //     .. e b a f c
+    PUSH r3     //     .. e b a f c d
+    MOV r0,r1   // b
+    MOV r1,r2   // c
+    CALL r_mul  // bc
+    PUSH r0     //     .. e b a f c d bc
+    MOV r0,s4   // a
+    MOV r1,s1   // d
+    CALL r_mul  // ad
+    POP r1      // bc; .. e b a f c d
+    CALL r_sub  // D:=ad-bc
+    XCHG r0,s4  // b ; .. e D a f c d
+    MOV r1,s2   // f
+    CALL r_mul  // bf
+    POP r1      // d ; .. e D a f c
+    PUSH r0     //     .. e D a f c bf
+    MOV r0,s5   // e
+    CALL r_mul  // ed
+    POP r1      // bf; .. e D a f c
+    CALL r_sub  // Dx:=ed-bf
+    XCHG r0,s4  // e ; .. Dx D a f c
+    POP r1      // c ; .. Dx D a f
+    CALL r_mul  // ec
+    XCHG r0,s1  // a ; .. Dx D ec f
+    POP r1      // f ; .. Dx D ec
+    CALL r_mul  // af
+    POP r1      // ec; .. Dx D
+    CALL r_sub  // Dy:=af-ec
+    XCHG r0,s1  // Dx; .. Dy D
+    MOV r1,s0   // D
+    CALL r_div  // x:=Dx/D
+    XCHG r0,s1  // Dy; .. x D
+    POP r1      // D ; .. x
+    CALL r_div  // y:=Dy/D
+    MOV r1,r0   // y
+    POP r0      // x ; ..
+    RET
+
+We have used 41 instructions: 17 one-byte (eight `PUSH`/`POP` pairs and one
+`RET`), 13 two-byte (`MOV` and `XCHG`; out of them 11 “new” ones, involving
+the stack), and 11 three-byte (`CALL`), for a total of 17 ⋅ 1 + 13 ⋅ 2 + 11 ⋅
+3 = 76 bytes.32
+
+[sp:cmp2.2addr.8] **Three-address and two-address register machines, _m_ = 8
+preserved registers.** Now we have eight registers, `r8` to `r15`, that are
+preserved by subroutine calls. We might keep some intermediate values there
+instead of pushing them into the stack. However, the penalty for doing so
+consists in a `PUSH`/`POP` pair for every such register that we choose to use,
+because our function is also required to preserve its original value. It seems
+that using these registers under such a penalty does not improve the density
+of the code, so the optimal code for three- and two-address machines for _m_ =
+8 preserved registers is the same as that provided in , with a total of 42
+instructions and 74 code bytes.
+
+[sp:cmp2.2addr.16] **Three-address and two-address register machines, _m_ = 16
+preserved registers.** This time _all_ registers must be preserved by the
+subroutines, excluding those used for returning the results. This means that
+our code must preserve the original values of `r2` to `r5`, as well as any
+other registers it uses for temporary values. A straightforward way of writing
+the code of our subroutine would be to push registers `r2` up to, say, `r8`
+into the stack, then perform all the operations required, using `r6`–`r8` for
+intermediate values, and finally restore registers from the stack. However,
+this would not optimize code size. We choose another approach:
+
+    
+    
+    PUSH r0     // STACK: a
+    PUSH r1     // STACK: a b
+    MOV r0,r1   // b
+    MOV r1,r2   // c
+    CALL r_mul  // bc
+    PUSH r0     //     .. a b bc
+    MOV r0,s2   // a
+    MOV r1,r3   // d
+    CALL r_mul  // ad
+    POP r1      // bc; .. a b
+    CALL r_sub  // D:=ad-bc
+    XCHG r0,s0  // b;  .. a D
+    MOV r1,r5   // f
+    CALL r_mul  // bf
+    PUSH r0     //     .. a D bf
+    MOV r0,r4   // e
+    MOV r1,r3   // d
+    CALL r_mul  // ed
+    POP r1      // bf; .. a D
+    CALL r_sub  // Dx:=ed-bf
+    XCHG r0,s1  // a ; .. Dx D
+    MOV r1,r5   // f
+    CALL r_mul  // af
+    PUSH r0     //     .. Dx D af
+    MOV r0,r4   // e
+    MOV r1,r2   // c
+    CALL r_mul  // ec
+    MOV r1,r0   // ec
+    POP r0      // af; .. Dx D
+    CALL r_sub  // Dy:=af-ec
+    XCHG r0,s1  // Dx; .. Dy D
+    MOV r1,s0   // D
+    CALL r_div  // x:=Dx/D
+    XCHG r0,s1  // Dy; .. x D
+    POP r1      // D ; .. x
+    CALL r_div  // y:=Dy/D
+    MOV r1,r0   // y
+    POP r0      // x
+    RET
+
+We have used 39 instructions: 11 one-byte, 17 two-byte (among them 5 “new”
+instructions), and 11 three-byte, for a total of 11 ⋅ 1 + 17 ⋅ 2 + 11 ⋅ 3 = 78
+bytes. Somewhat paradoxically, the code size in bytes is slightly longer than
+in the previous case (cf. ), contrary to what one might have expected. This is
+partially due to the fact that we have assumed two-byte encodings for “new”
+`MOV` and `XCHG` instructions involving the stack, similarly to the “old”
+instructions. Most existing architectures (such as x86-64) use longer
+encodings (maybe even twice as long) for their counterparts of our “new” move
+and exchange instructions compared to the “usual” register-register ones.
+Taking this into account, we see that we would have obtained here 83 bytes
+(versus 87 for the code in ) assuming three-byte encodings of new operations,
+and 88 bytes (versus 98) assuming four-byte encodings. This shows that, for
+two-address architectures without optimized encodings for register-stack move
+and exchange operations, _m_ = 16 preserved registers might result in slightly
+shorter code for some non-leaf functions, at the expense of leaf functions
+(cf. and ), which would become considerably longer.
+
+[sp:cmp2.1addr.0] **One-address register machine, _m_ = 0 preserved
+registers.** For our one-address register machine, we assume that new
+register-stack instructions work through the accumulator only. Therefore, we
+have three new instructions, `LD s(j)` (equivalent to `MOV r0,s(j)` of two-
+address machines), `ST s(j)` (equivalent to `MOV s(j),r0`), and `XCHG s(j)`
+(equivalent to `XCHG r0,s(j)`). To make the comparison with two-address
+machines more interesting, we assume one-byte encodings for these new
+instructions, even though this would consume 48/256 = 3/16 of the opcode
+space.
+
+By adapting the code provided in to the one-address machine, we obtain the
+following:
+
+    
+    
+    PUSH r4     // STACK: e
+    PUSH r1     // STACK: e b
+    PUSH r0     //     .. e b a
+    PUSH r6     //     .. e b a f
+    PUSH r2     //     .. e b a f c
+    PUSH r3     //     .. e b a f c d
+    LD s1       // r0:=c
+    XCHG r1     // r0:=b, r1:=c
+    CALL r_mul  // bc
+    PUSH r0     //     .. e b a f c d bc
+    LD s1       // d
+    XCHG r1     // r1:=d
+    LD s4       // a
+    CALL r_mul  // ad
+    POP r1      // bc; .. e b a f c d
+    CALL r_sub  // D:=ad-bc
+    XCHG s4     // b ; .. e D a f c d
+    XCHG r1
+    LD s2       // f
+    XCHG r1     // r0:=b, r1:=f
+    CALL r_mul  // bf
+    POP r1      // d ; .. e D a f c
+    PUSH r0     //     .. e D a f c bf
+    LD s5       // e
+    CALL r_mul  // ed
+    POP r1      // bf; .. e D a f c
+    CALL r_sub  // Dx:=ed-bf
+    XCHG s4     // e ; .. Dx D a f c
+    POP r1      // c ; .. Dx D a f
+    CALL r_mul  // ec
+    XCHG s1     // a ; .. Dx D ec f
+    POP r1      // f ; .. Dx D ec
+    CALL r_mul  // af
+    POP r1      // ec; .. Dx D
+    CALL r_sub  // Dy:=af-ec
+    XCHG s1     // Dx; .. Dy D
+    POP r1      // D ; .. Dy
+    PUSH r1     //     .. Dy D
+    CALL r_div  // x:=Dx/D
+    XCHG s1     // Dy; .. x D
+    POP r1      // D ; .. x
+    CALL r_div  // y:=Dy/D
+    XCHG r1     // r1:=y
+    POP r0      // r0:=x ; ..
+    RET
+
+We have used 45 instructions: 34 one-byte and 11 three-byte, for a total of 67
+bytes. Compared to the 76 bytes used by two- and three-address machines in ,
+we see that, again, the one-address register machine code may be denser than
+that of two-register machines, at the expense of utilizing more opcode space
+(just as shown in ). However, this time the extra 3/16 of the opcode space was
+used for data manipulation instructions, which do not depend on specific
+arithmetic operations or user functions invoked.
+
+[sp:cmp2.1addr.8] **One-address register machine, _m_ = 8 preserved
+registers.** As explained in , the preservation of `r8`–`r15` between
+subroutine calls does not improve the size of our previously written code, so
+the one-address machine will use for _m_ = 8 the same code provided in .
+
+[sp:cmp2.1addr.16] **One-address register machine, _m_ = 16 preserved
+registers.** We simply adapt the code provided in to the one-address register
+machine:
+
+    
+    
+    PUSH r0     // STACK: a
+    PUSH r1     // STACK: a b
+    MOV r0,r1   // b
+    MOV r1,r2   // c
+    CALL r_mul  // bc
+    PUSH r0     //     .. a b bc
+    LD s2       // a
+    MOV r1,r3   // d
+    CALL r_mul  // ad
+    POP r1      // bc; .. a b
+    CALL r_sub  // D:=ad-bc
+    XCHG s0     // b;  .. a D
+    MOV r1,r5   // f
+    CALL r_mul  // bf
+    PUSH r0     //     .. a D bf
+    MOV r0,r4   // e
+    MOV r1,r3   // d
+    CALL r_mul  // ed
+    POP r1      // bf; .. a D
+    CALL r_sub  // Dx:=ed-bf
+    XCHG s1     // a ; .. Dx D
+    MOV r1,r5   // f
+    CALL r_mul  // af
+    PUSH r0     //     .. Dx D af
+    MOV r0,r4   // e
+    MOV r1,r2   // c
+    CALL r_mul  // ec
+    MOV r1,r0   // ec
+    POP r0      // af; .. Dx D
+    CALL r_sub  // Dy:=af-ec
+    XCHG s1     // Dx; .. Dy D
+    POP r1      // D ; .. Dy
+    PUSH r1     //     .. Dy D
+    CALL r_div  // x:=Dx/D
+    XCHG s1     // Dy; .. x D
+    POP r1      // D ; .. x
+    CALL r_div  // y:=Dy/D
+    MOV r1,r0   // y
+    POP r0      // x
+    RET
+
+We have used 40 instructions: 18 one-byte, 11 two-byte, and 11 three-byte, for
+a total of 18 ⋅ 1 + 11 ⋅ 2 + 11 ⋅ 3 = 73 bytes.
+
+[sp:cmp2.stack.base] **Stack machine with basic stack primitives.** We reuse
+the code provided in , simply replacing arithmetic primitives (VM
+instructions) with subroutine calls. The only substantive modification is the
+insertion of the previously optional `XCHG s1` before the third
+multiplication, because even an optimizing compiler cannot now know whether
+`CALL r_mul` is a commutative operation. We have also used the “tail recursion
+optimization” by replacing the final `CALL r_div` followed by `RET` with `JMP
+r_div`.
+
+    
+    
+    PUSH s5     // a b c d e f a
+    PUSH s3     // a b c d e f a d
+    CALL r_mul  // a b c d e f ad
+    PUSH s5     // a b c d e f ad b
+    PUSH s5     // a b c d e f ad b c
+    CALL r_mul  // a b c d e f ad bc
+    CALL r_sub  // a b c d e f ad-bc
+    XCHG s3     // a b c ad-bc e f d
+    PUSH s2     // a b c ad-bc e f d e
+    XCHG s1     // a b c ad-bc e f e d
+    CALL r_mul  // a b c ad-bc e f ed
+    XCHG s5     // a ed c ad-bc e f b
+    PUSH s1     // a ed c ad-bc e f b f
+    CALL r_mul  // a ed c ad-bc e f bf
+    XCHG s1,s5  // a f c ad-bc e ed bf
+    CALL r_sub  // a f c ad-bc e ed-bf
+    XCHG s3     // a f ed-bf ad-bc e c
+    CALL r_mul  // a f ed-bf ad-bc ec
+    XCHG s3     // a ec ed-bf ad-bc f
+    XCHG s1,s4  // ad-bc ec ed-bf a f
+    CALL r_mul  // D ec Dx af
+    XCHG s1     // D ec af Dx
+    XCHG s2     // D Dx af ec
+    CALL r_sub  // D Dx Dy
+    XCHG s1     // D Dy Dx
+    PUSH s2     // D Dy Dx D
+    CALL r_div  // D Dy x
+    XCHG s2     // x Dy D
+    JMP r_div   // x y
+
+We have used 29 instructions; assuming one-byte encodings for all stack
+operations, and three-byte encodings for `CALL` and `JMP` instructions, we end
+up with 51 bytes.
+
+[sp:cmp2.stack.comp] **Stack machine with compound stack primitives.** We
+again reuse the code provided in , replacing arithmetic primitives with
+subroutine calls and making the tail recursion optimization:
+
+    
+    
+    PUSH2 s5,s2    // a b c d e f a d
+    CALL r_mul     // a b c d e f ad
+    PUSH2 s5,s4    // a b c d e f ad b c
+    CALL r_mul     // a b c d e f ad bc
+    CALL r_sub     // a b c d e f ad-bc
+    PUXC s2,s3     // a b c ad-bc e f e d
+    CALL r_mul     // a b c D e f ed
+    XCHG3 s6,s0,s5 //  (same as XCHG s2,s6; XCHG s1,s0; XCHG s0,s5)
+                   // e f c D a ed b
+    PUSH s5        // e f c D a ed b f
+    CALL r_mul     // e f c D a ed bf
+    CALL r_sub     // e f c D a ed-bf
+    XCHG s4        // e Dx c D a f
+    CALL r_mul     // e Dx c D af
+    XCHG2 s4,s2    // D Dx af e c
+    CALL r_mul     // D Dx af ec
+    CALL r_sub     // D Dx Dy
+    XCPU s1,s2     // D Dy Dx D
+    CALL r_div     // D Dy x
+    XCHG s2        // x Dy D
+    JMP r_div      // x y
+
+This code uses only 20 instructions, 9 stack-related and 11 control flow-
+related (`CALL` and `JMP`), for a total of 48 bytes.
+
+## Comparison of machine code for sample non-leaf function
+
+[sp:cmp2.summary] Table summarizes the properties of machine code
+corresponding to the same source file provided in . We consider only the
+“realistically” encoded three-address machines. Three-address and two-address
+machines have the same code density properties, but differ in the utilization
+of opcode space. The one-address machine, somewhat surprisingly, managed to
+produced shorter code than the two-address and three-address machines, at the
+expense of using up more than half of all opcode space. The stack machine is
+the obvious winner in this code density contest, without compromizing its
+excellent extendability (measured in opcode space used for arithmetic and
+other data transformation instructions).
+
+**Combining with results for leaf functions.** It is instructive to compare
+this table with the results in for a sample leaf function, summarized in Table
+(for _m_ = 0 preserved registers) and the very similar Table (for _m_ = 8
+preserved registers), and, if one is still interested in case _m_ = 16 (which
+turned out to be worse than _m_ = 8 in almost all situations), also to Table .
+
+We see that the stack machine beats all register machines on non-leaf
+functions. As for the leaf functions, only the three-address machine with the
+“optimistic” encoding of arithmetic instructions was able to beat the stack
+machine, winning by 15%, by compromising its extendability. However, the same
+three-address machine produces 25% longer code for non-leaf functions. If a
+typical program consists of a mixture of leaf and non-leaf functions in
+approximately equal proportion, then the stack machine will still win.
+
+**A fairer comparison using a binary code instead of a byte code.**
+[sp:cmp2.fair] Similarly to , we may offer a fairer comparison of different
+register machines and the stack machine by using arbitrary binary codes
+instead of byte codes to encode instructions, and matching the opcode space
+used for data manipulation and arithmetic instructions by different machines.
+The results of this modified comparison are summarized in Table . We see that
+the stack machines still win by a large margin, while using less opcode space
+for stack/data manipulation.
+
+**Comparison with real machines.** Note that our hypothetical register
+machines have been considerably optimized to produce shorter code than
+actually existing register machines; the latter are subject to other design
+considerations apart from code density and extendability, such as backward
+compatibility, faster instruction decoding, parallel execution of neighboring
+instructions, ease of automatically producing optimized code by compilers, and
+so on.
+
+For example, the very popular two-address register architecture x86-64
+produces code that is approximately twice as long as our “ideal” results for
+the two-address machines. On the other hand, our results for the stack
+machines are directly applicable to TVM, which has been explicitly designed
+with the considerations presented in this appendix in mind. Furthermore, the
+actual TVM code is even _shorter_ (in bytes) than shown in Table because of
+the presence of the two-byte `CALL` instruction, allowing TVM to call up to
+256 user-defined functions from the dictionary at `c3`. This means that one
+should subtract 10 bytes from the results for stack machines in Table if one
+wants to specifically consider TVM, rather than an abstract stack machine;
+this produces a code size of approximately 40 bytes (or shorter), almost half
+that of an abstract two-address or three-address machine.
+
+**Automatic generation of optimized code.** An interesting point is that the
+stack machine code in our samples might have been generated automatically by a
+very simple optimizing compiler, which rearranges values near the top of the
+stack appropriately before invoking each primitive or calling a function as
+explained in and . The only exception is the unimportant “manual” `XCHG3`
+optimization described in , which enabled us to shorten the code by one more
+byte.
+
+By contrast, the heavily optimized (with respect to size) code for register
+machines shown in and is unlikely to be produced automatically by an
+optimizing compiler. Therefore, if we had compared compiler-generated code
+instead of manually-generated code, the advantages of stack machines with
+respect to code density would have been even more striking.
+
+* * *
+
+  [^1]: For example, there are no floating-point arithmetic operations (which could be efficiently implemented using hardware-supported _double_ type on most modern CPUs) present in TVM, because the result of performing such operations is dependent on the specific underlying hardware implementation and rounding mode settings. Instead, TVM supports special integer arithmetic operations, which can be used to simulate fixed-point arithmetic if needed.↩︎
+
+  2. The production version will likely require some tweaks and modifications prior to launch, which will become apparent only after using the experimental version in the test environment for some time.↩︎
+
+  3. A high-level smart-contract language might create a visibility of variables for the ease of programming; however, the high-level source code working with variables will be translated into TVM machine code keeping all the values of these variables in the TVM stack.↩︎
+
+  4. In the TON Blockchain context, `c7` is initialized with a singleton _Tuple_ , the only component of which is a _Tuple_ containing blockchain-specific data. The smart contract is free to modify `c7` to store its temporary data provided the first component of this _Tuple_ remains intact.↩︎
+
+  5. Strictly speaking, there is also the current _library context_ , which consists of a dictionary with 256-bit keys and cell values, used to load library reference cells of .↩︎
+
+  6. Our inclusion of `r0` here creates a minor conflict with our assumption that the accumulator register, if present, is also `r0`; for simplicity, we will resolve this problem by assuming that the first argument to a function is passed in the accumulator.↩︎
+
+  7. For instance, if one writes a function for extracting square roots, this function will always accept its argument and return its result in the same registers, in contrast with a hypothetical built-in square root instruction, which could allow the programmer to arbitrarily choose the source and destination registers. Therefore, a user-defined function is tremendously less flexible than a built-in instruction on a register machine.↩︎
+
+  8. Of course, if the second option is used, this will destroy the original arrangement of _x_ in the top of the stack. In this case, one should either issue a `SWAP` before `XCHG s(j')`, or replace the previous operation `XCHG s(i)` with `XCHG s1, s(i)`, so that _x_ is exchanged with `s1` from the beginning.↩︎
+
+  9. Notice that the most common `XCHG s(i)` operation is not really required here if we do not insist on keeping the same temporary value or variable always in the same stack location, but rather keep track of its subsequent locations. We will move it to some other location while preparing the arguments to the next primitive or function call.↩︎
+
+  10. An alternative, arguably better, translation of `PU` _O_ ′`s`( _i_ 1), …, `s`( _i_ _γ_ ) consists of the translation of _O_ ′`s`( _i_ 2), …, `s`( _i_ _γ_ ), followed by `PUSH s(i_1+\alpha-1)`; `XCHG s(\gamma-1)`.↩︎
+
+  11. From the perspective of low-level cell operations, these data bits and cell references are not intermixed. In other words, an (ordinary) cell essentially is a couple consisting of a list of up to 1023 bits and of a list of up to four cell references, without prescribing an order in which the references and the data bits should be deserialized, even though TL-B schemes appear to suggest such an order.↩︎
+
+  12. From a theoretical perspective, we might say that a cell _c_ has an infinite sequence of hashes $\bigl(\operatorname{\mathrm{Hash}}_i(c)\bigr)_{i\geq1}$, which eventually stabilizes: $\operatorname{\mathrm{Hash}}_i(c)\to\operatorname{\mathrm{Hash}}_\infty(c)$. Then the level _l_ is simply the largest index _i_ , such that $\operatorname{\mathrm{Hash}}_i(c)\neq\operatorname{\mathrm{Hash}}_\infty(c)$.↩︎
+
+  13. A pruned branch cell _c_ ′ of level _l_ is _bound_ by a Merkle (proof or update) cell _c_ if there are exactly _l_ Merkle cells on the path from _c_ to its descendant _c_ ′, including _c_.↩︎
+
+  14. Negative numbers are represented using two’s complement. For instance, integer  − 17 is serialized by instruction `STI 8` into bitstring `xEF`.↩︎
+
+  15. A description of an older version of TL may be found at <https://core.telegram.org/mtproto/TL>.↩︎
+
+  16. The field’s name is useful for representing values of the type being defined in human-readable form, but it does not affect the binary serialization.↩︎
+
+  17. This is the “linear negation” operation ( − )⊥ of linear logic, hence our notation `\ `.↩︎
+
+  18. In fact, _f_ may receive _m_ extra arguments and return _m_ modified values, which are passed to the next invocation of _f_. This may be used to implement “map” and “reduce” operations with dictionaries.↩︎
+
+  19. Versions of this operation may be introduced where _f_ and _g_ receive an additional bitstring argument, equal to the key (for leaves) or to the common prefix of all keys (for forks) in the corresponding subtree.↩︎
+
+  20. If there are no bits of data left in `code`, but there is still exactly one reference, an implicit `JMP` to the cell at that reference is performed instead of an implicit `RET`.↩︎
+
+  21. Technically, TVM may simply invoke a virtual method `run()` of the continuation currently in `cc`.↩︎
+
+  22. The already used savelist `cc.save` of the new `cc` is emptied before the execution starts.↩︎
+
+  23. The implementation of `REPEAT` involves an extraordinary continuation that remembers the remaining number of iterations, the body of the loop _c_ , and the return continuation _c_ ′. (The latter term represents the remainder of the body of the function that invoked `REPEAT`, which would be normally stored in `c0` of the new `cc`.)↩︎
+
+  24. An important point here is that the tree of cells representing a TVM program cannot have cyclic references, so using `CALLREF` along with a reference to a cell higher up the tree would not work.↩︎
+
+  25. This is not exactly true. A more precise statement is that usually the codepage of the newly-created continuation is a known function of the current codepage.↩︎
+
+  26. This is another important mechanism of backward compatibility. All values of newly-added types, as well as values belonging to extended original types that do not belong to the original types (e.g., 513-bit integers that do not fit into 257 bits in the example above), are treated by all instructions (except stack manipulation instructions, which are naturally polymorphic, cf. ) in the old codepages as “values of incorrect type”, and generate type-checking exceptions accordingly.↩︎
+
+  27. If the cell dumps are hexadecimal, encodings consisting of an integral number of hexadecimal digits (i.e., having length divisible by four bits) might be equally convenient.↩︎
+
+  28. Notice that it is the probability of occurrence in the code that counts, not the probability of being executed. An instruction occurring in the body of a loop executed a million times is still counted only once.↩︎
+
+  29. Notice that any modifications after launch cannot be done unilaterally; rather they would require the support of at least two-thirds of validators.↩︎
+
+  30. The preliminary version of TVM does not use codepage  − 2 for this purpose. This may change in the future.↩︎
+
+  31. It is interesting to compare this code with that generated by optimizing C compilers for the x86-64 architecture.
+
+First of all, the integer division operation for x86-64 uses the one-address
+form, with the (double-length) dividend to be supplied in accumulator pair
+`r2:r0`. The quotient is also returned in `r0`. As a consequence, two single-
+to-double extension operations (`CDQ` or `CQO`) and at least one move
+operation need to be added.
+
+Secondly, the encoding used for arithmetic and move operations is less
+optimistic than in our example above, requiring about three bytes per
+operation on average. As a result, we obtain a total of 43 bytes for 32-bit
+integers, and 68 bytes for 64-bit integers.↩︎
+
+  32. Code produced for this function by an optimizing compiler for x86-64 architecture with size-optimization enabled actually occupied 150 bytes, due mostly to the fact that actual instruction encodings are about twice as long as we had optimistically assumed.↩︎
+


### PR DESCRIPTION
This is still pretty much a draft, because many headers need to be placed correctly, footnotes fixed, final math issues resolved, etc.

PDFs converted:
* tvm.pdf
* tblkch.pdf

Initial approach used `.mdx`, now trying `.html` outputs instead.

## Issue

Closes #2331.
