### PR TITLE
fix(docs/schema): adjust the `parser` config option

### DIFF
--- a/docs/src/content/docs/book/config.mdx
+++ b/docs/src/content/docs/book/config.mdx
@@ -256,9 +256,9 @@ If set to `true{:json}`, enables the generation of a [getter](/book/contracts#ge
 
 `"new"{:json}` by default.
 
-If set to `new{:json}`, Tact will compile using the new language parser.
+If set to `"new"{:json}`, Tact will compile using the new language parser.
 
-If set to `old{:json}`, Tact will compile using the old language parser.
+If set to `"old"{:json}`, Tact will compile using the legacy parser, which does not support all features of version 1.6.
 
 ```json filename="tact.config.json" {8,14}
 {
@@ -268,13 +268,13 @@ If set to `old{:json}`, Tact will compile using the old language parser.
       "path": "./contract.tact",
       "output": "./contract_output",
       "options": {
-        "debug": true
+        "parser": "new"
       }
     },
     {
       "name": "ContractUnderBlueprint",
       "options": {
-        "debug": true
+        "parser": "old"
       }
     }
   ]

--- a/src/config/config.zod.ts
+++ b/src/config/config.zod.ts
@@ -43,7 +43,7 @@ export const optionsSchema: z.ZodType<C.Options> = z.object({
      */
     interfacesGetter: z.boolean().optional(),
     /**
-     * If set to "new", uses new parser. If set to "old", uses legacy parser. Default is "old".
+     * If set to "new", uses new parser. If set to "old", uses legacy parser, which does not support all features of version 1.6. Defaults to "new".
      */
     parser: z.union([z.literal("new"), z.literal("old")]).optional(),
     /**

--- a/src/config/configSchema.json
+++ b/src/config/configSchema.json
@@ -54,6 +54,7 @@
               "parser": {
                 "type": "string",
                 "default": "new",
+                "enum": ["new", "old"],
                 "description": "\"new\" by default. If set to \"new\", Tact will compile using the new language parser. If set to \"old\", Tact will compile using the legacy parser, which does not support all features of version 1.6."
               },
               "experimental": {

--- a/src/config/configSchema.json
+++ b/src/config/configSchema.json
@@ -51,6 +51,11 @@
                 "default": false,
                 "description": "False by default. If set to true, enables generation of a getter the information on the interfaces provided by the contract.\n\nRead more about supported interfaces: https://docs.tact-lang.org/ref/evolution/OTP-001."
               },
+              "parser": {
+                "type": "string",
+                "default": "new",
+                "description": "\"new\" by default. If set to \"new\", Tact will compile using the new language parser. If set to \"old\", Tact will compile using the legacy parser, which does not support all features of version 1.6."
+              },
               "experimental": {
                 "type": "object",
                 "description": "Experimental options that might be removed in the future. Use with caution!",


### PR DESCRIPTION
## Issue

Closes #2359. A long forgotten follow-up to https://github.com/tact-lang/tact/pull/1258

I've thought about placing the `parser` option into `experimental` options, but it won't make much sense since users of 1.6.0, 1.6.1 and 1.6.2 won't have it there. And we're using the new parser since 1.6.0 anyways, so once the old parser is completely removed we'll simply mark this config option as deprecated.