### PR TITLE
refactor(codegen): apply parameters rearrangement only for methods with single parameter

### DIFF
--- a/dev-docs/CHANGELOG.md
+++ b/dev-docs/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Language features
+
+- [fix] Apply parameters rearrangement only for ASM methods with single parameter: PR [#2410](https://github.com/tact-lang/tact/pull/2410)
+
 ### Internal infrastructure
 
 - Removed `postinstall` from `package.json` to not run scripts with dev dependencies on the user side: PR [#2382](https://github.com/tact-lang/tact/pull/2382)

--- a/dev-docs/CHANGELOG.md
+++ b/dev-docs/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Language features
 
-- [fix] Apply parameters rearrangement only for ASM methods with single parameter: PR [#2410](https://github.com/tact-lang/tact/pull/2410)
+- Apply parameters rearrangement only for ASM methods with a single parameter to avoid confusion: PR [#2410](https://github.com/tact-lang/tact/pull/2410)
 
 ### Internal infrastructure
 

--- a/dev-docs/CHANGELOG.md
+++ b/dev-docs/CHANGELOG.md
@@ -30,6 +30,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [Novus Nota](https://github.com/novusnota)
 - [Anton Trunov](https://github.com/anton-trunov)
 - [Maksim Lagus](https://github.com/Kaladin13)
+- [Petr Makhnev](https://github.com/i582)
 
 ## [1.6.3] - 2025-03-12
 

--- a/src/generator/writers/writeExpression.ts
+++ b/src/generator/writers/writeExpression.ts
@@ -648,7 +648,8 @@ export function writeExpression(
                     methodDescr.ast.kind === "asm_function_def" &&
                     methodDescr.self &&
                     methodDescr.ast.shuffle.args.length > 1 &&
-                    methodDescr.ast.shuffle.ret.length === 0
+                    methodDescr.ast.shuffle.ret.length === 0 &&
+                    methodDescr.ast.params.length === 2 // apply only for `fun foo(self: Type, param: Type)`
                 ) {
                     const renderedSelfAndArguments = [s, ...renderedArguments];
                     const selfAndParameters = [

--- a/src/generator/writers/writeExpression.ts
+++ b/src/generator/writers/writeExpression.ts
@@ -649,7 +649,7 @@ export function writeExpression(
                     methodDescr.self &&
                     methodDescr.ast.shuffle.args.length > 1 &&
                     methodDescr.ast.shuffle.ret.length === 0 &&
-                    methodDescr.ast.params.length === 2 // apply only for `fun foo(self: Type, param: Type)`
+                    methodDescr.ast.params.length === 2 // apply only for `fun foo(self: T1, param: T2)`
                 ) {
                     const renderedSelfAndArguments = [s, ...renderedArguments];
                     const selfAndParameters = [

--- a/src/generator/writers/writeFunction.ts
+++ b/src/generator/writers/writeFunction.ts
@@ -734,7 +734,7 @@ function getAsmFunctionSignature(
     const needRearrange =
         fAst.shuffle.ret.length === 0 &&
         fAst.shuffle.args.length > 1 &&
-        fAst.params.length === 2 && // apply only for `fun foo(self: Type, param: Type)`
+        fAst.params.length === 2 && // apply only for `fun foo(self: T1, param: T2)`
         hasSelfParam &&
         !isMutable;
 

--- a/src/generator/writers/writeFunction.ts
+++ b/src/generator/writers/writeFunction.ts
@@ -734,7 +734,7 @@ function getAsmFunctionSignature(
     const needRearrange =
         fAst.shuffle.ret.length === 0 &&
         fAst.shuffle.args.length > 1 &&
-        fAst.params.length > 1 &&
+        fAst.params.length === 2 && // apply only for `fun foo(self: Type, param: Type)`
         hasSelfParam &&
         !isMutable;
 

--- a/src/test/e2e-emulated/asm-shuffle-in-comptime.spec.ts
+++ b/src/test/e2e-emulated/asm-shuffle-in-comptime.spec.ts
@@ -32,5 +32,6 @@ describe("asm-shuffle-in-comptime", () => {
     it("should shuffle arguments correctly", async () => {
         expect(await contract.getFoo(10n)).toEqual(20n);
         expect(await contract.getFoo(100n)).toEqual(100n);
+        expect(await contract.getBar()).toEqual(0n);
     });
 });

--- a/src/test/e2e-emulated/contracts/asm-shuffle-in-comptime.tact
+++ b/src/test/e2e-emulated/contracts/asm-shuffle-in-comptime.tact
@@ -1,7 +1,7 @@
 asm(other self) extends fun testFunc2(self: Int, other: String) { 2 BLKDROP }
 asm(nullable other self) extends fun testFunc3(self: Int, other: String, nullable: Bool?): Bool? { 2 BLKDROP }
 
-// comptime optimization only works for methods with one argument, so this function will be skipped
+// comptime optimization only works for methods with one argument, so this method will be skipped
 asm(val2 val1 self) extends fun storeTwo(self: Builder, val1: Bool, val2: Int): Builder {
     DUMPSTK
     1 STI   // val1 into self

--- a/src/test/e2e-emulated/contracts/asm-shuffle-in-comptime.tact
+++ b/src/test/e2e-emulated/contracts/asm-shuffle-in-comptime.tact
@@ -1,7 +1,7 @@
 asm(other self) extends fun testFunc2(self: Int, other: String) { 2 BLKDROP }
 asm(nullable other self) extends fun testFunc3(self: Int, other: String, nullable: Bool?): Bool? { 2 BLKDROP }
 
-// first stores Bool, then stores Int
+// comptime optimization only works for methods with one argument, so this function will be skipped
 asm(val2 val1 self) extends fun storeTwo(self: Builder, val1: Bool, val2: Int): Builder {
     DUMPSTK
     1 STI   // val1 into self

--- a/src/test/e2e-emulated/contracts/asm-shuffle-in-comptime.tact
+++ b/src/test/e2e-emulated/contracts/asm-shuffle-in-comptime.tact
@@ -1,6 +1,13 @@
 asm(other self) extends fun testFunc2(self: Int, other: String) { 2 BLKDROP }
 asm(nullable other self) extends fun testFunc3(self: Int, other: String, nullable: Bool?): Bool? { 2 BLKDROP }
 
+// first stores Bool, then stores Int
+asm(val2 val1 self) extends fun storeTwo(self: Builder, val1: Bool, val2: Int): Builder {
+    DUMPSTK
+    1 STI   // val1 into self
+    256 STI // val2 into self
+}
+
 contract Test {
     receive() {}
 
@@ -10,5 +17,17 @@ contract Test {
             return a + 10;
         }
         return a;
+    }
+
+    get fun bar(): Int {
+         let s = beginCell()
+            .storeBool(true)
+            .storeInt(0, 257)
+            .asSlice();
+
+        let c = beginCell()
+            .storeTwo(s.loadBool(), s.loadInt(257))
+            .endCell();
+        return c.depth() // just to keep the code above
     }
 }


### PR DESCRIPTION
## Issue

Closes #2390.

## Checklist

- [x] I have updated CHANGELOG.md
- [x] I have added tests to demonstrate the contribution is correctly implemented: this usually includes both positive and negative tests, showing the happy path(s) and featuring intentionally broken cases
