### PR TITLE
refactor(ast): import as Ast everywhere except AstNode and the AST helpers

### DIFF
--- a/src/abi/AbiFunction.ts
+++ b/src/abi/AbiFunction.ts
@@ -1,4 +1,4 @@
-import type { AstExpression } from "../ast/ast";
+import type * as Ast from "../ast/ast";
 import type { CompilerContext } from "../context/context";
 import type { WriterContext } from "../generator/Writer";
 import type { TypeRef } from "../types/types";
@@ -14,7 +14,7 @@ export type AbiFunction = {
     generate: (
         ctx: WriterContext,
         args: readonly TypeRef[],
-        resolved: readonly AstExpression[],
+        resolved: readonly Ast.Expression[],
         loc: SrcInfo,
     ) => string;
 };

--- a/src/abi/map.ts
+++ b/src/abi/map.ts
@@ -8,7 +8,7 @@ import { writeExpression } from "../generator/writers/writeExpression";
 import { throwCompilationError } from "../error/errors";
 import { getType } from "../types/resolveDescriptors";
 import type { AbiFunction } from "./AbiFunction";
-import type { AstExpression } from "../ast/ast";
+import type * as Ast from "../ast/ast";
 import { isAssignable } from "../types/subtyping";
 
 // Helper functions to avoid redundancy
@@ -149,7 +149,7 @@ export const MapFunctions: ReadonlyMap<string, AbiFunction> = new Map([
             generate(
                 ctx: WriterContext,
                 args: readonly (TypeRef | undefined)[],
-                exprs: readonly AstExpression[],
+                exprs: readonly Ast.Expression[],
                 ref: SrcInfo,
             ) {
                 checkArgumentsLength(args, 3, "set expects two arguments", ref);
@@ -223,7 +223,7 @@ export const MapFunctions: ReadonlyMap<string, AbiFunction> = new Map([
             generate(
                 ctx: WriterContext,
                 args: readonly (TypeRef | undefined)[],
-                exprs: readonly AstExpression[],
+                exprs: readonly Ast.Expression[],
                 ref: SrcInfo,
             ) {
                 checkArgumentsLength(args, 2, "get expects one argument", ref);
@@ -309,7 +309,7 @@ export const MapFunctions: ReadonlyMap<string, AbiFunction> = new Map([
             generate(
                 ctx: WriterContext,
                 args: readonly (TypeRef | undefined)[],
-                exprs: readonly AstExpression[],
+                exprs: readonly Ast.Expression[],
                 ref: SrcInfo,
             ) {
                 checkArgumentsLength(args, 2, "del expects one argument", ref);
@@ -359,7 +359,7 @@ export const MapFunctions: ReadonlyMap<string, AbiFunction> = new Map([
             generate(
                 ctx: WriterContext,
                 args: readonly (TypeRef | undefined)[],
-                exprs: readonly AstExpression[],
+                exprs: readonly Ast.Expression[],
                 ref: SrcInfo,
             ) {
                 checkArgumentsLength(
@@ -400,7 +400,7 @@ export const MapFunctions: ReadonlyMap<string, AbiFunction> = new Map([
             generate(
                 ctx: WriterContext,
                 args: readonly (TypeRef | undefined)[],
-                exprs: readonly AstExpression[],
+                exprs: readonly Ast.Expression[],
                 ref: SrcInfo,
             ) {
                 checkArgumentsLength(
@@ -443,7 +443,7 @@ export const MapFunctions: ReadonlyMap<string, AbiFunction> = new Map([
             generate(
                 ctx: WriterContext,
                 args: readonly (TypeRef | undefined)[],
-                exprs: readonly AstExpression[],
+                exprs: readonly Ast.Expression[],
                 ref: SrcInfo,
             ) {
                 checkArgumentsLength(
@@ -506,7 +506,7 @@ export const MapFunctions: ReadonlyMap<string, AbiFunction> = new Map([
             generate(
                 ctx: WriterContext,
                 args: readonly (TypeRef | undefined)[],
-                exprs: readonly AstExpression[],
+                exprs: readonly Ast.Expression[],
                 ref: SrcInfo,
             ) {
                 checkArgumentsLength(
@@ -578,7 +578,7 @@ export const MapFunctions: ReadonlyMap<string, AbiFunction> = new Map([
             generate(
                 ctx: WriterContext,
                 args: readonly (TypeRef | undefined)[],
-                exprs: readonly AstExpression[],
+                exprs: readonly Ast.Expression[],
                 ref: SrcInfo,
             ) {
                 checkArgumentsLength(
@@ -664,7 +664,7 @@ export const MapFunctions: ReadonlyMap<string, AbiFunction> = new Map([
             generate(
                 ctx: WriterContext,
                 args: readonly (TypeRef | undefined)[],
-                exprs: readonly AstExpression[],
+                exprs: readonly Ast.Expression[],
                 ref: SrcInfo,
             ) {
                 checkArgumentsLength(

--- a/src/ast/ast-constants.ts
+++ b/src/ast/ast-constants.ts
@@ -1,15 +1,8 @@
 import { keys } from "../utils/tricks";
-import type {
-    AstAugmentedAssignOperation,
-    AstBinaryOperation,
-    AstFunctionAttributeName,
-    AstNumberBase,
-    AstUnaryOperation,
-    ImportType,
-} from "./ast";
+import type * as Ast from "./ast";
 
 const augmentedAssignOperationsRecord: Record<
-    AstAugmentedAssignOperation,
+    Ast.AugmentedAssignOperation,
     true
 > = {
     "+": true,
@@ -30,7 +23,7 @@ export const astAugmentedAssignOperations = Object.freeze(
     keys(augmentedAssignOperationsRecord),
 );
 
-const binaryOperationsRecord: Record<AstBinaryOperation, true> = {
+const binaryOperationsRecord: Record<Ast.BinaryOperation, true> = {
     "+": true,
     "-": true,
     "*": true,
@@ -53,7 +46,7 @@ const binaryOperationsRecord: Record<AstBinaryOperation, true> = {
 
 export const astBinaryOperations = Object.freeze(keys(binaryOperationsRecord));
 
-const unaryOperationsRecord: Record<AstUnaryOperation, true> = {
+const unaryOperationsRecord: Record<Ast.UnaryOperation, true> = {
     "+": true,
     "-": true,
     "!": true,
@@ -63,7 +56,7 @@ const unaryOperationsRecord: Record<AstUnaryOperation, true> = {
 
 export const astUnaryOperations = Object.freeze(keys(unaryOperationsRecord));
 
-const numberBasesRecord: Record<AstNumberBase, true> = {
+const numberBasesRecord: Record<Ast.NumberBase, true> = {
     2: true,
     8: true,
     10: true,
@@ -74,7 +67,7 @@ export const astNumberBases = Object.freeze(
     keys(numberBasesRecord).map(Number),
 );
 
-const importTypesRecord: Record<ImportType, true> = {
+const importTypesRecord: Record<Ast.ImportType, true> = {
     stdlib: true,
     relative: true,
 };
@@ -93,7 +86,7 @@ export const astConstantAttributeNames = Object.freeze(
     keys(constantAttributeNamesRecord),
 );
 
-const functionAttributeNamesRecord: Record<AstFunctionAttributeName, true> = {
+const functionAttributeNamesRecord: Record<Ast.FunctionAttributeName, true> = {
     mutates: true,
     extends: true,
     virtual: true,

--- a/src/ast/ast-helpers.ts
+++ b/src/ast/ast-helpers.ts
@@ -1,5 +1,4 @@
-import type * as A from "./ast";
-import type { AstId } from "./ast";
+import type * as Ast from "./ast";
 import { throwInternalCompilerError } from "../error/errors";
 import { dummySrcInfo } from "../grammar";
 
@@ -9,7 +8,7 @@ import { dummySrcInfo } from "../grammar";
  * @param path A path expression to check.
  * @returns An array of identifiers or null if the input expression is not a path expression.
  */
-export function tryExtractPath(path: A.AstExpression): A.AstId[] | null {
+export function tryExtractPath(path: Ast.Expression): Ast.Id[] | null {
     switch (path.kind) {
         case "id":
             return [path];
@@ -29,10 +28,10 @@ type DistributiveOmit<T, K extends keyof any> = T extends any
 
 export const getAstFactory = () => {
     let nextId = 1;
-    function createNode(src: DistributiveOmit<A.AstNode, "id">): A.AstNode {
+    function createNode(src: DistributiveOmit<Ast.AstNode, "id">): Ast.AstNode {
         return Object.freeze(Object.assign({ id: nextId++ }, src));
     }
-    function cloneNode<T extends A.AstNode>(src: T): T {
+    function cloneNode<T extends Ast.AstNode>(src: T): T {
         const newNode: T = { ...src, id: nextId++ };
         return Object.freeze(newNode);
     }
@@ -44,57 +43,57 @@ export const getAstFactory = () => {
 
 export type FactoryAst = ReturnType<typeof getAstFactory>;
 
-export function idText(ident: A.AstId | A.AstFuncId | A.AstTypeId): string {
+export function idText(ident: Ast.Id | Ast.FuncId | Ast.TypeId): string {
     return ident.text;
 }
 
-export function isInt(ident: A.AstTypeId): boolean {
+export function isInt(ident: Ast.TypeId): boolean {
     return ident.text === "Int";
 }
 
-export function isBool(ident: A.AstTypeId): boolean {
+export function isBool(ident: Ast.TypeId): boolean {
     return ident.text === "Bool";
 }
 
-export function isCell(ident: A.AstTypeId): boolean {
+export function isCell(ident: Ast.TypeId): boolean {
     return ident.text === "Cell";
 }
 
-export function isSlice(ident: A.AstTypeId): boolean {
+export function isSlice(ident: Ast.TypeId): boolean {
     return ident.text === "Slice";
 }
 
-export function isBuilder(ident: A.AstTypeId): boolean {
+export function isBuilder(ident: Ast.TypeId): boolean {
     return ident.text === "Builder";
 }
 
-export function isAddress(ident: A.AstTypeId): boolean {
+export function isAddress(ident: Ast.TypeId): boolean {
     return ident.text === "Address";
 }
 
-export function isString(ident: A.AstTypeId): boolean {
+export function isString(ident: Ast.TypeId): boolean {
     return ident.text === "String";
 }
 
-export function isStringBuilder(ident: A.AstTypeId): boolean {
+export function isStringBuilder(ident: Ast.TypeId): boolean {
     return ident.text === "StringBuilder";
 }
 
-export function isSelfId(ident: A.AstId): boolean {
+export function isSelfId(ident: Ast.Id): boolean {
     return ident.text === "self";
 }
 
-export function isWildcard(ident: A.AstId): boolean {
+export function isWildcard(ident: Ast.Id): boolean {
     return ident.text === "_";
 }
 
-export function isRequire(ident: A.AstId): boolean {
+export function isRequire(ident: Ast.Id): boolean {
     return ident.text === "require";
 }
 
 export function eqNames(
-    left: A.AstId | A.AstTypeId | string,
-    right: A.AstId | A.AstTypeId | string,
+    left: Ast.Id | Ast.TypeId | string,
+    right: Ast.Id | Ast.TypeId | string,
 ): boolean {
     if (typeof left === "string") {
         if (typeof right === "string") {
@@ -109,7 +108,7 @@ export function eqNames(
     }
 }
 
-export function idOfText(text: string): A.AstId {
+export function idOfText(text: string): Ast.Id {
     return {
         kind: "id",
         text,
@@ -118,7 +117,7 @@ export function idOfText(text: string): A.AstId {
     };
 }
 
-export function astNumToString(n: A.AstNumber): string {
+export function astNumToString(n: Ast.Number): string {
     switch (n.base) {
         case 2:
             return `0b${n.value.toString(n.base)}`;
@@ -136,8 +135,8 @@ export function astNumToString(n: A.AstNumber): string {
 // For example, two struct instances are equal if they have the same
 // type and same fields in the same order.
 export function eqExpressions(
-    ast1: A.AstExpression,
-    ast2: A.AstExpression,
+    ast1: Ast.Expression,
+    ast2: Ast.Expression,
 ): boolean {
     if (ast1.kind !== ast2.kind) {
         return false;
@@ -147,98 +146,98 @@ export function eqExpressions(
         case "null":
             return true;
         case "boolean":
-            return ast1.value === (ast2 as A.AstBoolean).value;
+            return ast1.value === (ast2 as Ast.Boolean).value;
         case "number":
-            return ast1.value === (ast2 as A.AstNumber).value;
+            return ast1.value === (ast2 as Ast.Number).value;
         case "string":
-            return ast1.value === (ast2 as A.AstString).value;
+            return ast1.value === (ast2 as Ast.String).value;
         case "id":
-            return eqNames(ast1, ast2 as A.AstId);
+            return eqNames(ast1, ast2 as Ast.Id);
         case "address":
-            return ast1.value.equals((ast2 as A.AstAddress).value);
+            return ast1.value.equals((ast2 as Ast.Address).value);
         case "cell":
-            return ast1.value.equals((ast2 as A.AstCell).value);
+            return ast1.value.equals((ast2 as Ast.Cell).value);
         case "slice":
             return ast1.value
                 .asCell()
-                .equals((ast2 as A.AstSlice).value.asCell());
+                .equals((ast2 as Ast.Slice).value.asCell());
         case "simplified_string":
-            return ast1.value === (ast2 as A.AstSimplifiedString).value;
+            return ast1.value === (ast2 as Ast.SimplifiedString).value;
         case "struct_value":
             return (
-                eqNames(ast1.type, (ast2 as A.AstStructValue).type) &&
+                eqNames(ast1.type, (ast2 as Ast.StructValue).type) &&
                 eqArrays(
                     ast1.args,
-                    (ast2 as A.AstStructValue).args,
+                    (ast2 as Ast.StructValue).args,
                     eqFieldValues,
                 )
             );
         case "method_call":
             return (
-                eqNames(ast1.method, (ast2 as A.AstMethodCall).method) &&
-                eqExpressions(ast1.self, (ast2 as A.AstMethodCall).self) &&
+                eqNames(ast1.method, (ast2 as Ast.MethodCall).method) &&
+                eqExpressions(ast1.self, (ast2 as Ast.MethodCall).self) &&
                 eqArrays(
                     ast1.args,
-                    (ast2 as A.AstMethodCall).args,
+                    (ast2 as Ast.MethodCall).args,
                     eqExpressions,
                 )
             );
         case "init_of":
             return (
-                eqNames(ast1.contract, (ast2 as A.AstInitOf).contract) &&
-                eqArrays(ast1.args, (ast2 as A.AstInitOf).args, eqExpressions)
+                eqNames(ast1.contract, (ast2 as Ast.InitOf).contract) &&
+                eqArrays(ast1.args, (ast2 as Ast.InitOf).args, eqExpressions)
             );
         case "code_of":
-            return eqNames(ast1.contract, (ast2 as A.AstCodeOf).contract);
+            return eqNames(ast1.contract, (ast2 as Ast.CodeOf).contract);
         case "op_unary":
             return (
-                ast1.op === (ast2 as A.AstOpUnary).op &&
-                eqExpressions(ast1.operand, (ast2 as A.AstOpUnary).operand)
+                ast1.op === (ast2 as Ast.OpUnary).op &&
+                eqExpressions(ast1.operand, (ast2 as Ast.OpUnary).operand)
             );
         case "op_binary":
             return (
-                ast1.op === (ast2 as A.AstOpBinary).op &&
-                eqExpressions(ast1.left, (ast2 as A.AstOpBinary).left) &&
-                eqExpressions(ast1.right, (ast2 as A.AstOpBinary).right)
+                ast1.op === (ast2 as Ast.OpBinary).op &&
+                eqExpressions(ast1.left, (ast2 as Ast.OpBinary).left) &&
+                eqExpressions(ast1.right, (ast2 as Ast.OpBinary).right)
             );
         case "conditional":
             return (
                 eqExpressions(
                     ast1.condition,
-                    (ast2 as A.AstConditional).condition,
+                    (ast2 as Ast.Conditional).condition,
                 ) &&
                 eqExpressions(
                     ast1.thenBranch,
-                    (ast2 as A.AstConditional).thenBranch,
+                    (ast2 as Ast.Conditional).thenBranch,
                 ) &&
                 eqExpressions(
                     ast1.elseBranch,
-                    (ast2 as A.AstConditional).elseBranch,
+                    (ast2 as Ast.Conditional).elseBranch,
                 )
             );
         case "struct_instance":
             return (
-                eqNames(ast1.type, (ast2 as A.AstStructInstance).type) &&
+                eqNames(ast1.type, (ast2 as Ast.StructInstance).type) &&
                 eqArrays(
                     ast1.args,
-                    (ast2 as A.AstStructInstance).args,
+                    (ast2 as Ast.StructInstance).args,
                     eqFieldInitializers,
                 )
             );
         case "field_access":
             return (
-                eqNames(ast1.field, (ast2 as A.AstFieldAccess).field) &&
+                eqNames(ast1.field, (ast2 as Ast.FieldAccess).field) &&
                 eqExpressions(
                     ast1.aggregate,
-                    (ast2 as A.AstFieldAccess).aggregate,
+                    (ast2 as Ast.FieldAccess).aggregate,
                 )
             );
         case "static_call":
             return (
-                eqNames(ast1.function, (ast2 as A.AstStaticCall).function) &&
+                eqNames(ast1.function, (ast2 as Ast.StaticCall).function) &&
                 eqArrays(
                     ast1.args,
-                    (ast2 as A.AstStaticCall).args,
+                    (ast2 as Ast.StaticCall).args,
                     eqExpressions,
                 )
             );
@@ -248,8 +247,8 @@ export function eqExpressions(
 }
 
 function eqFieldInitializers(
-    arg1: A.AstStructFieldInitializer,
-    arg2: A.AstStructFieldInitializer,
+    arg1: Ast.AstStructFieldInitializer,
+    arg2: Ast.AstStructFieldInitializer,
 ): boolean {
     return (
         eqNames(arg1.field, arg2.field) &&
@@ -258,8 +257,8 @@ function eqFieldInitializers(
 }
 
 function eqFieldValues(
-    arg1: A.AstStructFieldValue,
-    arg2: A.AstStructFieldValue,
+    arg1: Ast.StructFieldValue,
+    arg2: Ast.StructFieldValue,
 ): boolean {
     return (
         eqNames(arg1.field, arg2.field) &&
@@ -362,7 +361,7 @@ function isB(d: A): d is B {
 }
 */
 
-export function isLiteral(ast: A.AstExpression): ast is A.AstLiteral {
+export function isLiteral(ast: Ast.Expression): ast is Ast.Literal {
     return checkLiteral(
         ast,
         () => true,
@@ -371,9 +370,9 @@ export function isLiteral(ast: A.AstExpression): ast is A.AstLiteral {
 }
 
 function checkLiteral<T>(
-    ast: A.AstExpression,
-    t: (node: A.AstLiteral) => T,
-    f: (node: Exclude<A.AstExpression, A.AstLiteral>) => T,
+    ast: Ast.Expression,
+    t: (node: Ast.Literal) => T,
+    f: (node: Exclude<Ast.Expression, Ast.Literal>) => T,
 ): T {
     switch (ast.kind) {
         case "null":
@@ -404,7 +403,7 @@ function checkLiteral<T>(
     }
 }
 
-export const selfId: AstId = {
+export const selfId: Ast.Id = {
     kind: "id",
     text: "self",
     id: 0,

--- a/src/ast/ast-helpers.ts
+++ b/src/ast/ast-helpers.ts
@@ -247,8 +247,8 @@ export function eqExpressions(
 }
 
 function eqFieldInitializers(
-    arg1: Ast.AstStructFieldInitializer,
-    arg2: Ast.AstStructFieldInitializer,
+    arg1: Ast.StructFieldInitializer,
+    arg2: Ast.StructFieldInitializer,
 ): boolean {
     return (
         eqNames(arg1.field, arg2.field) &&

--- a/src/ast/ast-printer.ts
+++ b/src/ast/ast-printer.ts
@@ -171,7 +171,7 @@ export const ppExprArgs = (args: readonly Ast.Expression[]) =>
     args.map((arg) => ppAstExpression(arg)).join(", ");
 
 export const ppAstStructFieldInit = (
-    param: Ast.AstStructFieldInitializer,
+    param: Ast.StructFieldInitializer,
 ): string => `${ppAstId(param.field)}: ${ppAstExpression(param.initializer)}`;
 export const ppAstStructFieldValue = (param: Ast.StructFieldValue): string =>
     `${ppAstId(param.field)}: ${ppAstExpression(param.initializer)}`;

--- a/src/ast/ast-printer.ts
+++ b/src/ast/ast-printer.ts
@@ -1,4 +1,4 @@
-import type * as A from "./ast";
+import type * as Ast from "./ast";
 import { groupBy, intercalate, isUndefined } from "../utils/array";
 import { makeVisitor } from "../utils/tricks";
 import { astNumToString, idText } from "./ast-helpers";
@@ -12,8 +12,8 @@ import { throwInternalCompilerError } from "../error/errors";
 export const ppAstTypeId = idText;
 
 export const ppAstTypeIdWithStorage = (
-    type: A.AstTypeId,
-    storageType: A.AstId | undefined,
+    type: Ast.TypeId,
+    storageType: Ast.Id | undefined,
 ): string => {
     const alias = storageType ? ` as ${ppAstId(storageType)}` : "";
     return `${ppAstTypeId(type)}${alias}`;
@@ -24,7 +24,7 @@ export const ppAstMapType = ({
     keyStorageType,
     valueType,
     valueStorageType,
-}: A.AstMapType): string => {
+}: Ast.MapType): string => {
     const key = ppAstTypeIdWithStorage(keyType, keyStorageType);
     const value = ppAstTypeIdWithStorage(valueType, valueStorageType);
     return `map<${key}, ${value}>`;
@@ -32,12 +32,12 @@ export const ppAstMapType = ({
 
 export const ppAstBouncedMessageType = ({
     messageType,
-}: A.AstBouncedMessageType): string => `bounced<${ppAstTypeId(messageType)}>`;
+}: Ast.BouncedMessageType): string => `bounced<${ppAstTypeId(messageType)}>`;
 
-export const ppAstOptionalType = ({ typeArg }: A.AstOptionalType): string =>
+export const ppAstOptionalType = ({ typeArg }: Ast.OptionalType): string =>
     `${ppAstType(typeArg)}?`;
 
-export const ppAstType = makeVisitor<A.AstType>()({
+export const ppAstType = makeVisitor<Ast.Type>()({
     type_id: ppAstTypeId,
     map_type: ppAstMapType,
     bounced_message_type: ppAstBouncedMessageType,
@@ -48,7 +48,7 @@ export const ppAstType = makeVisitor<A.AstType>()({
 // Expressions
 //
 
-export const unaryOperatorType: Record<A.AstUnaryOperation, "post" | "pre"> = {
+export const unaryOperatorType: Record<Ast.UnaryOperation, "post" | "pre"> = {
     "+": "pre",
     "-": "pre",
     "!": "pre",
@@ -57,7 +57,7 @@ export const unaryOperatorType: Record<A.AstUnaryOperation, "post" | "pre"> = {
     "!!": "post",
 };
 
-export const checkPostfix = (operator: A.AstUnaryOperation) =>
+export const checkPostfix = (operator: Ast.UnaryOperation) =>
     unaryOperatorType[operator] === "post";
 
 /**
@@ -110,7 +110,7 @@ export const lowestPrecedence = makePrecedence(0);
 export const conditionalPrecedence = makePrecedence(20);
 
 export const binaryPrecedence: Readonly<
-    Record<A.AstBinaryOperation, Precedence>
+    Record<Ast.BinaryOperation, Precedence>
 > = {
     "||": makePrecedence(30),
 
@@ -167,45 +167,44 @@ export const ppLeaf =
     () =>
         printer(node);
 
-export const ppExprArgs = (args: readonly A.AstExpression[]) =>
+export const ppExprArgs = (args: readonly Ast.Expression[]) =>
     args.map((arg) => ppAstExpression(arg)).join(", ");
 
 export const ppAstStructFieldInit = (
-    param: A.AstStructFieldInitializer,
+    param: Ast.AstStructFieldInitializer,
 ): string => `${ppAstId(param.field)}: ${ppAstExpression(param.initializer)}`;
-export const ppAstStructFieldValue = (param: A.AstStructFieldValue): string =>
+export const ppAstStructFieldValue = (param: Ast.StructFieldValue): string =>
     `${ppAstId(param.field)}: ${ppAstExpression(param.initializer)}`;
 
-export const ppAstStructInstance = ({ type, args }: A.AstStructInstance) =>
+export const ppAstStructInstance = ({ type, args }: Ast.StructInstance) =>
     `${ppAstId(type)}{${args.map((x) => ppAstStructFieldInit(x)).join(", ")}}`;
-export const ppAstStructValue = ({ type, args }: A.AstStructValue) =>
+export const ppAstStructValue = ({ type, args }: Ast.StructValue) =>
     `${ppAstId(type)}{${args.map((x) => ppAstStructFieldValue(x)).join(", ")}}`;
 
-export const ppAstInitOf = ({ contract, args }: A.AstInitOf) =>
+export const ppAstInitOf = ({ contract, args }: Ast.InitOf) =>
     `initOf ${ppAstId(contract)}(${ppExprArgs(args)})`;
 
-export const ppAstCodeOf = ({ contract }: A.AstCodeOf) =>
+export const ppAstCodeOf = ({ contract }: Ast.CodeOf) =>
     `codeOf ${ppAstId(contract)}`;
 
 export const ppAstNumber = astNumToString;
-export const ppAstBoolean = ({ value }: A.AstBoolean) => value.toString();
-export const ppAstId = ({ text }: A.AstId) => text;
-export const ppAstNull = (_expr: A.AstNull) => "null";
-export const ppAstString = ({ value }: A.AstString) => `"${value}"`;
-export const ppAstSimplifiedString = ({ value }: A.AstSimplifiedString) =>
+export const ppAstBoolean = ({ value }: Ast.Boolean) => value.toString();
+export const ppAstId = ({ text }: Ast.Id) => text;
+export const ppAstNull = (_expr: Ast.Null) => "null";
+export const ppAstString = ({ value }: Ast.String) => `"${value}"`;
+export const ppAstSimplifiedString = ({ value }: Ast.SimplifiedString) =>
     JSON.stringify(value);
-export const ppAstAddress = ({ value }: A.AstAddress) =>
+export const ppAstAddress = ({ value }: Ast.Address) =>
     `addr("${value.toRawString()}")`;
-export const ppAstCell = ({ value }: A.AstCell) =>
-    `cell("${value.toString()}")`;
-export const ppAstSlice = ({ value }: A.AstSlice) =>
+export const ppAstCell = ({ value }: Ast.Cell) => `cell("${value.toString()}")`;
+export const ppAstSlice = ({ value }: Ast.Slice) =>
     `slice("${value.toString()}")`;
 
-export const ppAstStaticCall = ({ function: func, args }: A.AstStaticCall) => {
+export const ppAstStaticCall = ({ function: func, args }: Ast.StaticCall) => {
     return `${ppAstId(func)}(${ppExprArgs(args)})`;
 };
 
-export const ppAstMethodCall: ExprPrinter<A.AstMethodCall> =
+export const ppAstMethodCall: ExprPrinter<Ast.MethodCall> =
     ({ self: object, method, args }) =>
     (position) => {
         const { brace, self } = postfixPrecedence;
@@ -215,7 +214,7 @@ export const ppAstMethodCall: ExprPrinter<A.AstMethodCall> =
         );
     };
 
-export const ppAstFieldAccess: ExprPrinter<A.AstFieldAccess> =
+export const ppAstFieldAccess: ExprPrinter<Ast.FieldAccess> =
     ({ aggregate, field }) =>
     (position) => {
         const { brace, self } = postfixPrecedence;
@@ -225,7 +224,7 @@ export const ppAstFieldAccess: ExprPrinter<A.AstFieldAccess> =
         );
     };
 
-export const ppAstOpUnary: ExprPrinter<A.AstOpUnary> =
+export const ppAstOpUnary: ExprPrinter<Ast.OpUnary> =
     ({ op, operand }) =>
     (position) => {
         const isPostfix = checkPostfix(op);
@@ -236,7 +235,7 @@ export const ppAstOpUnary: ExprPrinter<A.AstOpUnary> =
         return brace(position, isPostfix ? `${code}${op}` : `${op}${code}`);
     };
 
-export const ppAstOpBinary: ExprPrinter<A.AstOpBinary> =
+export const ppAstOpBinary: ExprPrinter<Ast.OpBinary> =
     ({ left, op, right }) =>
     (position) => {
         const { brace, self, child } = binaryPrecedence[op];
@@ -245,7 +244,7 @@ export const ppAstOpBinary: ExprPrinter<A.AstOpBinary> =
         return brace(position, `${leftCode} ${op} ${rightCode}`);
     };
 
-export const ppAstConditional: ExprPrinter<A.AstConditional> =
+export const ppAstConditional: ExprPrinter<Ast.Conditional> =
     ({ condition, thenBranch, elseBranch }) =>
     (position) => {
         const { brace, self, child } = conditionalPrecedence;
@@ -255,7 +254,7 @@ export const ppAstConditional: ExprPrinter<A.AstConditional> =
         return brace(position, `${conditionCode} ? ${thenCode} : ${elseCode}`);
     };
 
-export const ppAstExpressionNested = makeVisitor<A.AstExpression>()({
+export const ppAstExpressionNested = makeVisitor<Ast.Expression>()({
     struct_instance: ppLeaf(ppAstStructInstance),
     struct_value: ppLeaf(ppAstStructValue),
     number: ppLeaf(ppAstNumber),
@@ -281,7 +280,7 @@ export const ppAstExpressionNested = makeVisitor<A.AstExpression>()({
     conditional: ppAstConditional,
 });
 
-export const ppAstExpression = (expr: A.AstExpression): string => {
+export const ppAstExpression = (expr: Ast.Expression): string => {
     return ppAstExpressionNested(expr)(lowestPrecedence.child);
 };
 
@@ -423,7 +422,7 @@ const createContext = (spaces: number): Context<ContextModel> => {
  */
 type Printer<T> = (item: T) => <U>(ctx: Context<U>) => U;
 
-export const ppAstModule: Printer<A.AstModule> =
+export const ppAstModule: Printer<Ast.Module> =
     ({ imports, items }) =>
     (c) => {
         const itemsCode = c.grouped({
@@ -441,7 +440,7 @@ export const ppAstModule: Printer<A.AstModule> =
         ]);
     };
 
-export const ppAstStruct: Printer<A.AstStructDecl> =
+export const ppAstStruct: Printer<Ast.StructDecl> =
     ({ name, fields }) =>
     (c) =>
         c.concat([
@@ -449,7 +448,7 @@ export const ppAstStruct: Printer<A.AstStructDecl> =
             c.braced(c.list(fields, ppAstFieldDecl)),
         ]);
 
-export const ppAstContract: Printer<A.AstContract> =
+export const ppAstContract: Printer<Ast.Contract> =
     ({ name, traits, declarations, attributes }) =>
     (c) => {
         const attrsCode = attributes
@@ -476,19 +475,19 @@ export const ppAstContract: Printer<A.AstContract> =
         ]);
     };
 
-export const ppAstPrimitiveTypeDecl: Printer<A.AstPrimitiveTypeDecl> =
+export const ppAstPrimitiveTypeDecl: Printer<Ast.PrimitiveTypeDecl> =
     ({ name }) =>
     (c) =>
         c.row(`primitive ${ppAstId(name)};`);
 
-export const ppAstFunctionDef: Printer<A.AstFunctionDef> = (node) => (c) =>
+export const ppAstFunctionDef: Printer<Ast.FunctionDef> = (node) => (c) =>
     c.concat([
         c.row(ppAstFunctionSignature(node)),
         c.row(" "),
         ppStatementBlock(node.statements)(c),
     ]);
 
-export const ppAsmShuffle = ({ args, ret }: A.AstAsmShuffle): string => {
+export const ppAsmShuffle = ({ args, ret }: Ast.AsmShuffle): string => {
     if (args.length === 0 && ret.length === 0) {
         return "";
     }
@@ -500,16 +499,15 @@ export const ppAsmShuffle = ({ args, ret }: A.AstAsmShuffle): string => {
     return `(${argsCode} -> ${retCode})`;
 };
 
-export const ppAstAsmFunctionDef: Printer<A.AstAsmFunctionDef> =
-    (node) => (c) =>
-        c.concat([
-            c.row(
-                `asm${ppAsmShuffle(node.shuffle)} ${ppAstFunctionSignature(node)} `,
-            ),
-            ppAsmInstructionsBlock(node.instructions)(c),
-        ]);
+export const ppAstAsmFunctionDef: Printer<Ast.AsmFunctionDef> = (node) => (c) =>
+    c.concat([
+        c.row(
+            `asm${ppAsmShuffle(node.shuffle)} ${ppAstFunctionSignature(node)} `,
+        ),
+        ppAsmInstructionsBlock(node.instructions)(c),
+    ]);
 
-export const ppAstNativeFunction: Printer<A.AstNativeFunctionDecl> =
+export const ppAstNativeFunction: Printer<Ast.NativeFunctionDecl> =
     ({ name, nativeName, params, return: retTy, attributes }) =>
     (c) => {
         const attrs = attributes.map(({ type }) => type + " ").join("");
@@ -523,7 +521,7 @@ export const ppAstNativeFunction: Printer<A.AstNativeFunctionDecl> =
         ]);
     };
 
-export const ppAstTrait: Printer<A.AstTrait> =
+export const ppAstTrait: Printer<Ast.Trait> =
     ({ name, traits, attributes, declarations }) =>
     (c) => {
         const attrsCode = attributes
@@ -550,7 +548,7 @@ export const ppAstTrait: Printer<A.AstTrait> =
         ]);
     };
 
-export const ppAstConstant: Printer<A.AstConstantDef> =
+export const ppAstConstant: Printer<Ast.ConstantDef> =
     ({ attributes, initializer, name, type }) =>
     (c) => {
         const attrsCode = attributes.map(({ type }) => type + " ").join("");
@@ -559,7 +557,7 @@ export const ppAstConstant: Printer<A.AstConstantDef> =
         );
     };
 
-export const ppAstMessage: Printer<A.AstMessageDecl> =
+export const ppAstMessage: Printer<Ast.MessageDecl> =
     ({ name, opcode, fields }) =>
     (c) => {
         const prefixCode =
@@ -571,8 +569,8 @@ export const ppAstMessage: Printer<A.AstMessageDecl> =
         ]);
     };
 
-export const ppModuleItem: Printer<A.AstModuleItem> =
-    makeVisitor<A.AstModuleItem>()({
+export const ppModuleItem: Printer<Ast.ModuleItem> =
+    makeVisitor<Ast.ModuleItem>()({
         struct_decl: ppAstStruct,
         contract: ppAstContract,
         primitive_type_decl: ppAstPrimitiveTypeDecl,
@@ -584,7 +582,7 @@ export const ppModuleItem: Printer<A.AstModuleItem> =
         message_decl: ppAstMessage,
     });
 
-export const ppAstFieldDecl: Printer<A.AstFieldDecl> =
+export const ppAstFieldDecl: Printer<Ast.FieldDecl> =
     ({ type, initializer, as, name }) =>
     (c) => {
         const asAlias = as ? ` as ${ppAstId(as)}` : "";
@@ -596,7 +594,7 @@ export const ppAstFieldDecl: Printer<A.AstFieldDecl> =
         );
     };
 
-export const ppAstReceiver: Printer<A.AstReceiver> =
+export const ppAstReceiver: Printer<Ast.Receiver> =
     ({ selector, statements }) =>
     (c) =>
         c.concat([
@@ -604,18 +602,18 @@ export const ppAstReceiver: Printer<A.AstReceiver> =
             ppStatementBlock(statements)(c),
         ]);
 
-export const ppAstFunctionDecl: Printer<A.AstFunctionDecl> = (f) => (c) =>
+export const ppAstFunctionDecl: Printer<Ast.FunctionDecl> = (f) => (c) =>
     c.row(`${ppAstFunctionSignature(f)};`);
 
-export const ppAstConstDecl: Printer<A.AstConstantDecl> =
+export const ppAstConstDecl: Printer<Ast.ConstantDecl> =
     ({ attributes, name, type }) =>
     (c) => {
         const attrsCode = attributes.map(({ type }) => type + " ").join("");
         return c.row(`${attrsCode}const ${ppAstId(name)}: ${ppAstType(type)};`);
     };
 
-export const ppTraitBody: Printer<A.AstTraitDeclaration> =
-    makeVisitor<A.AstTraitDeclaration>()({
+export const ppTraitBody: Printer<Ast.TraitDeclaration> =
+    makeVisitor<Ast.TraitDeclaration>()({
         function_def: ppAstFunctionDef,
         asm_function_def: ppAstAsmFunctionDef,
         constant_def: ppAstConstant,
@@ -625,7 +623,7 @@ export const ppTraitBody: Printer<A.AstTraitDeclaration> =
         constant_decl: ppAstConstDecl,
     });
 
-export const ppAstInitFunction: Printer<A.AstContractInit> =
+export const ppAstInitFunction: Printer<Ast.ContractInit> =
     ({ params, statements }) =>
     (c) => {
         const argsCode = params
@@ -640,8 +638,8 @@ export const ppAstInitFunction: Printer<A.AstContractInit> =
         ]);
     };
 
-export const ppContractBody: Printer<A.AstContractDeclaration> =
-    makeVisitor<A.AstContractDeclaration>()({
+export const ppContractBody: Printer<Ast.ContractDeclaration> =
+    makeVisitor<Ast.ContractDeclaration>()({
         field_decl: ppAstFieldDecl,
         function_def: ppAstFunctionDef,
         asm_function_def: ppAstAsmFunctionDef,
@@ -650,7 +648,7 @@ export const ppContractBody: Printer<A.AstContractDeclaration> =
         constant_def: ppAstConstant,
     });
 
-export const ppAstImport: Printer<A.AstImport> =
+export const ppAstImport: Printer<Ast.Import> =
     ({ importPath: { path, type, language } }) =>
     (c) => {
         if (type === "relative") {
@@ -671,7 +669,7 @@ export const ppAstFunctionSignature = ({
     attributes,
     return: retTy,
     params,
-}: A.AstFunctionDef | A.AstAsmFunctionDef | A.AstFunctionDecl): string => {
+}: Ast.FunctionDef | Ast.AsmFunctionDef | Ast.FunctionDecl): string => {
     const argsCode = params
         .map(({ name, type }) => `${ppAstId(name)}: ${ppAstType(type)}`)
         .join(", ");
@@ -682,9 +680,7 @@ export const ppAstFunctionSignature = ({
     return `${attrsCode}fun ${ppAstId(name)}(${argsCode})${returnType}`;
 };
 
-export const ppAstFunctionAttribute = (
-    attr: A.AstFunctionAttribute,
-): string => {
+export const ppAstFunctionAttribute = (attr: Ast.FunctionAttribute): string => {
     if (attr.type === "get" && attr.methodId !== undefined) {
         return `get(${ppAstExpression(attr.methodId)})`;
     } else {
@@ -694,33 +690,33 @@ export const ppAstFunctionAttribute = (
 
 const wrap = (prefix: string, body: string) => `${prefix}(${body})`;
 
-export const ppReceiverSubKind = makeVisitor<A.AstReceiverSubKind>()({
+export const ppReceiverSubKind = makeVisitor<Ast.ReceiverSubKind>()({
     simple: ({ param }) => typedParameter(param),
     fallback: () => "",
     comment: ({ comment }) => `"${comment.value}"`,
 });
 
-export const ppAstReceiverKind = makeVisitor<A.AstReceiverKind>()({
+export const ppAstReceiverKind = makeVisitor<Ast.ReceiverKind>()({
     bounce: ({ param }) => wrap("bounced", typedParameter(param)),
     internal: ({ subKind }) => wrap("receive", ppReceiverSubKind(subKind)),
     external: ({ subKind }) => wrap("external", ppReceiverSubKind(subKind)),
 });
 
-export const ppAstFuncId = (func: A.AstFuncId): string => func.text;
+export const ppAstFuncId = (func: Ast.FuncId): string => func.text;
 
 //
 // Statements
 //
 
-export const ppStatementBlock: Printer<readonly A.AstStatement[]> =
+export const ppStatementBlock: Printer<readonly Ast.Statement[]> =
     (stmts) => (c) =>
         c.braced(stmts.length === 0 ? [] : c.list(stmts, ppAstStatement));
 
-export const ppAsmInstructionsBlock: Printer<readonly A.AstAsmInstruction[]> =
+export const ppAsmInstructionsBlock: Printer<readonly Ast.AsmInstruction[]> =
     (instructions) => (c) =>
         c.braced(instructions.map(c.row));
 
-export const ppAstStatementLet: Printer<A.AstStatementLet> =
+export const ppAstStatementLet: Printer<Ast.StatementLet> =
     ({ type, name, expression }) =>
     (c) => {
         const tyAnnotation = type === undefined ? "" : `: ${ppAstType(type)}`;
@@ -729,23 +725,23 @@ export const ppAstStatementLet: Printer<A.AstStatementLet> =
         );
     };
 
-export const ppAstStatementReturn: Printer<A.AstStatementReturn> =
+export const ppAstStatementReturn: Printer<Ast.StatementReturn> =
     ({ expression }) =>
     (c) =>
         c.row(`return ${expression ? ppAstExpression(expression) : ""};`);
 
-export const ppAstStatementExpression: Printer<A.AstStatementExpression> =
+export const ppAstStatementExpression: Printer<Ast.StatementExpression> =
     ({ expression }) =>
     (c) =>
         c.row(`${ppAstExpression(expression)};`);
 
-export const ppAstStatementAssign: Printer<A.AstStatementAssign> =
+export const ppAstStatementAssign: Printer<Ast.StatementAssign> =
     ({ path, expression }) =>
     (c) =>
         c.row(`${ppAstExpression(path)} = ${ppAstExpression(expression)};`);
 
 export const ppAstStatementAugmentedAssign: Printer<
-    A.AstStatementAugmentedAssign
+    Ast.StatementAugmentedAssign
 > =
     ({ path, op, expression }) =>
     (c) =>
@@ -753,7 +749,7 @@ export const ppAstStatementAugmentedAssign: Printer<
             `${ppAstExpression(path)} ${op}= ${ppAstExpression(expression)};`,
         );
 
-export const ppAstStatementCondition: Printer<A.AstStatementCondition> =
+export const ppAstStatementCondition: Printer<Ast.StatementCondition> =
     ({ condition, trueStatements, falseStatements }) =>
     (c) => {
         if (falseStatements) {
@@ -771,7 +767,7 @@ export const ppAstStatementCondition: Printer<A.AstStatementCondition> =
         }
     };
 
-export const ppAstStatementWhile: Printer<A.AstStatementWhile> =
+export const ppAstStatementWhile: Printer<Ast.StatementWhile> =
     ({ condition, statements }) =>
     (c) =>
         c.concat([
@@ -779,7 +775,7 @@ export const ppAstStatementWhile: Printer<A.AstStatementWhile> =
             ppStatementBlock(statements)(c),
         ]);
 
-export const ppAstStatementRepeat: Printer<A.AstStatementRepeat> =
+export const ppAstStatementRepeat: Printer<Ast.StatementRepeat> =
     ({ iterations, statements }) =>
     (c) =>
         c.concat([
@@ -787,7 +783,7 @@ export const ppAstStatementRepeat: Printer<A.AstStatementRepeat> =
             ppStatementBlock(statements)(c),
         ]);
 
-export const ppAstStatementUntil: Printer<A.AstStatementUntil> =
+export const ppAstStatementUntil: Printer<Ast.StatementUntil> =
     ({ condition, statements }) =>
     (c) =>
         c.concat([
@@ -796,7 +792,7 @@ export const ppAstStatementUntil: Printer<A.AstStatementUntil> =
             c.row(` until (${ppAstExpression(condition)});`),
         ]);
 
-export const ppAstStatementForEach: Printer<A.AstStatementForEach> =
+export const ppAstStatementForEach: Printer<Ast.StatementForEach> =
     ({ keyName, valueName, map, statements }) =>
     (c) =>
         c.concat([
@@ -806,7 +802,7 @@ export const ppAstStatementForEach: Printer<A.AstStatementForEach> =
             ppStatementBlock(statements)(c),
         ]);
 
-export const ppAstStatementTry: Printer<A.AstStatementTry> =
+export const ppAstStatementTry: Printer<Ast.StatementTry> =
     ({ statements, catchBlock }) =>
     (c) => {
         const catchBlocks =
@@ -824,7 +820,7 @@ export const ppAstStatementTry: Printer<A.AstStatementTry> =
         ]);
     };
 
-export const ppAstStatementDestruct: Printer<A.AstStatementDestruct> =
+export const ppAstStatementDestruct: Printer<Ast.StatementDestruct> =
     ({ type, identifiers, ignoreUnspecifiedFields, expression }) =>
     (c) => {
         const ids: string[] = [];
@@ -841,19 +837,19 @@ export const ppAstStatementDestruct: Printer<A.AstStatementDestruct> =
         );
     };
 
-const typedParameter = ({ name, type }: A.AstTypedParameter) =>
+const typedParameter = ({ name, type }: Ast.TypedParameter) =>
     `${ppAstId(name)}: ${ppAstType(type)}`;
 
-export const ppTypedParameter: Printer<A.AstTypedParameter> = (param) => (c) =>
+export const ppTypedParameter: Printer<Ast.TypedParameter> = (param) => (c) =>
     c.row(typedParameter(param));
 
-export const ppAstStatementBlock: Printer<A.AstStatementBlock> =
+export const ppAstStatementBlock: Printer<Ast.StatementBlock> =
     ({ statements }) =>
     (c) =>
         ppStatementBlock(statements)(c);
 
-export const ppAstStatement: Printer<A.AstStatement> =
-    makeVisitor<A.AstStatement>()({
+export const ppAstStatement: Printer<Ast.Statement> =
+    makeVisitor<Ast.Statement>()({
         statement_let: ppAstStatementLet,
         statement_return: ppAstStatementReturn,
         statement_expression: ppAstStatementExpression,
@@ -875,7 +871,7 @@ export const exprNode =
     (c) =>
         c.row(exprPrinter(node));
 
-export const ppAstNode: Printer<A.AstNode> = makeVisitor<A.AstNode>()({
+export const ppAstNode: Printer<Ast.AstNode> = makeVisitor<Ast.AstNode>()({
     op_binary: exprNode(ppAstExpression),
     op_unary: exprNode(ppAstExpression),
     field_access: exprNode(ppAstExpression),
@@ -953,7 +949,7 @@ export const ppAstNode: Printer<A.AstNode> = makeVisitor<A.AstNode>()({
  * @param node The AST node to format.
  * @returns A string that represents the formatted AST node.
  */
-export const prettyPrint = (node: A.AstNode): string =>
+export const prettyPrint = (node: Ast.AstNode): string =>
     ppAstNode(node)(createContext(4))
         // Initial level of indentation is 0
         .map((f) => f(0))

--- a/src/ast/ast.ts
+++ b/src/ast/ast.ts
@@ -1,193 +1,193 @@
-import type { Address, Cell, Slice } from "@ton/core";
+import type * as Ast from "@ton/core";
 import type { SrcInfo } from "../grammar/src-info";
 import type { RelativePath } from "../imports/path";
 import type { Language } from "../imports/source";
 
-export type AstModule = {
+export type Module = {
     readonly kind: "module";
-    readonly imports: readonly AstImport[];
-    readonly items: readonly AstModuleItem[];
+    readonly imports: readonly Import[];
+    readonly items: readonly ModuleItem[];
     readonly id: number;
 };
 
-export type AstImport = {
+export type Import = {
     readonly kind: "import";
     readonly importPath: ImportPath;
     readonly id: number;
     readonly loc: SrcInfo;
 };
 
-export type AstModuleItem =
-    | AstPrimitiveTypeDecl
-    | AstFunctionDef
-    | AstAsmFunctionDef
-    | AstNativeFunctionDecl
-    | AstConstantDef
-    | AstStructDecl
-    | AstMessageDecl
-    | AstContract
-    | AstTrait;
+export type ModuleItem =
+    | PrimitiveTypeDecl
+    | FunctionDef
+    | AsmFunctionDef
+    | NativeFunctionDecl
+    | ConstantDef
+    | StructDecl
+    | MessageDecl
+    | Contract
+    | Trait;
 
-export type AstTypeDecl =
-    | AstPrimitiveTypeDecl
-    | AstStructDecl
-    | AstMessageDecl
-    | AstContract
-    | AstTrait;
+export type TypeDecl =
+    | PrimitiveTypeDecl
+    | StructDecl
+    | MessageDecl
+    | Contract
+    | Trait;
 
-export type AstPrimitiveTypeDecl = {
+export type PrimitiveTypeDecl = {
     readonly kind: "primitive_type_decl";
-    readonly name: AstId;
+    readonly name: Id;
     readonly id: number;
     readonly loc: SrcInfo;
 };
 
-export type AstFunctionDef = {
+export type FunctionDef = {
     readonly kind: "function_def";
-    readonly attributes: readonly AstFunctionAttribute[];
-    readonly name: AstId;
-    readonly return: AstType | undefined;
-    readonly params: readonly AstTypedParameter[];
-    readonly statements: readonly AstStatement[];
+    readonly attributes: readonly FunctionAttribute[];
+    readonly name: Id;
+    readonly return: Type | undefined;
+    readonly params: readonly TypedParameter[];
+    readonly statements: readonly Statement[];
     readonly id: number;
     readonly loc: SrcInfo;
 };
 
-export type AstAsmFunctionDef = {
+export type AsmFunctionDef = {
     readonly kind: "asm_function_def";
-    readonly shuffle: AstAsmShuffle;
-    readonly attributes: readonly AstFunctionAttribute[];
-    readonly name: AstId;
-    readonly return: AstType | undefined;
-    readonly params: readonly AstTypedParameter[];
-    readonly instructions: readonly AstAsmInstruction[];
+    readonly shuffle: AsmShuffle;
+    readonly attributes: readonly FunctionAttribute[];
+    readonly name: Id;
+    readonly return: Type | undefined;
+    readonly params: readonly TypedParameter[];
+    readonly instructions: readonly AsmInstruction[];
     readonly id: number;
     readonly loc: SrcInfo;
 };
 
-export type AstAsmInstruction = string;
-export type AstAsmShuffle = {
-    readonly args: readonly AstId[];
-    readonly ret: readonly AstNumber[];
+export type AsmInstruction = string;
+export type AsmShuffle = {
+    readonly args: readonly Id[];
+    readonly ret: readonly Number[];
 };
 
-export type AstFunctionDecl = {
+export type FunctionDecl = {
     readonly kind: "function_decl";
-    readonly attributes: readonly AstFunctionAttribute[];
-    readonly name: AstId;
-    readonly return: AstType | undefined;
-    readonly params: readonly AstTypedParameter[];
+    readonly attributes: readonly FunctionAttribute[];
+    readonly name: Id;
+    readonly return: Type | undefined;
+    readonly params: readonly TypedParameter[];
     readonly id: number;
     readonly loc: SrcInfo;
 };
 
-export type AstNativeFunctionDecl = {
+export type NativeFunctionDecl = {
     readonly kind: "native_function_decl";
-    readonly attributes: readonly AstFunctionAttribute[];
-    readonly name: AstId;
-    readonly nativeName: AstFuncId;
-    readonly params: readonly AstTypedParameter[];
-    readonly return: AstType | undefined;
+    readonly attributes: readonly FunctionAttribute[];
+    readonly name: Id;
+    readonly nativeName: FuncId;
+    readonly params: readonly TypedParameter[];
+    readonly return: Type | undefined;
     readonly id: number;
     readonly loc: SrcInfo;
 };
 
-export type AstConstantDef = {
+export type ConstantDef = {
     readonly kind: "constant_def";
-    readonly attributes: readonly AstConstantAttribute[];
-    readonly name: AstId;
-    readonly type: AstType;
-    readonly initializer: AstExpression;
+    readonly attributes: readonly ConstantAttribute[];
+    readonly name: Id;
+    readonly type: Type;
+    readonly initializer: Expression;
     readonly id: number;
     readonly loc: SrcInfo;
 };
 
-export type AstConstantDecl = {
+export type ConstantDecl = {
     readonly kind: "constant_decl";
-    readonly attributes: readonly AstConstantAttribute[];
-    readonly name: AstId;
-    readonly type: AstType;
+    readonly attributes: readonly ConstantAttribute[];
+    readonly name: Id;
+    readonly type: Type;
     readonly id: number;
     readonly loc: SrcInfo;
 };
 
-export type AstStructDecl = {
+export type StructDecl = {
     readonly kind: "struct_decl";
-    readonly name: AstId;
-    readonly fields: readonly AstFieldDecl[];
+    readonly name: Id;
+    readonly fields: readonly FieldDecl[];
     readonly id: number;
     readonly loc: SrcInfo;
 };
 
-export type AstMessageDecl = {
+export type MessageDecl = {
     readonly kind: "message_decl";
-    readonly name: AstId;
-    readonly opcode: AstExpression | undefined;
-    readonly fields: readonly AstFieldDecl[];
+    readonly name: Id;
+    readonly opcode: Expression | undefined;
+    readonly fields: readonly FieldDecl[];
     readonly id: number;
     readonly loc: SrcInfo;
 };
 
-export type AstContract = {
+export type Contract = {
     readonly kind: "contract";
-    readonly name: AstId;
-    readonly traits: readonly AstId[];
-    readonly attributes: readonly AstContractAttribute[];
-    readonly params: undefined | readonly AstFieldDecl[];
-    readonly declarations: readonly AstContractDeclaration[];
+    readonly name: Id;
+    readonly traits: readonly Id[];
+    readonly attributes: readonly ContractAttribute[];
+    readonly params: undefined | readonly FieldDecl[];
+    readonly declarations: readonly ContractDeclaration[];
     readonly id: number;
     readonly loc: SrcInfo;
 };
 
-export type AstTrait = {
+export type Trait = {
     readonly kind: "trait";
-    readonly name: AstId;
-    readonly traits: readonly AstId[];
-    readonly attributes: readonly AstContractAttribute[];
-    readonly declarations: readonly AstTraitDeclaration[];
+    readonly name: Id;
+    readonly traits: readonly Id[];
+    readonly attributes: readonly ContractAttribute[];
+    readonly declarations: readonly TraitDeclaration[];
     readonly id: number;
     readonly loc: SrcInfo;
 };
 
-export type AstContractDeclaration =
-    | AstFieldDecl
-    | AstFunctionDef
-    | AstAsmFunctionDef
-    | AstContractInit
-    | AstReceiver
-    | AstConstantDef;
+export type ContractDeclaration =
+    | FieldDecl
+    | FunctionDef
+    | AsmFunctionDef
+    | ContractInit
+    | Receiver
+    | ConstantDef;
 
-export type AstTraitDeclaration =
-    | AstFieldDecl
-    | AstFunctionDef
-    | AstAsmFunctionDef
-    | AstFunctionDecl
-    | AstReceiver
-    | AstConstantDef
-    | AstConstantDecl;
+export type TraitDeclaration =
+    | FieldDecl
+    | FunctionDef
+    | AsmFunctionDef
+    | FunctionDecl
+    | Receiver
+    | ConstantDef
+    | ConstantDecl;
 
-export type AstFieldDecl = {
+export type FieldDecl = {
     readonly kind: "field_decl";
-    readonly name: AstId;
-    readonly type: AstType;
-    readonly initializer: AstExpression | undefined;
-    readonly as: AstId | undefined;
+    readonly name: Id;
+    readonly type: Type;
+    readonly initializer: Expression | undefined;
+    readonly as: Id | undefined;
     readonly id: number;
     readonly loc: SrcInfo;
 };
 
-export type AstReceiver = {
+export type Receiver = {
     readonly kind: "receiver";
-    readonly selector: AstReceiverKind;
-    readonly statements: readonly AstStatement[];
+    readonly selector: ReceiverKind;
+    readonly statements: readonly Statement[];
     readonly id: number;
     readonly loc: SrcInfo;
 };
 
-export type AstContractInit = {
+export type ContractInit = {
     readonly kind: "contract_init";
-    readonly params: readonly AstTypedParameter[];
-    readonly statements: readonly AstStatement[];
+    readonly params: readonly TypedParameter[];
+    readonly statements: readonly Statement[];
     readonly id: number;
     readonly loc: SrcInfo;
 };
@@ -196,53 +196,53 @@ export type AstContractInit = {
 // Statements
 //
 
-export type AstStatement =
-    | AstStatementLet
-    | AstStatementReturn
-    | AstStatementExpression
-    | AstStatementAssign
-    | AstStatementAugmentedAssign
-    | AstStatementCondition
-    | AstStatementWhile
-    | AstStatementUntil
-    | AstStatementRepeat
-    | AstStatementTry
-    | AstStatementForEach
-    | AstStatementDestruct
-    | AstStatementBlock;
+export type Statement =
+    | StatementLet
+    | StatementReturn
+    | StatementExpression
+    | StatementAssign
+    | StatementAugmentedAssign
+    | StatementCondition
+    | StatementWhile
+    | StatementUntil
+    | StatementRepeat
+    | StatementTry
+    | StatementForEach
+    | StatementDestruct
+    | StatementBlock;
 
-export type AstStatementLet = {
+export type StatementLet = {
     readonly kind: "statement_let";
-    readonly name: AstId;
-    readonly type: AstType | undefined;
-    readonly expression: AstExpression;
+    readonly name: Id;
+    readonly type: Type | undefined;
+    readonly expression: Expression;
     readonly id: number;
     readonly loc: SrcInfo;
 };
 
-export type AstStatementReturn = {
+export type StatementReturn = {
     readonly kind: "statement_return";
-    readonly expression: AstExpression | undefined;
+    readonly expression: Expression | undefined;
     readonly id: number;
     readonly loc: SrcInfo;
 };
 
-export type AstStatementExpression = {
+export type StatementExpression = {
     readonly kind: "statement_expression";
-    readonly expression: AstExpression;
+    readonly expression: Expression;
     readonly id: number;
     readonly loc: SrcInfo;
 };
 
-export type AstStatementAssign = {
+export type StatementAssign = {
     readonly kind: "statement_assign";
-    readonly path: AstExpression; // left-hand side of `=`
-    readonly expression: AstExpression;
+    readonly path: Expression; // left-hand side of `=`
+    readonly expression: Expression;
     readonly id: number;
     readonly loc: SrcInfo;
 };
 
-export type AstAugmentedAssignOperation =
+export type AugmentedAssignOperation =
     | "+"
     | "-"
     | "*"
@@ -256,85 +256,85 @@ export type AstAugmentedAssignOperation =
     | "&"
     | "^";
 
-export type AstStatementAugmentedAssign = {
+export type StatementAugmentedAssign = {
     readonly kind: "statement_augmentedassign";
-    readonly op: AstAugmentedAssignOperation;
-    readonly path: AstExpression;
-    readonly expression: AstExpression;
+    readonly op: AugmentedAssignOperation;
+    readonly path: Expression;
+    readonly expression: Expression;
     readonly id: number;
     readonly loc: SrcInfo;
 };
 
-export type AstStatementCondition = {
+export type StatementCondition = {
     readonly kind: "statement_condition";
-    readonly condition: AstExpression;
-    readonly trueStatements: readonly AstStatement[];
-    readonly falseStatements: readonly AstStatement[] | undefined;
+    readonly condition: Expression;
+    readonly trueStatements: readonly Statement[];
+    readonly falseStatements: readonly Statement[] | undefined;
     readonly id: number;
     readonly loc: SrcInfo;
 };
 
-export type AstStatementWhile = {
+export type StatementWhile = {
     readonly kind: "statement_while";
-    readonly condition: AstExpression;
-    readonly statements: readonly AstStatement[];
+    readonly condition: Expression;
+    readonly statements: readonly Statement[];
     readonly id: number;
     readonly loc: SrcInfo;
 };
 
-export type AstStatementUntil = {
+export type StatementUntil = {
     readonly kind: "statement_until";
-    readonly condition: AstExpression;
-    readonly statements: readonly AstStatement[];
+    readonly condition: Expression;
+    readonly statements: readonly Statement[];
     readonly id: number;
     readonly loc: SrcInfo;
 };
 
-export type AstStatementRepeat = {
+export type StatementRepeat = {
     readonly kind: "statement_repeat";
-    readonly iterations: AstExpression;
-    readonly statements: readonly AstStatement[];
+    readonly iterations: Expression;
+    readonly statements: readonly Statement[];
     readonly id: number;
     readonly loc: SrcInfo;
 };
 
-export type AstStatementTry = {
+export type StatementTry = {
     readonly kind: "statement_try";
-    readonly statements: readonly AstStatement[];
-    readonly catchBlock: AstCatchBlock | undefined;
+    readonly statements: readonly Statement[];
+    readonly catchBlock: CatchBlock | undefined;
     readonly id: number;
     readonly loc: SrcInfo;
 };
 
-export type AstCatchBlock = {
-    readonly catchName: AstId;
-    readonly catchStatements: readonly AstStatement[];
+export type CatchBlock = {
+    readonly catchName: Id;
+    readonly catchStatements: readonly Statement[];
 };
 
-export type AstStatementForEach = {
+export type StatementForEach = {
     readonly kind: "statement_foreach";
-    readonly keyName: AstId;
-    readonly valueName: AstId;
-    readonly map: AstExpression;
-    readonly statements: readonly AstStatement[];
+    readonly keyName: Id;
+    readonly valueName: Id;
+    readonly map: Expression;
+    readonly statements: readonly Statement[];
     readonly id: number;
     readonly loc: SrcInfo;
 };
 
-export type AstStatementDestruct = {
+export type StatementDestruct = {
     readonly kind: "statement_destruct";
-    readonly type: AstTypeId;
+    readonly type: TypeId;
     /** field name -> [field id, local id] */
-    readonly identifiers: ReadonlyMap<string, readonly [AstId, AstId]>;
+    readonly identifiers: ReadonlyMap<string, readonly [Id, Id]>;
     readonly ignoreUnspecifiedFields: boolean;
-    readonly expression: AstExpression;
+    readonly expression: Expression;
     readonly id: number;
     readonly loc: SrcInfo;
 };
 
-export type AstStatementBlock = {
+export type StatementBlock = {
     readonly kind: "statement_block";
-    readonly statements: readonly AstStatement[];
+    readonly statements: readonly Statement[];
     readonly id: number;
     readonly loc: SrcInfo;
 };
@@ -343,39 +343,35 @@ export type AstStatementBlock = {
 // Types
 //
 
-export type AstType =
-    | AstTypeId
-    | AstOptionalType
-    | AstMapType
-    | AstBouncedMessageType;
+export type Type = TypeId | OptionalType | MapType | BouncedMessageType;
 
-export type AstTypeId = {
+export type TypeId = {
     readonly kind: "type_id";
     readonly text: string;
     readonly id: number;
     readonly loc: SrcInfo;
 };
 
-export type AstOptionalType = {
+export type OptionalType = {
     readonly kind: "optional_type";
-    readonly typeArg: AstType;
+    readonly typeArg: Type;
     readonly id: number;
     readonly loc: SrcInfo;
 };
 
-export type AstMapType = {
+export type MapType = {
     readonly kind: "map_type";
-    readonly keyType: AstTypeId;
-    readonly keyStorageType: AstId | undefined;
-    readonly valueType: AstTypeId;
-    readonly valueStorageType: AstId | undefined;
+    readonly keyType: TypeId;
+    readonly keyStorageType: Id | undefined;
+    readonly valueType: TypeId;
+    readonly valueStorageType: Id | undefined;
     readonly id: number;
     readonly loc: SrcInfo;
 };
 
-export type AstBouncedMessageType = {
+export type BouncedMessageType = {
     readonly kind: "bounced_message_type";
-    readonly messageType: AstTypeId;
+    readonly messageType: TypeId;
     readonly id: number;
     readonly loc: SrcInfo;
 };
@@ -384,31 +380,31 @@ export type AstBouncedMessageType = {
 // Expressions
 //
 
-export type AstExpression =
-    | AstOpBinary
-    | AstOpUnary
-    | AstConditional
-    | AstMethodCall
-    | AstFieldAccess
-    | AstStaticCall
-    | AstStructInstance
-    | AstId
-    | AstInitOf
-    | AstCodeOf
-    | AstString
-    | AstLiteral;
+export type Expression =
+    | OpBinary
+    | OpUnary
+    | Conditional
+    | MethodCall
+    | FieldAccess
+    | StaticCall
+    | StructInstance
+    | Id
+    | InitOf
+    | CodeOf
+    | String
+    | Literal;
 
-export type AstLiteral =
-    | AstNumber
-    | AstBoolean
-    | AstNull
-    | AstSimplifiedString
-    | AstAddress
-    | AstCell
-    | AstSlice
-    | AstStructValue;
+export type Literal =
+    | Number
+    | Boolean
+    | Null
+    | SimplifiedString
+    | Address
+    | Cell
+    | Slice
+    | StructValue;
 
-export type AstBinaryOperation =
+export type BinaryOperation =
     | "+"
     | "-"
     | "*"
@@ -428,54 +424,54 @@ export type AstBinaryOperation =
     | "|"
     | "^";
 
-export type AstOpBinary = {
+export type OpBinary = {
     readonly kind: "op_binary";
-    readonly op: AstBinaryOperation;
-    readonly left: AstExpression;
-    readonly right: AstExpression;
+    readonly op: BinaryOperation;
+    readonly left: Expression;
+    readonly right: Expression;
     readonly id: number;
     readonly loc: SrcInfo;
 };
 
-export type AstUnaryOperation = "+" | "-" | "!" | "!!" | "~";
+export type UnaryOperation = "+" | "-" | "!" | "!!" | "~";
 
-export type AstOpUnary = {
+export type OpUnary = {
     readonly kind: "op_unary";
-    readonly op: AstUnaryOperation;
-    readonly operand: AstExpression;
+    readonly op: UnaryOperation;
+    readonly operand: Expression;
     readonly id: number;
     readonly loc: SrcInfo;
 };
 
-export type AstFieldAccess = {
+export type FieldAccess = {
     readonly kind: "field_access";
-    readonly aggregate: AstExpression; // contract, trait, struct, message
-    readonly field: AstId;
+    readonly aggregate: Expression; // contract, trait, struct, message
+    readonly field: Id;
     readonly id: number;
     readonly loc: SrcInfo;
 };
 
-export type AstMethodCall = {
+export type MethodCall = {
     readonly kind: "method_call";
-    readonly self: AstExpression; // anything with a method
-    readonly method: AstId;
-    readonly args: readonly AstExpression[];
+    readonly self: Expression; // anything with a method
+    readonly method: Id;
+    readonly args: readonly Expression[];
     readonly id: number;
     readonly loc: SrcInfo;
 };
 
 // builtins or top-level (module) functions
-export type AstStaticCall = {
+export type StaticCall = {
     readonly kind: "static_call";
-    readonly function: AstId;
-    readonly args: readonly AstExpression[];
+    readonly function: Id;
+    readonly args: readonly Expression[];
     readonly id: number;
     readonly loc: SrcInfo;
 };
 
-export type AstStructInstance = {
+export type StructInstance = {
     readonly kind: "struct_instance";
-    readonly type: AstId;
+    readonly type: Id;
     readonly args: readonly AstStructFieldInitializer[];
     readonly id: number;
     readonly loc: SrcInfo;
@@ -483,76 +479,76 @@ export type AstStructInstance = {
 
 export type AstStructFieldInitializer = {
     readonly kind: "struct_field_initializer";
-    readonly field: AstId;
-    readonly initializer: AstExpression;
+    readonly field: Id;
+    readonly initializer: Expression;
     readonly id: number;
     readonly loc: SrcInfo;
 };
 
-export type AstInitOf = {
+export type InitOf = {
     readonly kind: "init_of";
-    readonly contract: AstId;
-    readonly args: readonly AstExpression[];
+    readonly contract: Id;
+    readonly args: readonly Expression[];
     readonly id: number;
     readonly loc: SrcInfo;
 };
 
-export type AstCodeOf = {
+export type CodeOf = {
     readonly kind: "code_of";
-    readonly contract: AstId;
+    readonly contract: Id;
     readonly id: number;
     readonly loc: SrcInfo;
 };
 
-export type AstConditional = {
+export type Conditional = {
     readonly kind: "conditional";
-    readonly condition: AstExpression;
-    readonly thenBranch: AstExpression;
-    readonly elseBranch: AstExpression;
+    readonly condition: Expression;
+    readonly thenBranch: Expression;
+    readonly elseBranch: Expression;
     readonly id: number;
     readonly loc: SrcInfo;
 };
 
-export type AstId = {
+export type Id = {
     readonly kind: "id";
     readonly text: string;
     readonly id: number;
     readonly loc: SrcInfo;
 };
 
-export type AstFuncId = {
+export type FuncId = {
     readonly kind: "func_id";
     readonly text: string;
     readonly id: number;
     readonly loc: SrcInfo;
 };
 
-export type AstDestructMapping = {
+export type DestructMapping = {
     readonly kind: "destruct_mapping";
-    readonly field: AstId;
-    readonly name: AstId;
+    readonly field: Id;
+    readonly name: Id;
     readonly id: number;
     readonly loc: SrcInfo;
 };
 
-export type AstDestructEnd = {
+export type DestructEnd = {
     readonly kind: "destruct_end";
     readonly ignoreUnspecifiedFields: boolean;
     readonly id: number;
     readonly loc: SrcInfo;
 };
 
-export type AstNumber = {
+export type Number = {
     readonly kind: "number";
-    readonly base: AstNumberBase;
+    readonly base: NumberBase;
     readonly value: bigint;
     readonly id: number;
     readonly loc: SrcInfo;
 };
 
-export type AstNumberBase = 2 | 8 | 10 | 16;
+export type NumberBase = 2 | 8 | 10 | 16;
 
-export type AstBoolean = {
+export type Boolean = {
     readonly kind: "boolean";
     readonly value: boolean;
     readonly id: number;
@@ -574,7 +570,7 @@ export type ImportType = "stdlib" | "relative";
 // An AstString is not a literal because it may contain escaping characters that have not been simplified, like '\\'.
 // AstSimplifiedString is always produced by the interpreter, never directly by the parser. The parser produces AstStrings, which
 // then get transformed into AstSimplifiedString by the interpreter.
-export type AstSimplifiedString = {
+export type SimplifiedString = {
     readonly kind: "simplified_string";
     readonly value: string;
     readonly id: number;
@@ -582,9 +578,9 @@ export type AstSimplifiedString = {
 };
 
 /**
- * @deprecated AstSimplifiedString
+ * @deprecated SimplifiedString
  */
-export type AstString = {
+export type String = {
     readonly kind: "string";
     readonly value: string;
     readonly id: number;
@@ -594,70 +590,70 @@ export type AstString = {
 // `null` value is an inhabitant of several types:
 // it can represent missing values in optional types,
 // or empty map of any key and value types
-export type AstNull = {
+export type Null = {
     readonly kind: "null";
     readonly id: number;
     readonly loc: SrcInfo;
 };
 
-export type AstAddress = {
+export type Address = {
     readonly kind: "address";
-    readonly value: Address;
+    readonly value: Ast.Address;
     readonly id: number;
     readonly loc: SrcInfo;
 };
 
-export type AstCell = {
+export type Cell = {
     readonly kind: "cell";
-    readonly value: Cell;
+    readonly value: Ast.Cell;
     readonly id: number;
     readonly loc: SrcInfo;
 };
 
-export type AstSlice = {
+export type Slice = {
     readonly kind: "slice";
-    readonly value: Slice;
+    readonly value: Ast.Slice;
     readonly id: number;
     readonly loc: SrcInfo;
 };
 
-export type AstStructValue = {
+export type StructValue = {
     readonly kind: "struct_value";
-    readonly type: AstId;
-    readonly args: readonly AstStructFieldValue[];
+    readonly type: Id;
+    readonly args: readonly StructFieldValue[];
     readonly id: number;
     readonly loc: SrcInfo;
 };
 
-export type AstStructFieldValue = {
+export type StructFieldValue = {
     readonly kind: "struct_field_value";
-    readonly field: AstId;
-    readonly initializer: AstLiteral;
+    readonly field: Id;
+    readonly initializer: Literal;
     readonly id: number;
     readonly loc: SrcInfo;
 };
 
-export type AstConstantAttributeName = "virtual" | "override" | "abstract";
+export type ConstantAttributeName = "virtual" | "override" | "abstract";
 
-export type AstConstantAttribute = {
-    readonly type: AstConstantAttributeName;
+export type ConstantAttribute = {
+    readonly type: ConstantAttributeName;
     readonly loc: SrcInfo;
 };
 
-export type AstContractAttribute = {
+export type ContractAttribute = {
     readonly type: "interface";
-    readonly name: AstString;
+    readonly name: String;
     readonly loc: SrcInfo;
 };
 
-export type AstFunctionAttributeGet = {
+export type FunctionAttributeGet = {
     readonly kind: "function_attribute";
     readonly type: "get";
-    readonly methodId: AstExpression | undefined;
+    readonly methodId: Expression | undefined;
     readonly loc: SrcInfo;
 };
 
-export type AstFunctionAttributeName =
+export type FunctionAttributeName =
     | "mutates"
     | "extends"
     | "virtual"
@@ -665,94 +661,89 @@ export type AstFunctionAttributeName =
     | "override"
     | "inline";
 
-export type AstFunctionAttributeRest = {
+export type FunctionAttributeRest = {
     readonly kind: "function_attribute";
-    readonly type: AstFunctionAttributeName;
+    readonly type: FunctionAttributeName;
     readonly loc: SrcInfo;
 };
 
-export type AstFunctionAttribute =
-    | AstFunctionAttributeGet
-    | AstFunctionAttributeRest;
+export type FunctionAttribute = FunctionAttributeGet | FunctionAttributeRest;
 
-export type AstTypedParameter = {
+export type TypedParameter = {
     readonly kind: "typed_parameter";
-    readonly name: AstId;
-    readonly type: AstType;
+    readonly name: Id;
+    readonly type: Type;
     readonly id: number;
     readonly loc: SrcInfo;
 };
 
-export type AstReceiverSimple = {
+export type ReceiverSimple = {
     readonly kind: "simple";
-    readonly param: AstTypedParameter;
+    readonly param: TypedParameter;
     readonly id: number;
 };
 
-export type AstReceiverFallback = {
+export type ReceiverFallback = {
     readonly kind: "fallback";
     readonly id: number;
 };
 
-export type AstReceiverComment = {
+export type ReceiverComment = {
     readonly kind: "comment";
-    readonly comment: AstString;
+    readonly comment: String;
     readonly id: number;
 };
 
-export type AstReceiverSubKind =
-    | AstReceiverSimple
-    | AstReceiverFallback
-    | AstReceiverComment;
+export type ReceiverSubKind =
+    | ReceiverSimple
+    | ReceiverFallback
+    | ReceiverComment;
 
-export type AstReceiverInternal = {
+export type ReceiverInternal = {
     readonly kind: "internal";
-    readonly subKind: AstReceiverSubKind;
+    readonly subKind: ReceiverSubKind;
     readonly id: number;
     readonly loc: SrcInfo;
 };
 
-export type AstReceiverExternal = {
+export type ReceiverExternal = {
     readonly kind: "external";
-    readonly subKind: AstReceiverSubKind;
+    readonly subKind: ReceiverSubKind;
     readonly id: number;
     readonly loc: SrcInfo;
 };
 
-export type AstReceiverBounce = {
+export type ReceiverBounce = {
     readonly kind: "bounce";
-    readonly param: AstTypedParameter;
+    readonly param: TypedParameter;
     readonly id: number;
     readonly loc: SrcInfo;
 };
 
-export type AstReceiverKind =
-    | AstReceiverInternal
-    | AstReceiverExternal
-    | AstReceiverBounce;
+export type ReceiverKind = ReceiverInternal | ReceiverExternal | ReceiverBounce;
 
 export type AstNode =
-    | AstFuncId
-    | AstDestructMapping
-    | AstDestructEnd
-    | AstExpression
-    | AstStatement
-    | AstTypeDecl
-    | AstFieldDecl
-    | AstTypedParameter
-    | AstFunctionDef
-    | AstFunctionAttribute
-    | AstAsmFunctionDef
-    | AstFunctionDecl
-    | AstModule
-    | AstNativeFunctionDecl
+    | FuncId
+    | DestructMapping
+    | DestructEnd
+    | Expression
+    | Statement
+    | TypeDecl
+    | FieldDecl
+    | TypedParameter
+    | FunctionDef
+    | FunctionAttribute
+    | AsmFunctionDef
+    | FunctionDecl
+    | Module
+    | NativeFunctionDecl
     | AstStructFieldInitializer
-    | AstStructFieldValue
-    | AstType
-    | AstContractInit
-    | AstReceiver
-    | AstImport
-    | AstConstantDef
-    | AstConstantDecl
-    | AstReceiverKind
-    | AstReceiverSubKind;
+    | StructFieldValue
+    | Type
+    | ContractInit
+    | Receiver
+    | Import
+    | ConstantDef
+    | ConstantDecl
+    | ReceiverKind
+    | ReceiverSubKind;

--- a/src/ast/ast.ts
+++ b/src/ast/ast.ts
@@ -1,4 +1,4 @@
-import type * as Ast from "@ton/core";
+import type * as TonCore from "@ton/core";
 import type { SrcInfo } from "../grammar/src-info";
 import type { RelativePath } from "../imports/path";
 import type { Language } from "../imports/source";
@@ -472,12 +472,12 @@ export type StaticCall = {
 export type StructInstance = {
     readonly kind: "struct_instance";
     readonly type: Id;
-    readonly args: readonly AstStructFieldInitializer[];
+    readonly args: readonly StructFieldInitializer[];
     readonly id: number;
     readonly loc: SrcInfo;
 };
 
-export type AstStructFieldInitializer = {
+export type StructFieldInitializer = {
     readonly kind: "struct_field_initializer";
     readonly field: Id;
     readonly initializer: Expression;
@@ -566,10 +566,10 @@ export type ImportPath = {
 // from standard library is still import with origin: "stdlib"
 export type ImportType = "stdlib" | "relative";
 
-// An AstSimplifiedString is a string in which escaping characters, like '\\' has been simplified, e.g., '\\' simplified to '\'.
-// An AstString is not a literal because it may contain escaping characters that have not been simplified, like '\\'.
-// AstSimplifiedString is always produced by the interpreter, never directly by the parser. The parser produces AstStrings, which
-// then get transformed into AstSimplifiedString by the interpreter.
+// An SimplifiedString is a string in which escaping characters, like '\\' has been simplified, e.g., '\\' simplified to '\'.
+// An String is not a literal because it may contain escaping characters that have not been simplified, like '\\'.
+// SimplifiedString is always produced by the interpreter, never directly by the parser. The parser produces Strings, which
+// then get transformed into SimplifiedString by the interpreter.
 export type SimplifiedString = {
     readonly kind: "simplified_string";
     readonly value: string;
@@ -598,21 +598,21 @@ export type Null = {
 
 export type Address = {
     readonly kind: "address";
-    readonly value: Ast.Address;
+    readonly value: TonCore.Address;
     readonly id: number;
     readonly loc: SrcInfo;
 };
 
 export type Cell = {
     readonly kind: "cell";
-    readonly value: Ast.Cell;
+    readonly value: TonCore.Cell;
     readonly id: number;
     readonly loc: SrcInfo;
 };
 
 export type Slice = {
     readonly kind: "slice";
-    readonly value: Ast.Slice;
+    readonly value: TonCore.Slice;
     readonly id: number;
     readonly loc: SrcInfo;
 };
@@ -737,7 +737,7 @@ export type AstNode =
     | FunctionDecl
     | Module
     | NativeFunctionDecl
-    | AstStructFieldInitializer
+    | StructFieldInitializer
     | StructFieldValue
     | Type
     | ContractInit

--- a/src/ast/getAstSchema.ts
+++ b/src/ast/getAstSchema.ts
@@ -513,7 +513,7 @@ export const getAstSchema = (
             }),
         StructInstance: (
             type: Ast.Id,
-            args: Ast.AstStructFieldInitializer[],
+            args: Ast.StructFieldInitializer[],
             loc: Loc,
         ): Ast.StructInstance =>
             createNode<Ast.StructInstance>({
@@ -526,8 +526,8 @@ export const getAstSchema = (
             field: Ast.Id,
             initializer: Ast.Expression,
             loc: Loc,
-        ): Ast.AstStructFieldInitializer =>
-            createNode<Ast.AstStructFieldInitializer>({
+        ): Ast.StructFieldInitializer =>
+            createNode<Ast.StructFieldInitializer>({
                 kind: "struct_field_initializer",
                 field,
                 initializer,

--- a/src/ast/getAstSchema.ts
+++ b/src/ast/getAstSchema.ts
@@ -4,7 +4,7 @@
  */
 
 import type { Loc } from "@tonstudio/parser-runtime";
-import type * as A from "./ast";
+import type * as Ast from "./ast";
 import type { FactoryAst } from "../ast/ast-helpers";
 import type { SrcInfo } from "../grammar/src-info";
 
@@ -18,32 +18,29 @@ export const getAstSchema = (
     };
 
     return {
-        Module: (
-            imports: A.AstImport[],
-            items: A.AstModuleItem[],
-        ): A.AstModule =>
-            createNode<A.AstModule>({ kind: "module", imports, items }),
-        Import: (source: A.ImportPath, loc: Loc): A.AstImport =>
-            createNode<A.AstImport>({
+        Module: (imports: Ast.Import[], items: Ast.ModuleItem[]): Ast.Module =>
+            createNode<Ast.Module>({ kind: "module", imports, items }),
+        Import: (source: Ast.ImportPath, loc: Loc): Ast.Import =>
+            createNode<Ast.Import>({
                 kind: "import",
                 importPath: source,
                 loc: toSrcInfo(loc),
             }),
-        PrimitiveTypeDecl: (name: A.AstId, loc: Loc): A.AstPrimitiveTypeDecl =>
-            createNode<A.AstPrimitiveTypeDecl>({
+        PrimitiveTypeDecl: (name: Ast.Id, loc: Loc): Ast.PrimitiveTypeDecl =>
+            createNode<Ast.PrimitiveTypeDecl>({
                 kind: "primitive_type_decl",
                 name,
                 loc: toSrcInfo(loc),
             }),
         FunctionDef: (
-            attributes: A.AstFunctionAttribute[],
-            name: A.AstId,
-            retType: A.AstType | undefined,
-            params: A.AstTypedParameter[],
-            statements: A.AstStatement[],
+            attributes: Ast.FunctionAttribute[],
+            name: Ast.Id,
+            retType: Ast.Type | undefined,
+            params: Ast.TypedParameter[],
+            statements: Ast.Statement[],
             loc: Loc,
-        ): A.AstFunctionDef =>
-            createNode<A.AstFunctionDef>({
+        ): Ast.FunctionDef =>
+            createNode<Ast.FunctionDef>({
                 kind: "function_def",
                 attributes,
                 name,
@@ -53,15 +50,15 @@ export const getAstSchema = (
                 loc: toSrcInfo(loc),
             }),
         AsmFunctionDef: (
-            shuffle: A.AstAsmShuffle,
-            attributes: A.AstFunctionAttribute[],
-            name: A.AstId,
-            retType: A.AstType | undefined,
-            params: A.AstTypedParameter[],
-            instructions: A.AstAsmInstruction[],
+            shuffle: Ast.AsmShuffle,
+            attributes: Ast.FunctionAttribute[],
+            name: Ast.Id,
+            retType: Ast.Type | undefined,
+            params: Ast.TypedParameter[],
+            instructions: Ast.AsmInstruction[],
             loc: Loc,
-        ): A.AstAsmFunctionDef =>
-            createNode<A.AstAsmFunctionDef>({
+        ): Ast.AsmFunctionDef =>
+            createNode<Ast.AsmFunctionDef>({
                 kind: "asm_function_def",
                 shuffle,
                 attributes,
@@ -72,13 +69,13 @@ export const getAstSchema = (
                 loc: toSrcInfo(loc),
             }),
         FunctionDecl: (
-            attributes: A.AstFunctionAttribute[],
-            name: A.AstId,
-            retType: A.AstType | undefined,
-            params: A.AstTypedParameter[],
+            attributes: Ast.FunctionAttribute[],
+            name: Ast.Id,
+            retType: Ast.Type | undefined,
+            params: Ast.TypedParameter[],
             loc: Loc,
-        ): A.AstFunctionDecl =>
-            createNode<A.AstFunctionDecl>({
+        ): Ast.FunctionDecl =>
+            createNode<Ast.FunctionDecl>({
                 kind: "function_decl",
                 attributes,
                 name,
@@ -87,14 +84,14 @@ export const getAstSchema = (
                 loc: toSrcInfo(loc),
             }),
         NativeFunctionDecl: (
-            attributes: A.AstFunctionAttribute[],
-            name: A.AstId,
-            nativeName: A.AstFuncId,
-            params: A.AstTypedParameter[],
-            retType: A.AstType | undefined,
+            attributes: Ast.FunctionAttribute[],
+            name: Ast.Id,
+            nativeName: Ast.FuncId,
+            params: Ast.TypedParameter[],
+            retType: Ast.Type | undefined,
             loc: Loc,
-        ): A.AstNativeFunctionDecl =>
-            createNode<A.AstNativeFunctionDecl>({
+        ): Ast.NativeFunctionDecl =>
+            createNode<Ast.NativeFunctionDecl>({
                 kind: "native_function_decl",
                 attributes,
                 name,
@@ -104,13 +101,13 @@ export const getAstSchema = (
                 loc: toSrcInfo(loc),
             }),
         ConstantDef: (
-            attributes: A.AstConstantAttribute[],
-            name: A.AstId,
-            type: A.AstType,
-            initializer: A.AstExpression,
+            attributes: Ast.ConstantAttribute[],
+            name: Ast.Id,
+            type: Ast.Type,
+            initializer: Ast.Expression,
             loc: Loc,
-        ): A.AstConstantDef =>
-            createNode<A.AstConstantDef>({
+        ): Ast.ConstantDef =>
+            createNode<Ast.ConstantDef>({
                 kind: "constant_def",
                 attributes,
                 name,
@@ -119,12 +116,12 @@ export const getAstSchema = (
                 loc: toSrcInfo(loc),
             }),
         ConstantDecl: (
-            attributes: A.AstConstantAttribute[],
-            name: A.AstId,
-            type: A.AstType,
+            attributes: Ast.ConstantAttribute[],
+            name: Ast.Id,
+            type: Ast.Type,
             loc: Loc,
-        ): A.AstConstantDecl =>
-            createNode<A.AstConstantDecl>({
+        ): Ast.ConstantDecl =>
+            createNode<Ast.ConstantDecl>({
                 kind: "constant_decl",
                 attributes,
                 name,
@@ -132,23 +129,23 @@ export const getAstSchema = (
                 loc: toSrcInfo(loc),
             }),
         StructDecl: (
-            name: A.AstId,
-            fields: A.AstFieldDecl[],
+            name: Ast.Id,
+            fields: Ast.FieldDecl[],
             loc: Loc,
-        ): A.AstStructDecl =>
-            createNode<A.AstStructDecl>({
+        ): Ast.StructDecl =>
+            createNode<Ast.StructDecl>({
                 kind: "struct_decl",
                 name,
                 fields,
                 loc: toSrcInfo(loc),
             }),
         MessageDecl: (
-            name: A.AstId,
-            opcode: A.AstExpression | undefined,
-            fields: A.AstFieldDecl[],
+            name: Ast.Id,
+            opcode: Ast.Expression | undefined,
+            fields: Ast.FieldDecl[],
             loc: Loc,
-        ): A.AstMessageDecl =>
-            createNode<A.AstMessageDecl>({
+        ): Ast.MessageDecl =>
+            createNode<Ast.MessageDecl>({
                 kind: "message_decl",
                 name,
                 opcode,
@@ -156,14 +153,14 @@ export const getAstSchema = (
                 loc: toSrcInfo(loc),
             }),
         Contract: (
-            name: A.AstId,
-            traits: A.AstId[],
-            attributes: A.AstContractAttribute[],
-            params: undefined | readonly A.AstFieldDecl[],
-            declarations: A.AstContractDeclaration[],
+            name: Ast.Id,
+            traits: Ast.Id[],
+            attributes: Ast.ContractAttribute[],
+            params: undefined | readonly Ast.FieldDecl[],
+            declarations: Ast.ContractDeclaration[],
             loc: Loc,
-        ): A.AstContract =>
-            createNode<A.AstContract>({
+        ): Ast.Contract =>
+            createNode<Ast.Contract>({
                 kind: "contract",
                 name,
                 traits,
@@ -173,13 +170,13 @@ export const getAstSchema = (
                 loc: toSrcInfo(loc),
             }),
         Trait: (
-            name: A.AstId,
-            traits: A.AstId[],
-            attributes: A.AstContractAttribute[],
-            declarations: A.AstTraitDeclaration[],
+            name: Ast.Id,
+            traits: Ast.Id[],
+            attributes: Ast.ContractAttribute[],
+            declarations: Ast.TraitDeclaration[],
             loc: Loc,
-        ): A.AstTrait =>
-            createNode<A.AstTrait>({
+        ): Ast.Trait =>
+            createNode<Ast.Trait>({
                 kind: "trait",
                 name,
                 traits,
@@ -188,13 +185,13 @@ export const getAstSchema = (
                 loc: toSrcInfo(loc),
             }),
         FieldDecl: (
-            name: A.AstId,
-            type: A.AstType,
-            initializer: A.AstExpression | undefined,
-            as: A.AstId | undefined,
+            name: Ast.Id,
+            type: Ast.Type,
+            initializer: Ast.Expression | undefined,
+            as: Ast.Id | undefined,
             loc: Loc,
-        ): A.AstFieldDecl =>
-            createNode<A.AstFieldDecl>({
+        ): Ast.FieldDecl =>
+            createNode<Ast.FieldDecl>({
                 kind: "field_decl",
                 name,
                 type,
@@ -203,75 +200,75 @@ export const getAstSchema = (
                 loc: toSrcInfo(loc),
             }),
         Receiver: (
-            selector: A.AstReceiverKind,
-            statements: A.AstStatement[],
+            selector: Ast.ReceiverKind,
+            statements: Ast.Statement[],
             loc: Loc,
-        ): A.AstReceiver =>
-            createNode<A.AstReceiver>({
+        ): Ast.Receiver =>
+            createNode<Ast.Receiver>({
                 kind: "receiver",
                 selector,
                 statements,
                 loc: toSrcInfo(loc),
             }),
-        ReceiverSimple: (param: A.AstTypedParameter): A.AstReceiverSimple =>
-            createNode<A.AstReceiverSimple>({
+        ReceiverSimple: (param: Ast.TypedParameter): Ast.ReceiverSimple =>
+            createNode<Ast.ReceiverSimple>({
                 kind: "simple",
                 param,
             }),
-        ReceiverFallback: (): A.AstReceiverFallback =>
-            createNode<A.AstReceiverFallback>({
+        ReceiverFallback: (): Ast.ReceiverFallback =>
+            createNode<Ast.ReceiverFallback>({
                 kind: "fallback",
             }),
-        ReceiverComment: (comment: A.AstString): A.AstReceiverComment =>
-            createNode<A.AstReceiverComment>({
+        ReceiverComment: (comment: Ast.String): Ast.ReceiverComment =>
+            createNode<Ast.ReceiverComment>({
                 kind: "comment",
                 comment,
             }),
         ReceiverInternal: (
-            subKind: A.AstReceiverSubKind,
+            subKind: Ast.ReceiverSubKind,
             loc: Loc,
-        ): A.AstReceiverInternal =>
-            createNode<A.AstReceiverInternal>({
+        ): Ast.ReceiverInternal =>
+            createNode<Ast.ReceiverInternal>({
                 kind: "internal",
                 subKind,
                 loc: toSrcInfo(loc),
             }),
         ReceiverExternal: (
-            subKind: A.AstReceiverSubKind,
+            subKind: Ast.ReceiverSubKind,
             loc: Loc,
-        ): A.AstReceiverExternal =>
-            createNode<A.AstReceiverExternal>({
+        ): Ast.ReceiverExternal =>
+            createNode<Ast.ReceiverExternal>({
                 kind: "external",
                 subKind,
                 loc: toSrcInfo(loc),
             }),
         ReceiverBounce: (
-            param: A.AstTypedParameter,
+            param: Ast.TypedParameter,
             loc: Loc,
-        ): A.AstReceiverBounce =>
-            createNode<A.AstReceiverBounce>({
+        ): Ast.ReceiverBounce =>
+            createNode<Ast.ReceiverBounce>({
                 kind: "bounce",
                 param,
                 loc: toSrcInfo(loc),
             }),
         ContractInit: (
-            params: A.AstTypedParameter[],
-            statements: A.AstStatement[],
+            params: Ast.TypedParameter[],
+            statements: Ast.Statement[],
             loc: Loc,
-        ): A.AstContractInit =>
-            createNode<A.AstContractInit>({
+        ): Ast.ContractInit =>
+            createNode<Ast.ContractInit>({
                 kind: "contract_init",
                 params,
                 statements,
                 loc: toSrcInfo(loc),
             }),
         StatementLet: (
-            name: A.AstId,
-            type: A.AstType | undefined,
-            expression: A.AstExpression,
+            name: Ast.Id,
+            type: Ast.Type | undefined,
+            expression: Ast.Expression,
             loc: Loc,
-        ): A.AstStatementLet =>
-            createNode<A.AstStatementLet>({
+        ): Ast.StatementLet =>
+            createNode<Ast.StatementLet>({
                 kind: "statement_let",
                 name,
                 type,
@@ -279,13 +276,13 @@ export const getAstSchema = (
                 loc: toSrcInfo(loc),
             }),
         StatementDestruct: (
-            type: A.AstTypeId,
-            identifiers: Map<string, [A.AstId, A.AstId]>,
+            type: Ast.TypeId,
+            identifiers: Map<string, [Ast.Id, Ast.Id]>,
             ignoreUnspecifiedFields: boolean,
-            expression: A.AstExpression,
+            expression: Ast.Expression,
             loc: Loc,
-        ): A.AstStatementDestruct =>
-            createNode<A.AstStatementDestruct>({
+        ): Ast.StatementDestruct =>
+            createNode<Ast.StatementDestruct>({
                 kind: "statement_destruct",
                 type,
                 identifiers,
@@ -294,41 +291,41 @@ export const getAstSchema = (
                 loc: toSrcInfo(loc),
             }),
         StatementReturn: (
-            expression: A.AstExpression | undefined,
+            expression: Ast.Expression | undefined,
             loc: Loc,
-        ): A.AstStatementReturn =>
-            createNode<A.AstStatementReturn>({
+        ): Ast.StatementReturn =>
+            createNode<Ast.StatementReturn>({
                 kind: "statement_return",
                 expression,
                 loc: toSrcInfo(loc),
             }),
         StatementExpression: (
-            expression: A.AstExpression,
+            expression: Ast.Expression,
             loc: Loc,
-        ): A.AstStatementExpression =>
-            createNode<A.AstStatementExpression>({
+        ): Ast.StatementExpression =>
+            createNode<Ast.StatementExpression>({
                 kind: "statement_expression",
                 expression,
                 loc: toSrcInfo(loc),
             }),
         StatementAssign: (
-            path: A.AstExpression,
-            expression: A.AstExpression,
+            path: Ast.Expression,
+            expression: Ast.Expression,
             loc: Loc,
-        ): A.AstStatementAssign =>
-            createNode<A.AstStatementAssign>({
+        ): Ast.StatementAssign =>
+            createNode<Ast.StatementAssign>({
                 kind: "statement_assign",
                 path,
                 expression,
                 loc: toSrcInfo(loc),
             }),
         StatementAugmentedAssign: (
-            op: A.AstAugmentedAssignOperation,
-            path: A.AstExpression,
-            expression: A.AstExpression,
+            op: Ast.AugmentedAssignOperation,
+            path: Ast.Expression,
+            expression: Ast.Expression,
             loc: Loc,
-        ): A.AstStatementAugmentedAssign =>
-            createNode<A.AstStatementAugmentedAssign>({
+        ): Ast.StatementAugmentedAssign =>
+            createNode<Ast.StatementAugmentedAssign>({
                 kind: "statement_augmentedassign",
                 op,
                 path,
@@ -336,12 +333,12 @@ export const getAstSchema = (
                 loc: toSrcInfo(loc),
             }),
         StatementCondition: (
-            condition: A.AstExpression,
-            trueStatements: A.AstStatement[],
-            falseStatements: A.AstStatement[] | undefined,
+            condition: Ast.Expression,
+            trueStatements: Ast.Statement[],
+            falseStatements: Ast.Statement[] | undefined,
             loc: Loc,
-        ): A.AstStatementCondition =>
-            createNode<A.AstStatementCondition>({
+        ): Ast.StatementCondition =>
+            createNode<Ast.StatementCondition>({
                 kind: "statement_condition",
                 condition,
                 trueStatements,
@@ -349,60 +346,60 @@ export const getAstSchema = (
                 loc: toSrcInfo(loc),
             }),
         StatementWhile: (
-            condition: A.AstExpression,
-            statements: A.AstStatement[],
+            condition: Ast.Expression,
+            statements: Ast.Statement[],
             loc: Loc,
-        ): A.AstStatementWhile =>
-            createNode<A.AstStatementWhile>({
+        ): Ast.StatementWhile =>
+            createNode<Ast.StatementWhile>({
                 kind: "statement_while",
                 condition,
                 statements,
                 loc: toSrcInfo(loc),
             }),
         StatementUntil: (
-            condition: A.AstExpression,
-            statements: A.AstStatement[],
+            condition: Ast.Expression,
+            statements: Ast.Statement[],
             loc: Loc,
-        ): A.AstStatementUntil =>
-            createNode<A.AstStatementUntil>({
+        ): Ast.StatementUntil =>
+            createNode<Ast.StatementUntil>({
                 kind: "statement_until",
                 condition,
                 statements,
                 loc: toSrcInfo(loc),
             }),
         StatementRepeat: (
-            iterations: A.AstExpression,
-            statements: A.AstStatement[],
+            iterations: Ast.Expression,
+            statements: Ast.Statement[],
             loc: Loc,
-        ): A.AstStatementRepeat =>
-            createNode<A.AstStatementRepeat>({
+        ): Ast.StatementRepeat =>
+            createNode<Ast.StatementRepeat>({
                 kind: "statement_repeat",
                 iterations,
                 statements,
                 loc: toSrcInfo(loc),
             }),
         StatementTry: (
-            statements: A.AstStatement[],
+            statements: Ast.Statement[],
             loc: Loc,
             catchBlock?: {
-                catchName: A.AstId;
-                catchStatements: A.AstStatement[];
+                catchName: Ast.Id;
+                catchStatements: Ast.Statement[];
             },
-        ): A.AstStatementTry =>
-            createNode<A.AstStatementTry>({
+        ): Ast.StatementTry =>
+            createNode<Ast.StatementTry>({
                 kind: "statement_try",
                 statements,
                 catchBlock: catchBlock,
                 loc: toSrcInfo(loc),
             }),
         StatementForEach: (
-            keyName: A.AstId,
-            valueName: A.AstId,
-            map: A.AstExpression,
-            statements: A.AstStatement[],
+            keyName: Ast.Id,
+            valueName: Ast.Id,
+            map: Ast.Expression,
+            statements: Ast.Statement[],
             loc: Loc,
-        ): A.AstStatementForEach =>
-            createNode<A.AstStatementForEach>({
+        ): Ast.StatementForEach =>
+            createNode<Ast.StatementForEach>({
                 kind: "statement_foreach",
                 keyName,
                 valueName,
@@ -411,34 +408,34 @@ export const getAstSchema = (
                 loc: toSrcInfo(loc),
             }),
         StatementBlock: (
-            statements: A.AstStatement[],
+            statements: Ast.Statement[],
             loc: Loc,
-        ): A.AstStatementBlock =>
-            createNode<A.AstStatementBlock>({
+        ): Ast.StatementBlock =>
+            createNode<Ast.StatementBlock>({
                 kind: "statement_block",
                 statements,
                 loc: toSrcInfo(loc),
             }),
-        TypeId: (text: string, loc: Loc): A.AstTypeId =>
-            createNode<A.AstTypeId>({
+        TypeId: (text: string, loc: Loc): Ast.TypeId =>
+            createNode<Ast.TypeId>({
                 kind: "type_id",
                 text,
                 loc: toSrcInfo(loc),
             }),
-        OptionalType: (typeArg: A.AstType, loc: Loc): A.AstOptionalType =>
-            createNode<A.AstOptionalType>({
+        OptionalType: (typeArg: Ast.Type, loc: Loc): Ast.OptionalType =>
+            createNode<Ast.OptionalType>({
                 kind: "optional_type",
                 typeArg,
                 loc: toSrcInfo(loc),
             }),
         MapType: (
-            keyType: A.AstTypeId,
-            keyStorageType: A.AstId | undefined,
-            valueType: A.AstTypeId,
-            valueStorageType: A.AstId | undefined,
+            keyType: Ast.TypeId,
+            keyStorageType: Ast.Id | undefined,
+            valueType: Ast.TypeId,
+            valueStorageType: Ast.Id | undefined,
             loc: Loc,
-        ): A.AstMapType =>
-            createNode<A.AstMapType>({
+        ): Ast.MapType =>
+            createNode<Ast.MapType>({
                 kind: "map_type",
                 keyType,
                 keyStorageType,
@@ -447,21 +444,21 @@ export const getAstSchema = (
                 loc: toSrcInfo(loc),
             }),
         BouncedMessageType: (
-            messageType: A.AstTypeId,
+            messageType: Ast.TypeId,
             loc: Loc,
-        ): A.AstBouncedMessageType =>
-            createNode<A.AstBouncedMessageType>({
+        ): Ast.BouncedMessageType =>
+            createNode<Ast.BouncedMessageType>({
                 kind: "bounced_message_type",
                 messageType,
                 loc: toSrcInfo(loc),
             }),
         OpBinary: (
-            op: A.AstBinaryOperation,
-            left: A.AstExpression,
-            right: A.AstExpression,
+            op: Ast.BinaryOperation,
+            left: Ast.Expression,
+            right: Ast.Expression,
             loc: Loc,
-        ): A.AstOpBinary =>
-            createNode<A.AstOpBinary>({
+        ): Ast.OpBinary =>
+            createNode<Ast.OpBinary>({
                 kind: "op_binary",
                 op,
                 left,
@@ -469,34 +466,34 @@ export const getAstSchema = (
                 loc: toSrcInfo(loc),
             }),
         OpUnary: (
-            op: A.AstUnaryOperation,
-            operand: A.AstExpression,
+            op: Ast.UnaryOperation,
+            operand: Ast.Expression,
             loc: Loc,
-        ): A.AstOpUnary =>
-            createNode<A.AstOpUnary>({
+        ): Ast.OpUnary =>
+            createNode<Ast.OpUnary>({
                 kind: "op_unary",
                 op,
                 operand,
                 loc: toSrcInfo(loc),
             }),
         FieldAccess: (
-            aggregate: A.AstExpression,
-            field: A.AstId,
+            aggregate: Ast.Expression,
+            field: Ast.Id,
             loc: Loc,
-        ): A.AstFieldAccess =>
-            createNode<A.AstFieldAccess>({
+        ): Ast.FieldAccess =>
+            createNode<Ast.FieldAccess>({
                 kind: "field_access",
                 aggregate,
                 field,
                 loc: toSrcInfo(loc),
             }),
         MethodCall: (
-            self: A.AstExpression,
-            method: A.AstId,
-            args: A.AstExpression[],
+            self: Ast.Expression,
+            method: Ast.Id,
+            args: Ast.Expression[],
             loc: Loc,
-        ): A.AstMethodCall =>
-            createNode<A.AstMethodCall>({
+        ): Ast.MethodCall =>
+            createNode<Ast.MethodCall>({
                 kind: "method_call",
                 self,
                 method,
@@ -504,133 +501,133 @@ export const getAstSchema = (
                 loc: toSrcInfo(loc),
             }),
         StaticCall: (
-            funcId: A.AstId,
-            args: A.AstExpression[],
+            funcId: Ast.Id,
+            args: Ast.Expression[],
             loc: Loc,
-        ): A.AstStaticCall =>
-            createNode<A.AstStaticCall>({
+        ): Ast.StaticCall =>
+            createNode<Ast.StaticCall>({
                 kind: "static_call",
                 function: funcId,
                 args,
                 loc: toSrcInfo(loc),
             }),
         StructInstance: (
-            type: A.AstId,
-            args: A.AstStructFieldInitializer[],
+            type: Ast.Id,
+            args: Ast.AstStructFieldInitializer[],
             loc: Loc,
-        ): A.AstStructInstance =>
-            createNode<A.AstStructInstance>({
+        ): Ast.StructInstance =>
+            createNode<Ast.StructInstance>({
                 kind: "struct_instance",
                 type,
                 args,
                 loc: toSrcInfo(loc),
             }),
         StructFieldInitializer: (
-            field: A.AstId,
-            initializer: A.AstExpression,
+            field: Ast.Id,
+            initializer: Ast.Expression,
             loc: Loc,
-        ): A.AstStructFieldInitializer =>
-            createNode<A.AstStructFieldInitializer>({
+        ): Ast.AstStructFieldInitializer =>
+            createNode<Ast.AstStructFieldInitializer>({
                 kind: "struct_field_initializer",
                 field,
                 initializer,
                 loc: toSrcInfo(loc),
             }),
         InitOf: (
-            contract: A.AstId,
-            args: A.AstExpression[],
+            contract: Ast.Id,
+            args: Ast.Expression[],
             loc: Loc,
-        ): A.AstInitOf =>
-            createNode<A.AstInitOf>({
+        ): Ast.InitOf =>
+            createNode<Ast.InitOf>({
                 kind: "init_of",
                 contract,
                 args,
                 loc: toSrcInfo(loc),
             }),
-        CodeOf: (contract: A.AstId, loc: Loc): A.AstCodeOf =>
-            createNode<A.AstCodeOf>({
+        CodeOf: (contract: Ast.Id, loc: Loc): Ast.CodeOf =>
+            createNode<Ast.CodeOf>({
                 kind: "code_of",
                 contract,
                 loc: toSrcInfo(loc),
             }),
         Conditional: (
-            condition: A.AstExpression,
-            thenBranch: A.AstExpression,
-            elseBranch: A.AstExpression,
+            condition: Ast.Expression,
+            thenBranch: Ast.Expression,
+            elseBranch: Ast.Expression,
             loc: Loc,
-        ): A.AstConditional =>
-            createNode<A.AstConditional>({
+        ): Ast.Conditional =>
+            createNode<Ast.Conditional>({
                 kind: "conditional",
                 condition,
                 thenBranch,
                 elseBranch,
                 loc: toSrcInfo(loc),
             }),
-        Id: (text: string, loc: Loc): A.AstId =>
-            createNode<A.AstId>({ kind: "id", text, loc: toSrcInfo(loc) }),
-        FuncId: (text: string, loc: Loc): A.AstFuncId =>
-            createNode<A.AstFuncId>({
+        Id: (text: string, loc: Loc): Ast.Id =>
+            createNode<Ast.Id>({ kind: "id", text, loc: toSrcInfo(loc) }),
+        FuncId: (text: string, loc: Loc): Ast.FuncId =>
+            createNode<Ast.FuncId>({
                 kind: "func_id",
                 text,
                 loc: toSrcInfo(loc),
             }),
-        Null: (loc: Loc): A.AstNull =>
-            createNode<A.AstNull>({ kind: "null", loc: toSrcInfo(loc) }),
-        String: (value: string, loc: Loc): A.AstString =>
-            createNode<A.AstString>({
+        Null: (loc: Loc): Ast.Null =>
+            createNode<Ast.Null>({ kind: "null", loc: toSrcInfo(loc) }),
+        String: (value: string, loc: Loc): Ast.String =>
+            createNode<Ast.String>({
                 kind: "string",
                 value,
                 loc: toSrcInfo(loc),
             }),
-        Boolean: (value: boolean, loc: Loc): A.AstBoolean =>
-            createNode<A.AstBoolean>({
+        Boolean: (value: boolean, loc: Loc): Ast.Boolean =>
+            createNode<Ast.Boolean>({
                 kind: "boolean",
                 value,
                 loc: toSrcInfo(loc),
             }),
-        Number: (base: A.AstNumberBase, value: bigint, loc: Loc): A.AstNumber =>
-            createNode<A.AstNumber>({
+        Number: (base: Ast.NumberBase, value: bigint, loc: Loc): Ast.Number =>
+            createNode<Ast.Number>({
                 kind: "number",
                 base,
                 value,
                 loc: toSrcInfo(loc),
             }),
         ContractAttribute: (
-            name: A.AstString,
+            name: Ast.String,
             loc: Loc,
-        ): A.AstContractAttribute =>
-            createNode<A.AstContractAttribute>({
+        ): Ast.ContractAttribute =>
+            createNode<Ast.ContractAttribute>({
                 type: "interface",
                 name,
                 loc: toSrcInfo(loc),
             }),
         FunctionAttributeGet: (
-            methodId: A.AstExpression | undefined,
+            methodId: Ast.Expression | undefined,
             loc: Loc,
-        ): A.AstFunctionAttributeGet => ({
+        ): Ast.FunctionAttributeGet => ({
             kind: "function_attribute",
             type: "get",
             methodId,
             loc: toSrcInfo(loc),
         }),
         FunctionAttribute: (
-            type: A.AstFunctionAttributeName,
+            type: Ast.FunctionAttributeName,
             loc: Loc,
-        ): A.AstFunctionAttributeRest => ({
+        ): Ast.FunctionAttributeRest => ({
             kind: "function_attribute",
             type,
             loc: toSrcInfo(loc),
         }),
         ConstantAttribute: (
-            type: A.AstConstantAttributeName,
+            type: Ast.ConstantAttributeName,
             loc: Loc,
-        ): A.AstConstantAttribute => ({ type, loc: toSrcInfo(loc) }),
+        ): Ast.ConstantAttribute => ({ type, loc: toSrcInfo(loc) }),
         TypedParameter: (
-            name: A.AstId,
-            type: A.AstType,
+            name: Ast.Id,
+            type: Ast.Type,
             loc: Loc,
-        ): A.AstTypedParameter =>
-            createNode<A.AstTypedParameter>({
+        ): Ast.TypedParameter =>
+            createNode<Ast.TypedParameter>({
                 kind: "typed_parameter",
                 name,
                 type,

--- a/src/ast/random.infra.ts
+++ b/src/ast/random.infra.ts
@@ -1,5 +1,5 @@
 import fc from "fast-check";
-import type * as A from "./ast";
+import type * as Ast from "./ast";
 import { dummySrcInfo } from "../grammar/src-info";
 import { diffJson } from "diff";
 import { astBinaryOperations, astUnaryOperations } from "./ast-constants";
@@ -59,7 +59,7 @@ function dummyAstNode<T>(
     }));
 }
 
-function randomAstBoolean(): fc.Arbitrary<A.AstBoolean> {
+function randomAstBoolean(): fc.Arbitrary<Ast.Boolean> {
     return dummyAstNode(
         fc.record({
             kind: fc.constant("boolean"),
@@ -68,7 +68,7 @@ function randomAstBoolean(): fc.Arbitrary<A.AstBoolean> {
     );
 }
 
-function randomAstString(): fc.Arbitrary<A.AstString> {
+function randomAstString(): fc.Arbitrary<Ast.String> {
     const escapeString = (s: string): string =>
         s.replace(/\\/g, "\\\\").replace(/"/g, '\\"');
 
@@ -80,7 +80,7 @@ function randomAstString(): fc.Arbitrary<A.AstString> {
     );
 }
 
-function randomAstNumber(): fc.Arbitrary<A.AstNumber> {
+function randomAstNumber(): fc.Arbitrary<Ast.Number> {
     const values = [
         ...Array.from({ length: 10 }, (_, i) => [0n, BigInt(i)]).flat(),
         ...Array.from({ length: 256 }, (_, i) => 1n ** BigInt(i)),
@@ -96,8 +96,8 @@ function randomAstNumber(): fc.Arbitrary<A.AstNumber> {
 }
 
 function randomAstOpUnary(
-    operand: fc.Arbitrary<A.AstExpression>,
-): fc.Arbitrary<A.AstOpUnary> {
+    operand: fc.Arbitrary<Ast.Expression>,
+): fc.Arbitrary<Ast.OpUnary> {
     return dummyAstNode(
         fc.record({
             kind: fc.constant("op_unary"),
@@ -107,9 +107,9 @@ function randomAstOpUnary(
     );
 }
 function randomAstOpBinary(
-    leftExpression: fc.Arbitrary<A.AstExpression>,
-    rightExpression: fc.Arbitrary<A.AstExpression>,
-): fc.Arbitrary<A.AstOpBinary> {
+    leftExpression: fc.Arbitrary<Ast.Expression>,
+    rightExpression: fc.Arbitrary<Ast.Expression>,
+): fc.Arbitrary<Ast.OpBinary> {
     return dummyAstNode(
         fc.record({
             kind: fc.constant("op_binary"),
@@ -121,10 +121,10 @@ function randomAstOpBinary(
 }
 
 function randomAstConditional(
-    conditionExpression: fc.Arbitrary<A.AstExpression>,
-    thenBranchExpression: fc.Arbitrary<A.AstExpression>,
-    elseBranchExpression: fc.Arbitrary<A.AstExpression>,
-): fc.Arbitrary<A.AstConditional> {
+    conditionExpression: fc.Arbitrary<Ast.Expression>,
+    thenBranchExpression: fc.Arbitrary<Ast.Expression>,
+    elseBranchExpression: fc.Arbitrary<Ast.Expression>,
+): fc.Arbitrary<Ast.Conditional> {
     return dummyAstNode(
         fc.record({
             kind: fc.constant("conditional"),
@@ -135,7 +135,7 @@ function randomAstConditional(
     );
 }
 
-function randomAstId(): fc.Arbitrary<A.AstId> {
+function randomAstId(): fc.Arbitrary<Ast.Id> {
     return dummyAstNode(
         fc.record({
             kind: fc.constant("id"),
@@ -151,7 +151,7 @@ function randomAstId(): fc.Arbitrary<A.AstId> {
     );
 }
 
-function randomAstCapitalizedId(): fc.Arbitrary<A.AstId> {
+function randomAstCapitalizedId(): fc.Arbitrary<Ast.Id> {
     return dummyAstNode(
         fc.record({
             kind: fc.constant("id"),
@@ -160,7 +160,7 @@ function randomAstCapitalizedId(): fc.Arbitrary<A.AstId> {
     );
 }
 
-function randomAstNull(): fc.Arbitrary<A.AstNull> {
+function randomAstNull(): fc.Arbitrary<Ast.Null> {
     return dummyAstNode(
         fc.record({
             kind: fc.constant("null"),
@@ -169,8 +169,8 @@ function randomAstNull(): fc.Arbitrary<A.AstNull> {
 }
 
 function randomAstInitOf(
-    expression: fc.Arbitrary<A.AstExpression>,
-): fc.Arbitrary<A.AstInitOf> {
+    expression: fc.Arbitrary<Ast.Expression>,
+): fc.Arbitrary<Ast.InitOf> {
     return dummyAstNode(
         fc.record({
             kind: fc.constant("init_of"),
@@ -180,7 +180,7 @@ function randomAstInitOf(
     );
 }
 
-function randomAstCodeOf(): fc.Arbitrary<A.AstCodeOf> {
+function randomAstCodeOf(): fc.Arbitrary<Ast.CodeOf> {
     return dummyAstNode(
         fc.record({
             kind: fc.constant("code_of"),
@@ -190,8 +190,8 @@ function randomAstCodeOf(): fc.Arbitrary<A.AstCodeOf> {
 }
 
 function randomAstStaticCall(
-    expression: fc.Arbitrary<A.AstExpression>,
-): fc.Arbitrary<A.AstStaticCall> {
+    expression: fc.Arbitrary<Ast.Expression>,
+): fc.Arbitrary<Ast.StaticCall> {
     return dummyAstNode(
         fc.record({
             kind: fc.constant("static_call"),
@@ -202,8 +202,8 @@ function randomAstStaticCall(
 }
 
 function randomAstStructFieldInitializer(
-    expression: fc.Arbitrary<A.AstExpression>,
-): fc.Arbitrary<A.AstStructFieldInitializer> {
+    expression: fc.Arbitrary<Ast.Expression>,
+): fc.Arbitrary<Ast.AstStructFieldInitializer> {
     return dummyAstNode(
         fc.record({
             kind: fc.constant("struct_field_initializer"),
@@ -214,8 +214,8 @@ function randomAstStructFieldInitializer(
 }
 
 function randomAstStructInstance(
-    structFieldInitializer: fc.Arbitrary<A.AstStructFieldInitializer>,
-): fc.Arbitrary<A.AstStructInstance> {
+    structFieldInitializer: fc.Arbitrary<Ast.AstStructFieldInitializer>,
+): fc.Arbitrary<Ast.StructInstance> {
     return dummyAstNode(
         fc.record({
             kind: fc.constant("struct_instance"),
@@ -226,8 +226,8 @@ function randomAstStructInstance(
 }
 
 function randomAstFieldAccess(
-    expression: fc.Arbitrary<A.AstExpression>,
-): fc.Arbitrary<A.AstFieldAccess> {
+    expression: fc.Arbitrary<Ast.Expression>,
+): fc.Arbitrary<Ast.FieldAccess> {
     return dummyAstNode(
         fc.record({
             kind: fc.constant("field_access"),
@@ -238,9 +238,9 @@ function randomAstFieldAccess(
 }
 
 function randomAstMethodCall(
-    selfExpression: fc.Arbitrary<A.AstExpression>,
-    argsExpression: fc.Arbitrary<A.AstExpression>,
-): fc.Arbitrary<A.AstMethodCall> {
+    selfExpression: fc.Arbitrary<Ast.Expression>,
+    argsExpression: fc.Arbitrary<Ast.Expression>,
+): fc.Arbitrary<Ast.MethodCall> {
     return dummyAstNode(
         fc.record({
             self: selfExpression,
@@ -252,8 +252,8 @@ function randomAstMethodCall(
 }
 
 function randomAstStructFieldValue(
-    subLiteral: fc.Arbitrary<A.AstLiteral>,
-): fc.Arbitrary<A.AstStructFieldValue> {
+    subLiteral: fc.Arbitrary<Ast.Literal>,
+): fc.Arbitrary<Ast.StructFieldValue> {
     return dummyAstNode(
         fc.record({
             kind: fc.constant("struct_field_value"),
@@ -264,8 +264,8 @@ function randomAstStructFieldValue(
 }
 
 function randomAstStructValue(
-    subLiteral: fc.Arbitrary<A.AstLiteral>,
-): fc.Arbitrary<A.AstStructValue> {
+    subLiteral: fc.Arbitrary<Ast.Literal>,
+): fc.Arbitrary<Ast.StructValue> {
     return dummyAstNode(
         fc.record({
             kind: fc.constant("struct_value"),
@@ -275,8 +275,8 @@ function randomAstStructValue(
     );
 }
 
-function randomAstLiteral(maxDepth: number): fc.Arbitrary<A.AstLiteral> {
-    return fc.memo((depth: number): fc.Arbitrary<A.AstLiteral> => {
+function randomAstLiteral(maxDepth: number): fc.Arbitrary<Ast.Literal> {
+    return fc.memo((depth: number): fc.Arbitrary<Ast.Literal> => {
         if (depth <= 1) {
             return fc.oneof(
                 randomAstNumber(),
@@ -304,8 +304,8 @@ function randomAstLiteral(maxDepth: number): fc.Arbitrary<A.AstLiteral> {
 
 export function randomAstExpression(
     maxDepth: number,
-): fc.Arbitrary<A.AstExpression> {
-    return fc.memo((depth: number): fc.Arbitrary<A.AstExpression> => {
+): fc.Arbitrary<Ast.Expression> {
+    return fc.memo((depth: number): fc.Arbitrary<Ast.Expression> => {
         if (depth <= 1) {
             return fc.oneof(randomAstLiteral(depth - 1));
         }
@@ -352,8 +352,8 @@ function sortObjectKeys<T extends Record<string, unknown>>(obj: T): T {
 }
 
 export function diffAstObjects(
-    left: A.AstExpression,
-    right: A.AstExpression,
+    left: Ast.Expression,
+    right: Ast.Expression,
     prettyBefore: string,
     prettyAfter: string,
 ): void {

--- a/src/ast/random.infra.ts
+++ b/src/ast/random.infra.ts
@@ -203,7 +203,7 @@ function randomAstStaticCall(
 
 function randomAstStructFieldInitializer(
     expression: fc.Arbitrary<Ast.Expression>,
-): fc.Arbitrary<Ast.AstStructFieldInitializer> {
+): fc.Arbitrary<Ast.StructFieldInitializer> {
     return dummyAstNode(
         fc.record({
             kind: fc.constant("struct_field_initializer"),
@@ -214,7 +214,7 @@ function randomAstStructFieldInitializer(
 }
 
 function randomAstStructInstance(
-    structFieldInitializer: fc.Arbitrary<Ast.AstStructFieldInitializer>,
+    structFieldInitializer: fc.Arbitrary<Ast.StructFieldInitializer>,
 ): fc.Arbitrary<Ast.StructInstance> {
     return dummyAstNode(
         fc.record({

--- a/src/ast/util.ts
+++ b/src/ast/util.ts
@@ -1,5 +1,5 @@
 import type { Address, Cell, Slice } from "@ton/core";
-import type * as A from "./ast";
+import type * as Ast from "./ast";
 import type { FactoryAst } from "./ast-helpers";
 import { isLiteral } from "./ast-helpers";
 import type { SrcInfo } from "../grammar";
@@ -7,23 +7,23 @@ import { dummySrcInfo } from "../grammar";
 
 export const getAstUtil = ({ createNode }: FactoryAst) => {
     function makeUnaryExpression(
-        op: A.AstUnaryOperation,
-        operand: A.AstExpression,
-    ): A.AstExpression {
+        op: Ast.UnaryOperation,
+        operand: Ast.Expression,
+    ): Ast.Expression {
         const result = createNode({
             kind: "op_unary",
             op: op,
             operand: operand,
             loc: dummySrcInfo,
         });
-        return result as A.AstExpression;
+        return result as Ast.Expression;
     }
 
     function makeBinaryExpression(
-        op: A.AstBinaryOperation,
-        left: A.AstExpression,
-        right: A.AstExpression,
-    ): A.AstExpression {
+        op: Ast.BinaryOperation,
+        left: Ast.Expression,
+        right: Ast.Expression,
+    ): Ast.Expression {
         const result = createNode({
             kind: "op_binary",
             op: op,
@@ -31,105 +31,105 @@ export const getAstUtil = ({ createNode }: FactoryAst) => {
             right: right,
             loc: dummySrcInfo,
         });
-        return result as A.AstExpression;
+        return result as Ast.Expression;
     }
 
-    function makeNumberLiteral(n: bigint, loc: SrcInfo): A.AstNumber {
+    function makeNumberLiteral(n: bigint, loc: SrcInfo): Ast.Number {
         const result = createNode({
             kind: "number",
             base: 10,
             value: n,
             loc: loc,
         });
-        return result as A.AstNumber;
+        return result as Ast.Number;
     }
 
-    function makeBooleanLiteral(b: boolean, loc: SrcInfo): A.AstBoolean {
+    function makeBooleanLiteral(b: boolean, loc: SrcInfo): Ast.Boolean {
         const result = createNode({
             kind: "boolean",
             value: b,
             loc: loc,
         });
-        return result as A.AstBoolean;
+        return result as Ast.Boolean;
     }
 
     function makeSimplifiedStringLiteral(
         s: string,
         loc: SrcInfo,
-    ): A.AstSimplifiedString {
+    ): Ast.SimplifiedString {
         const result = createNode({
             kind: "simplified_string",
             value: s,
             loc: loc,
         });
-        return result as A.AstSimplifiedString;
+        return result as Ast.SimplifiedString;
     }
 
-    function makeNullLiteral(loc: SrcInfo): A.AstNull {
+    function makeNullLiteral(loc: SrcInfo): Ast.Null {
         const result = createNode({
             kind: "null",
             loc: loc,
         });
-        return result as A.AstNull;
+        return result as Ast.Null;
     }
 
-    function makeCellLiteral(c: Cell, loc: SrcInfo): A.AstCell {
+    function makeCellLiteral(c: Cell, loc: SrcInfo): Ast.Cell {
         const result = createNode({
             kind: "cell",
             value: c,
             loc: loc,
         });
-        return result as A.AstCell;
+        return result as Ast.Cell;
     }
 
-    function makeSliceLiteral(s: Slice, loc: SrcInfo): A.AstSlice {
+    function makeSliceLiteral(s: Slice, loc: SrcInfo): Ast.Slice {
         const result = createNode({
             kind: "slice",
             value: s,
             loc: loc,
         });
-        return result as A.AstSlice;
+        return result as Ast.Slice;
     }
 
-    function makeAddressLiteral(a: Address, loc: SrcInfo): A.AstAddress {
+    function makeAddressLiteral(a: Address, loc: SrcInfo): Ast.Address {
         const result = createNode({
             kind: "address",
             value: a,
             loc: loc,
         });
-        return result as A.AstAddress;
+        return result as Ast.Address;
     }
 
     function makeStructFieldValue(
         fieldName: string,
-        val: A.AstLiteral,
+        val: Ast.Literal,
         loc: SrcInfo,
-    ): A.AstStructFieldValue {
+    ): Ast.StructFieldValue {
         const result = createNode({
             kind: "struct_field_value",
             field: createNode({
                 kind: "id",
                 text: fieldName,
                 loc: loc,
-            }) as A.AstId,
+            }) as Ast.Id,
             initializer: val,
             loc: loc,
         });
-        return result as A.AstStructFieldValue;
+        return result as Ast.StructFieldValue;
     }
 
     function makeStructValue(
-        fields: A.AstStructFieldValue[],
-        type: A.AstId,
+        fields: Ast.StructFieldValue[],
+        type: Ast.Id,
         loc: SrcInfo,
-    ): A.AstStructValue {
+    ): Ast.StructValue {
         const result = createNode({
             kind: "struct_value",
             args: fields,
             loc: loc,
             type: type,
         });
-        return result as A.AstStructValue;
+        return result as Ast.StructValue;
     }
 
     return {
@@ -150,37 +150,37 @@ export const getAstUtil = ({ createNode }: FactoryAst) => {
 export type AstUtil = ReturnType<typeof getAstUtil>;
 
 // Checks if the top level node is an unary op node
-export function checkIsUnaryOpNode(ast: A.AstExpression): boolean {
+export function checkIsUnaryOpNode(ast: Ast.Expression): boolean {
     return ast.kind === "op_unary";
 }
 
 // Checks if the top level node is a binary op node
-export function checkIsBinaryOpNode(ast: A.AstExpression): boolean {
+export function checkIsBinaryOpNode(ast: Ast.Expression): boolean {
     return ast.kind === "op_binary";
 }
 
 // Checks if top level node is a binary op node
 // with a value node on the right
-export function checkIsBinaryOp_With_RightValue(ast: A.AstExpression): boolean {
+export function checkIsBinaryOp_With_RightValue(ast: Ast.Expression): boolean {
     return ast.kind === "op_binary" ? isLiteral(ast.right) : false;
 }
 
 // Checks if top level node is a binary op node
 // with a value node on the left
-export function checkIsBinaryOp_With_LeftValue(ast: A.AstExpression): boolean {
+export function checkIsBinaryOp_With_LeftValue(ast: Ast.Expression): boolean {
     return ast.kind === "op_binary" ? isLiteral(ast.left) : false;
 }
 
 // Checks if the top level node is the specified number
-export function checkIsNumber(ast: A.AstExpression, n: bigint): boolean {
+export function checkIsNumber(ast: Ast.Expression, n: bigint): boolean {
     return ast.kind === "number" ? ast.value == n : false;
 }
 
-export function checkIsName(ast: A.AstExpression): boolean {
+export function checkIsName(ast: Ast.Expression): boolean {
     return ast.kind === "id";
 }
 
 // Checks if the top level node is the specified boolean
-export function checkIsBoolean(ast: A.AstExpression, b: boolean): boolean {
+export function checkIsBoolean(ast: Ast.Expression, b: boolean): boolean {
     return ast.kind === "boolean" ? ast.value == b : false;
 }

--- a/src/context/store.ts
+++ b/src/context/store.ts
@@ -1,4 +1,4 @@
-import type * as A from "../ast/ast";
+import type * as Ast from "../ast/ast";
 import { throwInternalCompilerError } from "../error/errors";
 import type { CompilerContext } from "./context";
 import { createContextStore } from "./context";
@@ -16,12 +16,12 @@ export type AstStore = {
     sources: Source[];
     funcSources: { code: string; path: string }[];
     functions: (
-        | A.AstFunctionDef
-        | A.AstNativeFunctionDecl
-        | A.AstAsmFunctionDef
+        | Ast.FunctionDef
+        | Ast.NativeFunctionDecl
+        | Ast.AsmFunctionDef
     )[];
-    constants: A.AstConstantDef[];
-    types: A.AstTypeDecl[];
+    constants: Ast.ConstantDef[];
+    types: Ast.TypeDecl[];
 };
 
 const store = createContextStore<AstStore>();
@@ -45,7 +45,7 @@ export function getRawAST(ctx: CompilerContext): AstStore {
  * Parses multiple Tact source files into AST modules.
  * @public
  */
-export function parseModules(sources: Source[], parser: Parser): A.AstModule[] {
+export function parseModules(sources: Source[], parser: Parser): Ast.Module[] {
     return sources.map((source) => parser.parse(source));
 }
 
@@ -61,16 +61,16 @@ export function openContext(
     sources: Source[],
     funcSources: { code: string; path: string }[],
     parser: Parser,
-    parsedModules?: A.AstModule[],
+    parsedModules?: Ast.Module[],
 ): CompilerContext {
     const modules = parsedModules ?? parseModules(sources, parser);
-    const types: A.AstTypeDecl[] = [];
+    const types: Ast.TypeDecl[] = [];
     const functions: (
-        | A.AstNativeFunctionDecl
-        | A.AstFunctionDef
-        | A.AstAsmFunctionDef
+        | Ast.NativeFunctionDecl
+        | Ast.FunctionDef
+        | Ast.AsmFunctionDef
     )[] = [];
-    const constants: A.AstConstantDef[] = [];
+    const constants: Ast.ConstantDef[] = [];
     for (const module of modules) {
         for (const item of module.items) {
             switch (item.kind) {

--- a/src/error/errors.ts
+++ b/src/error/errors.ts
@@ -1,6 +1,6 @@
 import path from "path";
 import { cwd } from "process";
-import type { AstFuncId, AstId, AstTypeId } from "../ast/ast";
+import type * as Ast from "../ast/ast";
 import type { SrcInfo } from "../grammar";
 
 export class TactInternalError extends Error {
@@ -118,7 +118,7 @@ export function throwConstEvalError(
  * @deprecated Use loc.locatedId()
  */
 export function idTextErr(
-    ident: AstId | AstFuncId | AstTypeId | string,
+    ident: Ast.Id | Ast.FuncId | Ast.TypeId | string,
 ): string {
     if (typeof ident === "string") {
         return `"${ident}"`;

--- a/src/generator/writers/id.ts
+++ b/src/generator/writers/id.ts
@@ -1,14 +1,14 @@
-import type { AstId } from "../../ast/ast";
+import type * as Ast from "../../ast/ast";
 import { idText } from "../../ast/ast-helpers";
 
-export function funcIdOf(ident: AstId | string): string {
+export function funcIdOf(ident: Ast.Id | string): string {
     if (typeof ident === "string") {
         return "$" + ident;
     }
     return "$" + idText(ident);
 }
 
-export function funcInitIdOf(ident: AstId | string): string {
+export function funcInitIdOf(ident: Ast.Id | string): string {
     if (typeof ident === "string") {
         return ident + "$init";
     }

--- a/src/generator/writers/writeExpression.ts
+++ b/src/generator/writers/writeExpression.ts
@@ -4,7 +4,7 @@ import {
     throwCompilationError,
     throwInternalCompilerError,
 } from "../../error/errors";
-import type * as A from "../../ast/ast";
+import type * as Ast from "../../ast/ast";
 import { getExpType } from "../../types/resolveExpression";
 import {
     getStaticConstant,
@@ -40,7 +40,7 @@ import {
 } from "../../ast/ast-helpers";
 import { enabledDebug, enabledNullChecks } from "../../config/features";
 
-function isNull(wCtx: WriterContext, expr: A.AstExpression): boolean {
+function isNull(wCtx: WriterContext, expr: Ast.Expression): boolean {
     return getExpType(wCtx.ctx, expr).kind === "null";
 }
 
@@ -94,7 +94,7 @@ function writeStructConstructor(
     return name;
 }
 
-export function writeValue(val: A.AstLiteral, wCtx: WriterContext): string {
+export function writeValue(val: Ast.Literal, wCtx: WriterContext): string {
     switch (val.kind) {
         case "number":
             return val.value.toString(10);
@@ -124,7 +124,7 @@ export function writeValue(val: A.AstLiteral, wCtx: WriterContext): string {
             return "null()";
         case "struct_value": {
             // Transform the struct fields into a map for lookup
-            const valMap: Map<string, A.AstLiteral> = new Map();
+            const valMap: Map<string, Ast.Literal> = new Map();
             for (const f of val.args) {
                 valMap.set(idText(f.field), f.initializer);
             }
@@ -157,12 +157,12 @@ export function writeValue(val: A.AstLiteral, wCtx: WriterContext): string {
     }
 }
 
-export function writePathExpression(path: A.AstId[]): string {
+export function writePathExpression(path: Ast.Id[]): string {
     return [funcIdOf(idText(path[0]!)), ...path.slice(1).map(idText)].join(`'`);
 }
 
 export function writeExpression(
-    f: A.AstExpression,
+    f: Ast.Expression,
     wCtx: WriterContext,
 ): string {
     // literals and constant expressions are covered here
@@ -739,7 +739,7 @@ export function writeExpression(
 }
 
 export function writeTypescriptValue(
-    val: A.AstLiteral | undefined,
+    val: Ast.Literal | undefined,
 ): string | undefined {
     if (typeof val === "undefined") return undefined;
 

--- a/src/generator/writers/writeFunction.ts
+++ b/src/generator/writers/writeFunction.ts
@@ -1,5 +1,5 @@
 import { enabledInline } from "../../config/features";
-import type * as A from "../../ast/ast";
+import type * as Ast from "../../ast/ast";
 import {
     idOfText,
     idText,
@@ -23,7 +23,7 @@ import { idTextErr, throwInternalCompilerError } from "../../error/errors";
 import { ppAsmShuffle } from "../../ast/ast-printer";
 
 export function writeCastedExpression(
-    expression: A.AstExpression,
+    expression: Ast.Expression,
     to: TypeRef,
     ctx: WriterContext,
 ) {
@@ -61,7 +61,7 @@ function unwrapExternal(
 }
 
 export function writeStatement(
-    f: A.AstStatement,
+    f: Ast.Statement,
     self: string | null,
     returns: TypeRef | null,
     ctx: WriterContext,
@@ -529,7 +529,7 @@ export function writeStatement(
 }
 
 function writeCondition(
-    f: A.AstStatementCondition,
+    f: Ast.StatementCondition,
     self: string | null,
     elseif: boolean,
     returns: TypeRef | null,
@@ -726,7 +726,7 @@ export function writeFunction(f: FunctionDescription, ctx: WriterContext) {
 
 function getAsmFunctionSignature(
     f: FunctionDescription,
-    fAst: A.AstAsmFunctionDef,
+    fAst: Ast.AsmFunctionDef,
     params: string[],
 ) {
     const isMutable = fAst.attributes.some((a) => a.type === "mutates");
@@ -739,7 +739,7 @@ function getAsmFunctionSignature(
         !isMutable;
 
     if (!needRearrange) {
-        const asmShuffleEscaped: A.AstAsmShuffle = {
+        const asmShuffleEscaped: Ast.AsmShuffle = {
             ...fAst.shuffle,
             args: fAst.shuffle.args.map((id) => idOfText(funcIdOf(id))),
         };

--- a/src/generator/writers/writeRouter.ts
+++ b/src/generator/writers/writeRouter.ts
@@ -11,7 +11,7 @@ import { funcIdOf } from "./id";
 import { ops } from "./ops";
 import { resolveFuncTypeUnpack } from "./resolveFuncTypeUnpack";
 import { writeStatement } from "./writeFunction";
-import type { AstNumber, AstReceiver } from "../../ast/ast";
+import type * as Ast from "../../ast/ast";
 import {
     throwCompilationError,
     throwInternal,
@@ -47,7 +47,7 @@ type Receivers = {
 type FallbackReceiver = {
     selector: FallbackReceiverSelector;
     effects: ReadonlySet<Effect>;
-    ast: AstReceiver;
+    ast: Ast.Receiver;
 };
 
 type BouncedReceivers = {
@@ -685,7 +685,7 @@ function writeReceiverBody(
     wCtx.append("return ();");
 }
 
-function messageOpcode(n: AstNumber): string {
+function messageOpcode(n: Ast.Number): string {
     // FunC does not support binary and octal numerals
     switch (n.base) {
         case 10:

--- a/src/grammar/index.ts
+++ b/src/grammar/index.ts
@@ -220,7 +220,7 @@ const parseStructFieldInitializer =
         name,
         init,
         loc,
-    }: $ast.StructFieldInitializer): Handler<Ast.AstStructFieldInitializer> =>
+    }: $ast.StructFieldInitializer): Handler<Ast.StructFieldInitializer> =>
     (ctx) => {
         const fieldId = parseId(name)(ctx);
 

--- a/src/imports/resolveLibrary.ts
+++ b/src/imports/resolveLibrary.ts
@@ -1,10 +1,10 @@
-import type { ImportPath } from "../ast/ast";
+import type * as Ast from "../ast/ast";
 import type { VirtualFileSystem } from "../vfs/VirtualFileSystem";
 import { asString } from "./path";
 import type { ItemOrigin, Language, Source } from "./source";
 
 type ResolveLibraryArgs = {
-    readonly importPath: ImportPath;
+    readonly importPath: Ast.ImportPath;
     readonly sourceFrom: Source;
     readonly project: VirtualFileSystem;
     readonly stdlib: VirtualFileSystem;

--- a/src/optimizer/algebraic.ts
+++ b/src/optimizer/algebraic.ts
@@ -1,4 +1,4 @@
-import type * as A from "../ast/ast";
+import type * as Ast from "../ast/ast";
 import { eqExpressions, isLiteral } from "../ast/ast-helpers";
 import type { ExpressionTransformer } from "./types";
 import { Rule } from "./types";
@@ -11,14 +11,14 @@ import {
 } from "../ast/util";
 
 export class AddZero extends Rule {
-    private additiveOperators: A.AstBinaryOperation[] = ["+", "-"];
+    private additiveOperators: Ast.BinaryOperation[] = ["+", "-"];
 
     public applyRule(
-        ast: A.AstExpression,
+        ast: Ast.Expression,
         { util }: ExpressionTransformer,
-    ): A.AstExpression {
+    ): Ast.Expression {
         if (checkIsBinaryOpNode(ast)) {
-            const topLevelNode = ast as A.AstOpBinary;
+            const topLevelNode = ast as Ast.OpBinary;
             if (this.additiveOperators.includes(topLevelNode.op)) {
                 if (
                     !isLiteral(topLevelNode.left) &&
@@ -57,11 +57,11 @@ export class AddZero extends Rule {
 
 export class MultiplyZero extends Rule {
     public applyRule(
-        ast: A.AstExpression,
+        ast: Ast.Expression,
         { util }: ExpressionTransformer,
-    ): A.AstExpression {
+    ): Ast.Expression {
         if (checkIsBinaryOpNode(ast)) {
-            const topLevelNode = ast as A.AstOpBinary;
+            const topLevelNode = ast as Ast.OpBinary;
             if (topLevelNode.op === "*") {
                 if (
                     checkIsName(topLevelNode.left) &&
@@ -91,11 +91,11 @@ export class MultiplyZero extends Rule {
 
 export class MultiplyOne extends Rule {
     public applyRule(
-        ast: A.AstExpression,
+        ast: Ast.Expression,
         _optimizer: ExpressionTransformer,
-    ): A.AstExpression {
+    ): Ast.Expression {
         if (checkIsBinaryOpNode(ast)) {
-            const topLevelNode = ast as A.AstOpBinary;
+            const topLevelNode = ast as Ast.OpBinary;
             if (topLevelNode.op === "*") {
                 if (
                     !isLiteral(topLevelNode.left) &&
@@ -129,11 +129,11 @@ export class MultiplyOne extends Rule {
 
 export class SubtractSelf extends Rule {
     public applyRule(
-        ast: A.AstExpression,
+        ast: Ast.Expression,
         { util }: ExpressionTransformer,
-    ): A.AstExpression {
+    ): Ast.Expression {
         if (checkIsBinaryOpNode(ast)) {
-            const topLevelNode = ast as A.AstOpBinary;
+            const topLevelNode = ast as Ast.OpBinary;
             if (topLevelNode.op === "-") {
                 if (
                     checkIsName(topLevelNode.left) &&
@@ -161,11 +161,11 @@ export class SubtractSelf extends Rule {
 
 export class AddSelf extends Rule {
     public applyRule(
-        ast: A.AstExpression,
+        ast: Ast.Expression,
         { applyRules, util }: ExpressionTransformer,
-    ): A.AstExpression {
+    ): Ast.Expression {
         if (checkIsBinaryOpNode(ast)) {
-            const topLevelNode = ast as A.AstOpBinary;
+            const topLevelNode = ast as Ast.OpBinary;
             if (topLevelNode.op === "+") {
                 if (
                     !isLiteral(topLevelNode.left) &&
@@ -200,11 +200,11 @@ export class AddSelf extends Rule {
 
 export class OrTrue extends Rule {
     public applyRule(
-        ast: A.AstExpression,
+        ast: Ast.Expression,
         { util }: ExpressionTransformer,
-    ): A.AstExpression {
+    ): Ast.Expression {
         if (checkIsBinaryOpNode(ast)) {
-            const topLevelNode = ast as A.AstOpBinary;
+            const topLevelNode = ast as Ast.OpBinary;
             if (topLevelNode.op === "||") {
                 if (
                     (checkIsName(topLevelNode.left) ||
@@ -232,11 +232,11 @@ export class OrTrue extends Rule {
 
 export class AndFalse extends Rule {
     public applyRule(
-        ast: A.AstExpression,
+        ast: Ast.Expression,
         { util }: ExpressionTransformer,
-    ): A.AstExpression {
+    ): Ast.Expression {
         if (checkIsBinaryOpNode(ast)) {
-            const topLevelNode = ast as A.AstOpBinary;
+            const topLevelNode = ast as Ast.OpBinary;
             if (topLevelNode.op === "&&") {
                 if (
                     (checkIsName(topLevelNode.left) ||
@@ -264,11 +264,11 @@ export class AndFalse extends Rule {
 
 export class OrFalse extends Rule {
     public applyRule(
-        ast: A.AstExpression,
+        ast: Ast.Expression,
         _optimizer: ExpressionTransformer,
-    ): A.AstExpression {
+    ): Ast.Expression {
         if (checkIsBinaryOpNode(ast)) {
-            const topLevelNode = ast as A.AstOpBinary;
+            const topLevelNode = ast as Ast.OpBinary;
             if (topLevelNode.op === "||") {
                 if (checkIsBoolean(topLevelNode.right, false)) {
                     // The tree has this form:
@@ -296,11 +296,11 @@ export class OrFalse extends Rule {
 
 export class AndTrue extends Rule {
     public applyRule(
-        ast: A.AstExpression,
+        ast: Ast.Expression,
         _optimizer: ExpressionTransformer,
-    ): A.AstExpression {
+    ): Ast.Expression {
         if (checkIsBinaryOpNode(ast)) {
-            const topLevelNode = ast as A.AstOpBinary;
+            const topLevelNode = ast as Ast.OpBinary;
             if (topLevelNode.op === "&&") {
                 if (checkIsBoolean(topLevelNode.right, true)) {
                     // The tree has this form:
@@ -328,11 +328,11 @@ export class AndTrue extends Rule {
 
 export class OrSelf extends Rule {
     public applyRule(
-        ast: A.AstExpression,
+        ast: Ast.Expression,
         _optimizer: ExpressionTransformer,
-    ): A.AstExpression {
+    ): Ast.Expression {
         if (checkIsBinaryOpNode(ast)) {
-            const topLevelNode = ast as A.AstOpBinary;
+            const topLevelNode = ast as Ast.OpBinary;
             if (topLevelNode.op === "||") {
                 // The tree has this form:
                 // x || y
@@ -355,11 +355,11 @@ export class OrSelf extends Rule {
 
 export class AndSelf extends Rule {
     public applyRule(
-        ast: A.AstExpression,
+        ast: Ast.Expression,
         _optimizer: ExpressionTransformer,
-    ): A.AstExpression {
+    ): Ast.Expression {
         if (checkIsBinaryOpNode(ast)) {
-            const topLevelNode = ast as A.AstOpBinary;
+            const topLevelNode = ast as Ast.OpBinary;
             if (topLevelNode.op === "&&") {
                 // The tree has this form:
                 // x && y
@@ -382,14 +382,14 @@ export class AndSelf extends Rule {
 
 export class ExcludedMiddle extends Rule {
     public applyRule(
-        ast: A.AstExpression,
+        ast: Ast.Expression,
         { util }: ExpressionTransformer,
-    ): A.AstExpression {
+    ): Ast.Expression {
         if (checkIsBinaryOpNode(ast)) {
-            const topLevelNode = ast as A.AstOpBinary;
+            const topLevelNode = ast as Ast.OpBinary;
             if (topLevelNode.op === "||") {
                 if (checkIsUnaryOpNode(topLevelNode.right)) {
-                    const rightNode = topLevelNode.right as A.AstOpUnary;
+                    const rightNode = topLevelNode.right as Ast.OpUnary;
                     if (rightNode.op === "!") {
                         // The tree has this form:
                         // x || !y
@@ -407,7 +407,7 @@ export class ExcludedMiddle extends Rule {
                         }
                     }
                 } else if (checkIsUnaryOpNode(topLevelNode.left)) {
-                    const leftNode = topLevelNode.left as A.AstOpUnary;
+                    const leftNode = topLevelNode.left as Ast.OpUnary;
                     if (leftNode.op === "!") {
                         // The tree has this form:
                         // !x || y
@@ -436,14 +436,14 @@ export class ExcludedMiddle extends Rule {
 
 export class Contradiction extends Rule {
     public applyRule(
-        ast: A.AstExpression,
+        ast: Ast.Expression,
         { util }: ExpressionTransformer,
-    ): A.AstExpression {
+    ): Ast.Expression {
         if (checkIsBinaryOpNode(ast)) {
-            const topLevelNode = ast as A.AstOpBinary;
+            const topLevelNode = ast as Ast.OpBinary;
             if (topLevelNode.op === "&&") {
                 if (checkIsUnaryOpNode(topLevelNode.right)) {
-                    const rightNode = topLevelNode.right as A.AstOpUnary;
+                    const rightNode = topLevelNode.right as Ast.OpUnary;
                     if (rightNode.op === "!") {
                         // The tree has this form:
                         // x && !y
@@ -461,7 +461,7 @@ export class Contradiction extends Rule {
                         }
                     }
                 } else if (checkIsUnaryOpNode(topLevelNode.left)) {
-                    const leftNode = topLevelNode.left as A.AstOpUnary;
+                    const leftNode = topLevelNode.left as Ast.OpUnary;
                     if (leftNode.op === "!") {
                         // The tree has this form:
                         // !x && y
@@ -490,14 +490,14 @@ export class Contradiction extends Rule {
 
 export class DoubleNegation extends Rule {
     public applyRule(
-        ast: A.AstExpression,
+        ast: Ast.Expression,
         _optimizer: ExpressionTransformer,
-    ): A.AstExpression {
+    ): Ast.Expression {
         if (checkIsUnaryOpNode(ast)) {
-            const topLevelNode = ast as A.AstOpUnary;
+            const topLevelNode = ast as Ast.OpUnary;
             if (topLevelNode.op === "!") {
                 if (checkIsUnaryOpNode(topLevelNode.operand)) {
-                    const innerNode = topLevelNode.operand as A.AstOpUnary;
+                    const innerNode = topLevelNode.operand as Ast.OpUnary;
                     if (innerNode.op === "!") {
                         // The tree has this form:
                         // !!x
@@ -518,11 +518,11 @@ export class DoubleNegation extends Rule {
 
 export class NegateTrue extends Rule {
     public applyRule(
-        ast: A.AstExpression,
+        ast: Ast.Expression,
         { util }: ExpressionTransformer,
-    ): A.AstExpression {
+    ): Ast.Expression {
         if (checkIsUnaryOpNode(ast)) {
-            const topLevelNode = ast as A.AstOpUnary;
+            const topLevelNode = ast as Ast.OpUnary;
             if (topLevelNode.op === "!") {
                 if (checkIsBoolean(topLevelNode.operand, true)) {
                     // The tree has this form
@@ -541,11 +541,11 @@ export class NegateTrue extends Rule {
 
 export class NegateFalse extends Rule {
     public applyRule(
-        ast: A.AstExpression,
+        ast: Ast.Expression,
         { util }: ExpressionTransformer,
-    ): A.AstExpression {
+    ): Ast.Expression {
         if (checkIsUnaryOpNode(ast)) {
-            const topLevelNode = ast as A.AstOpUnary;
+            const topLevelNode = ast as Ast.OpUnary;
             if (topLevelNode.op === "!") {
                 if (checkIsBoolean(topLevelNode.operand, false)) {
                     // The tree has this form

--- a/src/optimizer/constEval.ts
+++ b/src/optimizer/constEval.ts
@@ -1,5 +1,5 @@
 import type { CompilerContext } from "../context/context";
-import type * as A from "../ast/ast";
+import type * as Ast from "../ast/ast";
 import { isLiteral } from "../ast/ast-helpers";
 import {
     TactConstEvalError,
@@ -21,9 +21,9 @@ import type { SrcInfo } from "../grammar";
 // Utility Exception class to interrupt the execution
 // of functions that cannot evaluate a tree fully into a value.
 class PartiallyEvaluatedTree extends Error {
-    public tree: A.AstExpression;
+    public tree: Ast.Expression;
 
-    constructor(tree: A.AstExpression) {
+    constructor(tree: Ast.Expression) {
         super();
         this.tree = tree;
     }
@@ -35,11 +35,11 @@ export const getOptimizer = (util: AstUtil) => {
     const optimizer: ExpressionTransformer = new StandardOptimizer(util);
 
     function partiallyEvalUnaryOp(
-        op: A.AstUnaryOperation,
-        operand: A.AstExpression,
+        op: Ast.UnaryOperation,
+        operand: Ast.Expression,
         source: SrcInfo,
         ctx: CompilerContext,
-    ): A.AstExpression {
+    ): Ast.Expression {
         if (operand.kind === "number" && op === "-") {
             // emulating negative integer literals
             return ensureInt(util.makeNumberLiteral(-operand.value, source));
@@ -57,12 +57,12 @@ export const getOptimizer = (util: AstUtil) => {
     }
 
     function partiallyEvalBinaryOp(
-        op: A.AstBinaryOperation,
-        left: A.AstExpression,
-        right: A.AstExpression,
+        op: Ast.BinaryOperation,
+        left: Ast.Expression,
+        right: Ast.Expression,
         source: SrcInfo,
         ctx: CompilerContext,
-    ): A.AstExpression {
+    ): Ast.Expression {
         const leftOperand = partiallyEvalExpression(left, ctx);
 
         if (isLiteral(leftOperand)) {
@@ -126,10 +126,10 @@ export const getOptimizer = (util: AstUtil) => {
 
     // FIXME: Refactor this method in a separate PR because many cases in the switch do the same.
     function partiallyEvalExpression(
-        ast: A.AstExpression,
+        ast: Ast.Expression,
         ctx: CompilerContext,
         interpreterConfig?: InterpreterConfig,
-    ): A.AstExpression {
+    ): Ast.Expression {
         const interpreter = new Interpreter(util, ctx, interpreterConfig);
         switch (ast.kind) {
             case "id":
@@ -212,11 +212,11 @@ export const getOptimizer = (util: AstUtil) => {
 };
 
 export function evalConstantExpression(
-    ast: A.AstExpression,
+    ast: Ast.Expression,
     ctx: CompilerContext,
     util: AstUtil,
     interpreterConfig?: InterpreterConfig,
-): A.AstLiteral {
+): Ast.Literal {
     const interpreter = new Interpreter(util, ctx, interpreterConfig);
     const result = interpreter.interpretExpression(ast);
     return result;

--- a/src/optimizer/interpreter.ts
+++ b/src/optimizer/interpreter.ts
@@ -1,7 +1,7 @@
 import { Address, beginCell, BitString, Cell, toNano } from "@ton/core";
 import { paddedBufferToBits } from "@ton/core/dist/boc/utils/paddedBits";
 import { crc32 } from "../utils/crc32";
-import type * as A from "../ast/ast";
+import type * as Ast from "../ast/ast";
 import { evalConstantExpression } from "./constEval";
 import { CompilerContext } from "../context/context";
 import {
@@ -73,10 +73,10 @@ function throwErrorConstEval(msg: string, source: SrcInfo): never {
 }
 
 type EvalResult =
-    | { kind: "ok"; value: A.AstLiteral }
+    | { kind: "ok"; value: Ast.Literal }
     | { kind: "error"; message: string };
 
-export function ensureInt(val: A.AstExpression): A.AstNumber {
+export function ensureInt(val: Ast.Expression): Ast.Number {
     if (val.kind !== "number") {
         throwErrorConstEval(
             `integer expected, but got expression of kind '${val.kind}'`,
@@ -93,7 +93,7 @@ export function ensureInt(val: A.AstExpression): A.AstNumber {
     }
 }
 
-function ensureArgumentForEquality(val: A.AstLiteral): A.AstLiteral {
+function ensureArgumentForEquality(val: Ast.Literal): Ast.Literal {
     switch (val.kind) {
         case "address":
         case "boolean":
@@ -114,7 +114,7 @@ function ensureArgumentForEquality(val: A.AstLiteral): A.AstLiteral {
     }
 }
 
-function ensureRepeatInt(val: A.AstExpression): A.AstNumber {
+function ensureRepeatInt(val: Ast.Expression): Ast.Number {
     if (val.kind !== "number") {
         throwErrorConstEval(
             `integer expected, but got expression of kind '${val.kind}'`,
@@ -131,7 +131,7 @@ function ensureRepeatInt(val: A.AstExpression): A.AstNumber {
     }
 }
 
-export function ensureBoolean(val: A.AstExpression): A.AstBoolean {
+export function ensureBoolean(val: Ast.Expression): Ast.Boolean {
     if (val.kind !== "boolean") {
         throwErrorConstEval(
             `boolean expected, but got expression of kind '${val.kind}'`,
@@ -141,7 +141,7 @@ export function ensureBoolean(val: A.AstExpression): A.AstBoolean {
     return val;
 }
 
-export function ensureString(val: A.AstExpression): A.AstString {
+export function ensureString(val: Ast.Expression): Ast.String {
     if (val.kind !== "string") {
         throwErrorConstEval(
             `string expected, but got expression of kind '${val.kind}'`,
@@ -152,8 +152,8 @@ export function ensureString(val: A.AstExpression): A.AstString {
 }
 
 export function ensureSimplifiedString(
-    val: A.AstExpression,
-): A.AstSimplifiedString {
+    val: Ast.Expression,
+): Ast.SimplifiedString {
     if (val.kind !== "simplified_string") {
         throwErrorConstEval(
             `simplified string expected, but got expression of kind '${val.kind}'`,
@@ -165,7 +165,7 @@ export function ensureSimplifiedString(
 
 function ensureFunArity(
     arity: number,
-    args: readonly A.AstExpression[],
+    args: readonly Ast.Expression[],
     source: SrcInfo,
 ) {
     if (args.length !== arity) {
@@ -178,7 +178,7 @@ function ensureFunArity(
 
 function ensureMethodArity(
     arity: number,
-    args: readonly A.AstExpression[],
+    args: readonly Ast.Expression[],
     source: SrcInfo,
 ) {
     if (args.length !== arity) {
@@ -190,11 +190,11 @@ function ensureMethodArity(
 }
 
 export function evalUnaryOp(
-    op: A.AstUnaryOperation,
-    valOperand: A.AstLiteral,
+    op: Ast.UnaryOperation,
+    valOperand: Ast.Literal,
     source: SrcInfo,
     util: AstUtil,
-): A.AstLiteral {
+): Ast.Literal {
     switch (op) {
         case "+":
             return ensureInt(valOperand);
@@ -227,12 +227,12 @@ export function evalUnaryOp(
 }
 
 export function evalBinaryOp(
-    op: A.AstBinaryOperation,
-    valLeft: A.AstLiteral,
-    valRightContinuation: () => A.AstLiteral, // It needs to be a continuation, because some binary operators short-circuit
+    op: Ast.BinaryOperation,
+    valLeft: Ast.Literal,
+    valRightContinuation: () => Ast.Literal, // It needs to be a continuation, because some binary operators short-circuit
     source: SrcInfo,
     util: AstUtil,
-): A.AstLiteral {
+): Ast.Literal {
     switch (op) {
         case "+": {
             const astLeft = ensureInt(valLeft);
@@ -482,14 +482,14 @@ export function interpretEscapeSequences(
 }
 
 class ReturnSignal extends Error {
-    private value?: A.AstLiteral;
+    private value?: Ast.Literal;
 
-    constructor(value?: A.AstLiteral) {
+    constructor(value?: Ast.Literal) {
         super();
         this.value = value;
     }
 
-    public getValue(): A.AstLiteral | undefined {
+    public getValue(): Ast.Literal | undefined {
         return this.value;
     }
 }
@@ -505,7 +505,7 @@ export type InterpreterConfig = {
 const WILDCARD_NAME: string = "_";
 
 type Environment = {
-    values: Map<string, A.AstLiteral>;
+    values: Map<string, Ast.Literal>;
     parent?: Environment;
 };
 
@@ -516,9 +516,7 @@ class EnvironmentStack {
         this.currentEnv = { values: new Map() };
     }
 
-    private findBindingMap(
-        name: string,
-    ): Map<string, A.AstLiteral> | undefined {
+    private findBindingMap(name: string): Map<string, Ast.Literal> | undefined {
         let env: Environment | undefined = this.currentEnv;
         while (env !== undefined) {
             if (env.values.has(name)) {
@@ -576,7 +574,7 @@ class EnvironmentStack {
     so that the return at line 5 (now in the environment a = 3) will 
     produce 3 * 2 = 6, and so on.
     */
-    public setNewBinding(name: string, val: A.AstLiteral) {
+    public setNewBinding(name: string, val: Ast.Literal) {
         if (name !== WILDCARD_NAME) {
             this.currentEnv.values.set(name, val);
         }
@@ -589,7 +587,7 @@ class EnvironmentStack {
     to "val". If it does not find "name", the stack is unchanged.
     As a special case, name "_" is always ignored.
     */
-    public updateBinding(name: string, val: A.AstLiteral) {
+    public updateBinding(name: string, val: Ast.Literal) {
         if (name !== WILDCARD_NAME) {
             const bindings = this.findBindingMap(name);
             if (bindings !== undefined) {
@@ -605,7 +603,7 @@ class EnvironmentStack {
     If it does not find "name", it returns undefined.
     As a special case, name "_" always returns undefined.
     */
-    public getBinding(name: string): A.AstLiteral | undefined {
+    public getBinding(name: string): Ast.Literal | undefined {
         if (name === WILDCARD_NAME) {
             return undefined;
         }
@@ -635,7 +633,7 @@ class EnvironmentStack {
      */
     public executeInNewEnvironment<T>(
         code: () => T,
-        initialBindings: { names: string[]; values: A.AstLiteral[] } = {
+        initialBindings: { names: string[]; values: Ast.Literal[] } = {
             names: [],
             values: [],
         },
@@ -763,7 +761,7 @@ export class Interpreter {
      * This is the public access for expression interpretation.
      * @param ast Expression to interpret.
      */
-    public interpretExpression(expr: A.AstExpression): A.AstLiteral {
+    public interpretExpression(expr: Ast.Expression): Ast.Literal {
         return this.handleStackOverflow(expr.loc, () =>
             this.interpretExpressionInternal(expr),
         );
@@ -773,7 +771,7 @@ export class Interpreter {
      * This is the public access for statement interpretation.
      * @param stmt Statement to interpret.
      */
-    public interpretStatement(stmt: A.AstStatement) {
+    public interpretStatement(stmt: Ast.Statement) {
         this.handleStackOverflow(stmt.loc, () => {
             this.interpretStatementInternal(stmt);
         });
@@ -783,13 +781,13 @@ export class Interpreter {
      * This is the public access for module item interpretation.
      * @param modItem Module item to interpret.
      */
-    public interpretModuleItem(modItem: A.AstModuleItem) {
+    public interpretModuleItem(modItem: Ast.ModuleItem) {
         this.handleStackOverflow(modItem.loc, () => {
             this.interpretModuleItemInternal(modItem);
         });
     }
 
-    private interpretModuleItemInternal(ast: A.AstModuleItem) {
+    private interpretModuleItemInternal(ast: Ast.ModuleItem) {
         switch (ast.kind) {
             case "constant_def":
                 this.interpretConstantDef(ast);
@@ -824,63 +822,63 @@ export class Interpreter {
         }
     }
 
-    private interpretConstantDef(ast: A.AstConstantDef) {
+    private interpretConstantDef(ast: Ast.ConstantDef) {
         throwNonFatalErrorConstEval(
             "Constant definitions are currently not supported.",
             ast.loc,
         );
     }
 
-    private interpretFunctionDef(ast: A.AstFunctionDef) {
+    private interpretFunctionDef(ast: Ast.FunctionDef) {
         throwNonFatalErrorConstEval(
             "Function definitions are currently not supported.",
             ast.loc,
         );
     }
 
-    private interpretStructDecl(ast: A.AstStructDecl) {
+    private interpretStructDecl(ast: Ast.StructDecl) {
         throwNonFatalErrorConstEval(
             "Struct declarations are currently not supported.",
             ast.loc,
         );
     }
 
-    private interpretMessageDecl(ast: A.AstMessageDecl) {
+    private interpretMessageDecl(ast: Ast.MessageDecl) {
         throwNonFatalErrorConstEval(
             "Message declarations are currently not supported.",
             ast.loc,
         );
     }
 
-    private interpretPrimitiveTypeDecl(ast: A.AstPrimitiveTypeDecl) {
+    private interpretPrimitiveTypeDecl(ast: Ast.PrimitiveTypeDecl) {
         throwNonFatalErrorConstEval(
             "Primitive type declarations are currently not supported.",
             ast.loc,
         );
     }
 
-    private interpretFunctionDecl(ast: A.AstNativeFunctionDecl) {
+    private interpretFunctionDecl(ast: Ast.NativeFunctionDecl) {
         throwNonFatalErrorConstEval(
             "Native function declarations are currently not supported.",
             ast.loc,
         );
     }
 
-    private interpretContract(ast: A.AstContract) {
+    private interpretContract(ast: Ast.Contract) {
         throwNonFatalErrorConstEval(
             "Contract declarations are currently not supported.",
             ast.loc,
         );
     }
 
-    private interpretTrait(ast: A.AstTrait) {
+    private interpretTrait(ast: Ast.Trait) {
         throwNonFatalErrorConstEval(
             "Trait declarations are currently not supported.",
             ast.loc,
         );
     }
 
-    private interpretExpressionInternal(ast: A.AstExpression): A.AstLiteral {
+    private interpretExpressionInternal(ast: Ast.Expression): Ast.Literal {
         switch (ast.kind) {
             case "id":
                 return this.interpretName(ast);
@@ -925,7 +923,7 @@ export class Interpreter {
         }
     }
 
-    private interpretName(ast: A.AstId): A.AstLiteral {
+    private interpretName(ast: Ast.Id): Ast.Literal {
         const name = idText(ast);
 
         if (hasStaticConstant(this.context, name)) {
@@ -967,7 +965,7 @@ export class Interpreter {
         throwNonFatalErrorConstEval("cannot evaluate a variable", ast.loc);
     }
 
-    private interpretMethodCall(ast: A.AstMethodCall): A.AstLiteral {
+    private interpretMethodCall(ast: Ast.MethodCall): Ast.Literal {
         switch (idText(ast.method)) {
             case "asComment": {
                 ensureMethodArity(0, ast.args, ast.loc);
@@ -990,33 +988,33 @@ export class Interpreter {
         }
     }
 
-    private interpretInitOf(ast: A.AstInitOf): A.AstLiteral {
+    private interpretInitOf(ast: Ast.InitOf): Ast.Literal {
         throwNonFatalErrorConstEval(
             "initOf is not supported at this moment",
             ast.loc,
         );
     }
 
-    private interpretCodeOf(ast: A.AstCodeOf): A.AstLiteral {
+    private interpretCodeOf(ast: Ast.CodeOf): Ast.Literal {
         throwNonFatalErrorConstEval(
             "codeOf is not supported at this moment",
             ast.loc,
         );
     }
 
-    private interpretNull(ast: A.AstNull): A.AstNull {
+    private interpretNull(ast: Ast.Null): Ast.Null {
         return ast;
     }
 
-    private interpretBoolean(ast: A.AstBoolean): A.AstBoolean {
+    private interpretBoolean(ast: Ast.Boolean): Ast.Boolean {
         return ast;
     }
 
-    private interpretNumber(ast: A.AstNumber): A.AstNumber {
+    private interpretNumber(ast: Ast.Number): Ast.Number {
         return ensureInt(ast);
     }
 
-    private interpretString(ast: A.AstString): A.AstSimplifiedString {
+    private interpretString(ast: Ast.String): Ast.SimplifiedString {
         return this.util.makeSimplifiedStringLiteral(
             interpretEscapeSequences(ast.value, ast.loc),
             ast.loc,
@@ -1024,24 +1022,24 @@ export class Interpreter {
     }
 
     private interpretSimplifiedString(
-        ast: A.AstSimplifiedString,
-    ): A.AstSimplifiedString {
+        ast: Ast.SimplifiedString,
+    ): Ast.SimplifiedString {
         return ast;
     }
 
-    private interpretAddress(ast: A.AstAddress): A.AstAddress {
+    private interpretAddress(ast: Ast.Address): Ast.Address {
         return ast;
     }
 
-    private interpretCell(ast: A.AstCell): A.AstCell {
+    private interpretCell(ast: Ast.Cell): Ast.Cell {
         return ast;
     }
 
-    private interpretSlice(ast: A.AstSlice): A.AstSlice {
+    private interpretSlice(ast: Ast.Slice): Ast.Slice {
         return ast;
     }
 
-    private interpretUnaryOp(ast: A.AstOpUnary): A.AstLiteral {
+    private interpretUnaryOp(ast: Ast.OpUnary): Ast.Literal {
         // Tact grammar does not have negative integer literals,
         // so in order to avoid errors for `-115792089237316195423570985008687907853269984665640564039457584007913129639936`
         // which is `-(2**256)` we need to have a special case for it
@@ -1058,7 +1056,7 @@ export class Interpreter {
         return evalUnaryOp(ast.op, valOperand, ast.loc, this.util);
     }
 
-    private interpretBinaryOp(ast: A.AstOpBinary): A.AstLiteral {
+    private interpretBinaryOp(ast: Ast.OpBinary): Ast.Literal {
         const valLeft = this.interpretExpressionInternal(ast.left);
         const valRightContinuation = () =>
             this.interpretExpressionInternal(ast.right);
@@ -1072,7 +1070,7 @@ export class Interpreter {
         );
     }
 
-    private interpretConditional(ast: A.AstConditional): A.AstLiteral {
+    private interpretConditional(ast: Ast.Conditional): Ast.Literal {
         // here we rely on the typechecker that both branches have the same type
         const valCond = ensureBoolean(
             this.interpretExpressionInternal(ast.condition),
@@ -1084,15 +1082,13 @@ export class Interpreter {
         }
     }
 
-    private interpretStructInstance(
-        ast: A.AstStructInstance,
-    ): A.AstStructValue {
+    private interpretStructInstance(ast: Ast.StructInstance): Ast.StructValue {
         const structTy = getType(this.context, ast.type);
 
         // initialize the resulting struct value with
         // the default values for fields with initializers
         // or null for uninitialized optional fields
-        const resultMap: Map<string, A.AstLiteral> = new Map();
+        const resultMap: Map<string, Ast.Literal> = new Map();
 
         for (const field of structTy.fields) {
             if (typeof field.default !== "undefined") {
@@ -1118,7 +1114,7 @@ export class Interpreter {
         // Create the field entries for the StructValue
         // The previous loop ensures that the map resultMap cannot return
         // undefined for each of the fields in ast.args
-        const structValueFields: A.AstStructFieldValue[] = [];
+        const structValueFields: Ast.StructFieldValue[] = [];
         for (const [fieldName, fieldValue] of resultMap) {
             // Find the source code declaration, if existent
             const sourceField = ast.args.find(
@@ -1147,12 +1143,12 @@ export class Interpreter {
         return this.util.makeStructValue(structValueFields, ast.type, ast.loc);
     }
 
-    private interpretStructValue(ast: A.AstStructValue): A.AstStructValue {
+    private interpretStructValue(ast: Ast.StructValue): Ast.StructValue {
         // Struct values are already simplified to their simplest form
         return ast;
     }
 
-    private interpretFieldAccess(ast: A.AstFieldAccess): A.AstLiteral {
+    private interpretFieldAccess(ast: Ast.FieldAccess): Ast.Literal {
         // special case for contract/trait constant accesses via `self.constant`
         // interpret "self" as a contract/trait access only if "self"
         // is not already assigned in the environment (this would mean
@@ -1231,7 +1227,7 @@ export class Interpreter {
         }
     }
 
-    private interpretStaticCall(ast: A.AstStaticCall): A.AstLiteral {
+    private interpretStaticCall(ast: Ast.StaticCall): Ast.Literal {
         switch (idText(ast.function)) {
             case "ton": {
                 ensureFunArity(1, ast.args, ast.loc);
@@ -1566,10 +1562,10 @@ export class Interpreter {
     }
 
     private evalStaticFunction(
-        functionCode: A.AstFunctionDef,
-        args: readonly A.AstExpression[],
+        functionCode: Ast.FunctionDef,
+        args: readonly Ast.Expression[],
         returns: TypeRef,
-    ): A.AstLiteral {
+    ): Ast.Literal {
         // Evaluate the arguments in the current environment
         const argValues = args.map(this.interpretExpressionInternal, this);
         // Extract the parameter names
@@ -1630,7 +1626,7 @@ export class Interpreter {
         );
     }
 
-    private interpretStatementInternal(ast: A.AstStatement) {
+    private interpretStatementInternal(ast: Ast.Statement) {
         switch (ast.kind) {
             case "statement_let":
                 this.interpretLetStatement(ast);
@@ -1674,7 +1670,7 @@ export class Interpreter {
         }
     }
 
-    private interpretLetStatement(ast: A.AstStatementLet) {
+    private interpretLetStatement(ast: Ast.StatementLet) {
         if (hasStaticConstant(this.context, idText(ast.name))) {
             // Attempt of shadowing a constant in a let declaration
             throwInternalCompilerError(
@@ -1686,7 +1682,7 @@ export class Interpreter {
         this.envStack.setNewBinding(idText(ast.name), val);
     }
 
-    private interpretDestructStatement(ast: A.AstStatementDestruct) {
+    private interpretDestructStatement(ast: Ast.StatementDestruct) {
         for (const [_, name] of ast.identifiers.values()) {
             if (hasStaticConstant(this.context, idText(name))) {
                 // Attempt of shadowing a constant in a destructuring declaration
@@ -1707,7 +1703,7 @@ export class Interpreter {
         }
 
         // Keep a map of the fields in val for lookup
-        const valAsMap: Map<string, A.AstLiteral> = new Map();
+        const valAsMap: Map<string, Ast.Literal> = new Map();
         val.args.forEach((f) => valAsMap.set(idText(f.field), f.initializer));
 
         for (const [field, name] of ast.identifiers.values()) {
@@ -1727,7 +1723,7 @@ export class Interpreter {
         }
     }
 
-    private interpretAssignStatement(ast: A.AstStatementAssign) {
+    private interpretAssignStatement(ast: Ast.StatementAssign) {
         if (ast.path.kind === "id") {
             const val = this.interpretExpressionInternal(ast.expression);
             this.envStack.updateBinding(idText(ast.path), val);
@@ -1740,7 +1736,7 @@ export class Interpreter {
     }
 
     private interpretAugmentedAssignStatement(
-        ast: A.AstStatementAugmentedAssign,
+        ast: Ast.StatementAugmentedAssign,
     ) {
         if (ast.path.kind === "id") {
             const updateVal = () =>
@@ -1768,7 +1764,7 @@ export class Interpreter {
         }
     }
 
-    private interpretConditionStatement(ast: A.AstStatementCondition) {
+    private interpretConditionStatement(ast: Ast.StatementCondition) {
         const condition = ensureBoolean(
             this.interpretExpressionInternal(ast.condition),
         );
@@ -1789,15 +1785,15 @@ export class Interpreter {
         }
     }
 
-    private interpretExpressionStatement(ast: A.AstStatementExpression) {
+    private interpretExpressionStatement(ast: Ast.StatementExpression) {
         this.interpretExpressionInternal(ast.expression);
     }
 
-    private interpretForEachStatement(ast: A.AstStatementForEach) {
+    private interpretForEachStatement(ast: Ast.StatementForEach) {
         throwNonFatalErrorConstEval("foreach currently not supported", ast.loc);
     }
 
-    private interpretRepeatStatement(ast: A.AstStatementRepeat) {
+    private interpretRepeatStatement(ast: Ast.StatementRepeat) {
         const iterations = ensureRepeatInt(
             this.interpretExpressionInternal(ast.iterations),
         );
@@ -1819,7 +1815,7 @@ export class Interpreter {
         }
     }
 
-    private interpretReturnStatement(ast: A.AstStatementReturn) {
+    private interpretReturnStatement(ast: Ast.StatementReturn) {
         if (ast.expression !== undefined) {
             const val = this.interpretExpressionInternal(ast.expression);
             throw new ReturnSignal(val);
@@ -1828,14 +1824,14 @@ export class Interpreter {
         }
     }
 
-    private interpretTryStatement(ast: A.AstStatementTry) {
+    private interpretTryStatement(ast: Ast.StatementTry) {
         throwNonFatalErrorConstEval(
             "try statements currently not supported",
             ast.loc,
         );
     }
 
-    private interpretUntilStatement(ast: A.AstStatementUntil) {
+    private interpretUntilStatement(ast: Ast.StatementUntil) {
         let condition;
         let iterCount = 0;
         // We can create a single environment for all the iterations in the loop
@@ -1864,7 +1860,7 @@ export class Interpreter {
         });
     }
 
-    private interpretWhileStatement(ast: A.AstStatementWhile) {
+    private interpretWhileStatement(ast: Ast.StatementWhile) {
         let condition;
         let iterCount = 0;
         // We can create a single environment for all the iterations in the loop
@@ -1898,7 +1894,7 @@ export class Interpreter {
         });
     }
 
-    private interpretBlockStatement(ast: A.AstStatementBlock) {
+    private interpretBlockStatement(ast: Ast.StatementBlock) {
         this.envStack.executeInNewEnvironment(() => {
             ast.statements.forEach(this.interpretStatementInternal, this);
         });

--- a/src/optimizer/standardOptimizer.ts
+++ b/src/optimizer/standardOptimizer.ts
@@ -1,4 +1,4 @@
-import type { AstExpression } from "../ast/ast";
+import type * as Ast from "../ast/ast";
 import {
     AddSelf,
     AddZero,
@@ -59,7 +59,7 @@ export class StandardOptimizer implements ExpressionTransformer {
         this.rules.sort((r1, r2) => r1.priority - r2.priority);
     }
 
-    public applyRules = (ast: AstExpression): AstExpression => {
+    public applyRules = (ast: Ast.Expression): Ast.Expression => {
         return this.rules.reduce(
             (prev, prioritizedRule) =>
                 prioritizedRule.rule.applyRule(prev, this),

--- a/src/optimizer/test/partial-eval.spec.ts
+++ b/src/optimizer/test/partial-eval.spec.ts
@@ -1,4 +1,4 @@
-import type * as A from "../../ast/ast";
+import type * as Ast from "../../ast/ast";
 import type { AstUtil } from "../../ast/util";
 import { getAstUtil } from "../../ast/util";
 import { getOptimizer } from "../constEval";
@@ -349,12 +349,12 @@ function testExpressionWithOptimizer(
 // expressions. So, when comparing for equality of expressions, we also need to simplify
 // constant expressions.
 function dummyEval(
-    ast: A.AstExpression,
+    ast: Ast.Expression,
     astFactory: FactoryAst,
-): A.AstExpression {
+): Ast.Expression {
     const cloneNode = astFactory.cloneNode;
     const util = getAstUtil(astFactory);
-    const recurse = (ast: A.AstExpression): A.AstExpression => {
+    const recurse = (ast: Ast.Expression): Ast.Expression => {
         switch (ast.kind) {
             case "null":
                 return ast;
@@ -377,7 +377,7 @@ function dummyEval(
             case "struct_value":
                 return ast; // No need to simplify: fields already simplified
             case "method_call": {
-                const copy: A.AstMethodCall = {
+                const copy: Ast.MethodCall = {
                     ...ast,
                     args: ast.args.map(recurse),
                     self: recurse(ast.self),
@@ -385,20 +385,20 @@ function dummyEval(
                 return cloneNode(copy);
             }
             case "init_of": {
-                const copy: A.AstInitOf = {
+                const copy: Ast.InitOf = {
                     ...ast,
                     args: ast.args.map(recurse),
                 };
                 return cloneNode(copy);
             }
             case "code_of": {
-                const copy: A.AstCodeOf = {
+                const copy: Ast.CodeOf = {
                     ...ast,
                 };
                 return cloneNode(copy);
             }
             case "op_unary": {
-                const copy: A.AstOpUnary = {
+                const copy: Ast.OpUnary = {
                     ...ast,
                     operand: recurse(ast.operand),
                 };
@@ -409,7 +409,7 @@ function dummyEval(
                 return newNode;
             }
             case "op_binary": {
-                const copy: A.AstOpBinary = {
+                const copy: Ast.OpBinary = {
                     ...ast,
                     left: recurse(ast.left),
                     right: recurse(ast.right),
@@ -428,7 +428,7 @@ function dummyEval(
                 return newNode;
             }
             case "conditional": {
-                const copy: A.AstConditional = {
+                const copy: Ast.Conditional = {
                     ...ast,
                     thenBranch: recurse(ast.thenBranch),
                     elseBranch: recurse(ast.elseBranch),
@@ -436,10 +436,10 @@ function dummyEval(
                 return cloneNode(copy);
             }
             case "struct_instance": {
-                const copy: A.AstStructInstance = {
+                const copy: Ast.StructInstance = {
                     ...ast,
                     args: ast.args.map((param) => {
-                        const copy: A.AstStructFieldInitializer = {
+                        const copy: Ast.AstStructFieldInitializer = {
                             ...param,
                             initializer: recurse(param.initializer),
                         };
@@ -449,14 +449,14 @@ function dummyEval(
                 return cloneNode(copy);
             }
             case "field_access": {
-                const copy: A.AstFieldAccess = {
+                const copy: Ast.FieldAccess = {
                     ...ast,
                     aggregate: recurse(ast.aggregate),
                 };
                 return cloneNode(copy);
             }
             case "static_call": {
-                const copy: A.AstStaticCall = {
+                const copy: Ast.StaticCall = {
                     ...ast,
                     args: ast.args.map(recurse),
                 };
@@ -481,7 +481,7 @@ class ParameterizableDummyOptimizer implements ExpressionTransformer {
         this.rules = rules;
     }
 
-    public applyRules = (ast: A.AstExpression): A.AstExpression => {
+    public applyRules = (ast: Ast.Expression): Ast.Expression => {
         return this.rules.reduce(
             (prev, rule) => rule.applyRule(prev, this),
             ast,

--- a/src/optimizer/test/partial-eval.spec.ts
+++ b/src/optimizer/test/partial-eval.spec.ts
@@ -439,7 +439,7 @@ function dummyEval(
                 const copy: Ast.StructInstance = {
                     ...ast,
                     args: ast.args.map((param) => {
-                        const copy: Ast.AstStructFieldInitializer = {
+                        const copy: Ast.StructFieldInitializer = {
                             ...param,
                             initializer: recurse(param.initializer),
                         };

--- a/src/optimizer/types.ts
+++ b/src/optimizer/types.ts
@@ -1,14 +1,14 @@
-import type { AstExpression } from "../ast/ast";
+import type * as Ast from "../ast/ast";
 import type { AstUtil } from "../ast/util";
 
 export interface ExpressionTransformer {
     util: AstUtil;
-    applyRules(ast: AstExpression): AstExpression;
+    applyRules(ast: Ast.Expression): Ast.Expression;
 }
 
 export abstract class Rule {
     public abstract applyRule(
-        ast: AstExpression,
+        ast: Ast.Expression,
         optimizer: ExpressionTransformer,
-    ): AstExpression;
+    ): Ast.Expression;
 }

--- a/src/pipeline/precompile.ts
+++ b/src/pipeline/precompile.ts
@@ -7,7 +7,7 @@ import { resolveErrors } from "../types/resolveErrors";
 import { resolveSignatures } from "../types/resolveSignatures";
 import { resolveImports } from "../imports/resolveImports";
 import type { VirtualFileSystem } from "../vfs/VirtualFileSystem";
-import type { AstModule } from "../ast/ast";
+import type * as Ast from "../ast/ast";
 import type { FactoryAst } from "../ast/ast-helpers";
 import type { Parser } from "../grammar";
 import { evalComptimeExpressions } from "../types/evalComptimeExpressions";
@@ -20,7 +20,7 @@ export function precompile(
     entrypoint: string,
     parser: Parser,
     ast: FactoryAst,
-    parsedModules?: AstModule[],
+    parsedModules?: Ast.Module[],
 ) {
     // Load all sources
     const imported = resolveImports({ entrypoint, project, stdlib, parser });

--- a/src/types/effects.ts
+++ b/src/types/effects.ts
@@ -1,4 +1,4 @@
-import type { AstExpression, AstId, AstStatement } from "../ast/ast";
+import type * as Ast from "../ast/ast";
 import { idText, isSelfId, tryExtractPath } from "../ast/ast-helpers";
 import type { CompilerContext } from "../context/context";
 import { getAllTypes, getType } from "./resolveDescriptors";
@@ -14,7 +14,7 @@ export function computeReceiversEffects(ctx: CompilerContext) {
             for (const receiver of type.receivers) {
                 receiver.effects = statementListEffects(
                     receiver.ast.statements,
-                    new Set<AstId>(),
+                    new Set<Ast.Id>(),
                     ctx,
                 );
             }
@@ -23,8 +23,8 @@ export function computeReceiversEffects(ctx: CompilerContext) {
 }
 
 function statementListEffects(
-    statements: readonly AstStatement[],
-    processedContractMethods: ReadonlySet<AstId>,
+    statements: readonly Ast.Statement[],
+    processedContractMethods: ReadonlySet<Ast.Id>,
     ctx: CompilerContext,
 ): ReadonlySet<Effect> {
     return mapUnionAll(statements, (stmt) =>
@@ -33,8 +33,8 @@ function statementListEffects(
 }
 
 function statementEffects(
-    stmt: AstStatement,
-    processedContractMethods: ReadonlySet<AstId>,
+    stmt: Ast.Statement,
+    processedContractMethods: ReadonlySet<Ast.Id>,
     ctx: CompilerContext,
 ): ReadonlySet<Effect> {
     switch (stmt.kind) {
@@ -167,8 +167,8 @@ function statementEffects(
 }
 
 function expressionEffects(
-    expr: AstExpression,
-    processedContractMethods: ReadonlySet<AstId>,
+    expr: Ast.Expression,
+    processedContractMethods: ReadonlySet<Ast.Id>,
     ctx: CompilerContext,
 ): ReadonlySet<Effect> {
     switch (expr.kind) {
@@ -274,9 +274,9 @@ function expressionEffects(
 }
 
 function methodEffects(
-    self: AstExpression,
-    method: AstId,
-    processedContractMethods: ReadonlySet<AstId>,
+    self: Ast.Expression,
+    method: Ast.Id,
+    processedContractMethods: ReadonlySet<Ast.Id>,
     ctx: CompilerContext,
 ): ReadonlySet<Effect> {
     const selfTypeRef = getExpType(ctx, self);

--- a/src/types/resolveABITypeRef.ts
+++ b/src/types/resolveABITypeRef.ts
@@ -1,5 +1,5 @@
 import type { ABITypeRef } from "@ton/core";
-import type * as A from "../ast/ast";
+import type * as Ast from "../ast/ast";
 import {
     eqNames,
     idText,
@@ -76,8 +76,8 @@ const builderFormats: FormatDef = {
 };
 
 type ResolveTypeOptions = {
-    readonly type: A.AstType;
-    readonly as: A.AstId | undefined;
+    readonly type: Ast.Type;
+    readonly as: Ast.Id | undefined;
     readonly loc: SrcInfo;
 };
 
@@ -94,7 +94,7 @@ export function resolveABIType({
         // Primitive types
         //
 
-        const typeId: A.AstTypeId =
+        const typeId: Ast.TypeId =
             type.kind === "type_id"
                 ? type
                 : type.typeArg.kind === "type_id"

--- a/src/types/resolveDescriptors.ts
+++ b/src/types/resolveDescriptors.ts
@@ -1,4 +1,4 @@
-import type * as A from "../ast/ast";
+import type * as Ast from "../ast/ast";
 import type { FactoryAst } from "../ast/ast-helpers";
 import {
     eqNames,
@@ -53,8 +53,8 @@ const staticConstantsStore = createContextStore<ConstantDescription>();
 
 // this function does not handle the case of structs
 function verifyMapAsAnnotationsForPrimitiveTypes(
-    type: A.AstTypeId,
-    asAnnotation: A.AstId | undefined,
+    type: Ast.TypeId,
+    asAnnotation: Ast.Id | undefined,
     kind: "keyType" | "valType",
 ): void {
     switch (idText(type)) {
@@ -98,8 +98,8 @@ function verifyMapAsAnnotationsForPrimitiveTypes(
 }
 
 function verifyMapTypes(
-    typeId: A.AstTypeId,
-    asAnnotation: A.AstId | undefined,
+    typeId: Ast.TypeId,
+    asAnnotation: Ast.Id | undefined,
     allowedTypeNames: string[],
     kind: "keyType" | "valType",
 ): void {
@@ -112,7 +112,7 @@ function verifyMapTypes(
     verifyMapAsAnnotationsForPrimitiveTypes(typeId, asAnnotation, kind);
 }
 
-function verifyMapType(mapTy: A.AstMapType, isValTypeStruct: boolean) {
+function verifyMapType(mapTy: Ast.MapType, isValTypeStruct: boolean) {
     // optional and other compound key and value types are disallowed at the level of grammar
 
     // check allowed key types
@@ -138,7 +138,7 @@ function verifyMapType(mapTy: A.AstMapType, isValTypeStruct: boolean) {
 
 export const toBounced = (type: string) => `${type}%%BOUNCED%%`;
 
-export function resolveTypeRef(ctx: CompilerContext, type: A.AstType): TypeRef {
+export function resolveTypeRef(ctx: CompilerContext, type: Ast.Type): TypeRef {
     switch (type.kind) {
         case "type_id": {
             const t = getType(ctx, type);
@@ -191,7 +191,7 @@ export function resolveTypeRef(ctx: CompilerContext, type: A.AstType): TypeRef {
 }
 
 function buildTypeRef(
-    type: A.AstType,
+    type: Ast.Type,
     types: Map<string, TypeDescription>,
 ): TypeRef {
     switch (type.kind) {
@@ -394,7 +394,7 @@ export function resolveDescriptors(ctx: CompilerContext, Ast: FactoryAst) {
     //
 
     function buildFieldDescription(
-        src: A.AstFieldDecl,
+        src: Ast.FieldDecl,
         index: number,
     ): FieldDescription {
         const fieldTy = buildTypeRef(src.type, types);
@@ -424,7 +424,7 @@ export function resolveDescriptors(ctx: CompilerContext, Ast: FactoryAst) {
     }
 
     function buildConstantDescription(
-        src: A.AstConstantDef | A.AstConstantDecl,
+        src: Ast.ConstantDef | Ast.ConstantDecl,
     ): ConstantDescription {
         const constDeclTy = buildTypeRef(src.type, types);
         return {
@@ -449,8 +449,8 @@ export function resolveDescriptors(ctx: CompilerContext, Ast: FactoryAst) {
             }
 
             const params: InitParameter[] = [];
-            const args: A.AstTypedParameter[] = [];
-            const statements: A.AstStatement[] = [];
+            const args: Ast.TypedParameter[] = [];
+            const statements: Ast.Statement[] = [];
             for (const r of a.params) {
                 const type = buildTypeRef(r.type, types);
                 params.push({
@@ -475,13 +475,13 @@ export function resolveDescriptors(ctx: CompilerContext, Ast: FactoryAst) {
                                 kind: "id",
                                 text: "self",
                                 loc: r.loc,
-                            }) as A.AstExpression,
+                            }) as Ast.Expression,
                             field: Ast.cloneNode(r.name),
                             loc: r.loc,
-                        }) as A.AstExpression,
+                        }) as Ast.Expression,
                         expression: Ast.cloneNode(r.name),
                         loc: r.loc,
-                    }) as A.AstStatement,
+                    }) as Ast.Statement,
                 );
                 if (s.fields.find((v) => eqNames(v.name, r.name))) {
                     throwCompilationError(
@@ -500,7 +500,7 @@ export function resolveDescriptors(ctx: CompilerContext, Ast: FactoryAst) {
                     params: args,
                     statements,
                     loc: a.loc,
-                }) as A.AstContractInit,
+                }) as Ast.ContractInit,
                 contract: a,
             };
         }
@@ -686,10 +686,10 @@ export function resolveDescriptors(ctx: CompilerContext, Ast: FactoryAst) {
     function resolveFunctionDescriptor(
         optSelf: TypeRef | null,
         a:
-            | A.AstFunctionDef
-            | A.AstNativeFunctionDecl
-            | A.AstFunctionDecl
-            | A.AstAsmFunctionDef,
+            | Ast.FunctionDef
+            | Ast.NativeFunctionDecl
+            | Ast.FunctionDecl
+            | Ast.AsmFunctionDef,
         origin: ItemOrigin,
     ): FunctionDescription {
         let self = optSelf;
@@ -1079,7 +1079,7 @@ export function resolveDescriptors(ctx: CompilerContext, Ast: FactoryAst) {
         };
     }
 
-    function resolveInitFunction(ast: A.AstContractInit): InitDescription {
+    function resolveInitFunction(ast: Ast.ContractInit): InitDescription {
         const params: InitParameter[] = [];
         for (const r of ast.params) {
             params.push({
@@ -1101,7 +1101,7 @@ export function resolveDescriptors(ctx: CompilerContext, Ast: FactoryAst) {
             }
         }
 
-        function checkNode(node: A.AstNode): boolean {
+        function checkNode(node: Ast.AstNode): boolean {
             if (node.kind === "field_access" || node.kind === "method_call") {
                 // we don't need to check `self.a` or `self.foo()`
                 return false;
@@ -1557,7 +1557,7 @@ export function resolveDescriptors(ctx: CompilerContext, Ast: FactoryAst) {
                         params: [],
                         statements: [],
                         loc: t.ast.loc,
-                    }) as A.AstContractInit,
+                    }) as Ast.ContractInit,
                 };
             }
         }
@@ -2084,16 +2084,16 @@ export function resolveDescriptors(ctx: CompilerContext, Ast: FactoryAst) {
 
     for (const [k, t] of types) {
         const visited: Set<string> = new Set();
-        const queue: A.AstNode[] = [];
+        const queue: Ast.AstNode[] = [];
 
-        const queuePush = (name: string, element: A.AstNode) => {
+        const queuePush = (name: string, element: Ast.AstNode) => {
             if (visited.has(name)) return;
             visited.add(name);
             queue.push(element);
         };
 
         const dependsOn: Set<string> = new Set();
-        const handler = (src: A.AstNode) => {
+        const handler = (src: Ast.AstNode) => {
             if (src.kind === "init_of" || src.kind === "code_of") {
                 if (!types.has(idText(src.contract))) {
                     throwCompilationError(
@@ -2213,7 +2213,7 @@ export function resolveDescriptors(ctx: CompilerContext, Ast: FactoryAst) {
 
 export function getType(
     ctx: CompilerContext,
-    ident: A.AstId | A.AstTypeId | string,
+    ident: Ast.Id | Ast.TypeId | string,
 ): TypeDescription {
     const name = typeof ident === "string" ? ident : idText(ident);
     const r = store.get(ctx, name);
@@ -2340,7 +2340,7 @@ function checkInitializerType(
     name: string,
     kind: "Constant" | "Struct field",
     declTy: TypeRef,
-    initializer: A.AstExpression,
+    initializer: Ast.Expression,
     ctx: CompilerContext,
     selfTypeRef: TypeRef | undefined,
 ): CompilerContext {
@@ -2438,7 +2438,7 @@ function checkRecursiveTypes(ctx: CompilerContext): void {
         (aggregate) => aggregate.kind === "struct",
     );
     let index = 0;
-    const stack: A.AstId[] = [];
+    const stack: Ast.Id[] = [];
     // `string` here means "struct name"
     const indices: Map<string, number> = new Map();
     const lowLinks: Map<string, number> = new Map();
@@ -2518,7 +2518,7 @@ function checkRecursiveTypes(ctx: CompilerContext): void {
         }
 
         if (lowLinks.get(struct.name) === indices.get(struct.name)) {
-            const cycle: A.AstId[] = [];
+            const cycle: Ast.Id[] = [];
             let e = "";
             do {
                 const last = stack.pop()!;

--- a/src/types/resolveExpression.ts
+++ b/src/types/resolveExpression.ts
@@ -1,4 +1,4 @@
-import type * as A from "../ast/ast";
+import type * as Ast from "../ast/ast";
 import { eqNames, idText, isWildcard } from "../ast/ast-helpers";
 import {
     idTextErr,
@@ -25,11 +25,11 @@ import { StructFunctions } from "../abi/struct";
 import { prettyPrint } from "../ast/ast-printer";
 
 const store = createContextStore<{
-    ast: A.AstExpression;
+    ast: Ast.Expression;
     description: TypeRef;
 }>();
 
-export function getExpType(ctx: CompilerContext, exp: A.AstExpression) {
+export function getExpType(ctx: CompilerContext, exp: Ast.Expression) {
     const t = store.get(ctx, exp.id);
     if (!t) {
         throwInternalCompilerError(`Expression ${exp.id} not found`);
@@ -39,7 +39,7 @@ export function getExpType(ctx: CompilerContext, exp: A.AstExpression) {
 
 function registerExpType(
     ctx: CompilerContext,
-    exp: A.AstExpression,
+    exp: Ast.Expression,
     description: TypeRef,
 ): CompilerContext {
     const ex = store.get(ctx, exp.id);
@@ -56,7 +56,7 @@ function registerExpType(
 }
 
 function resolveBooleanLiteral(
-    exp: A.AstBoolean,
+    exp: Ast.Boolean,
     sctx: StatementContext,
     ctx: CompilerContext,
 ): CompilerContext {
@@ -68,7 +68,7 @@ function resolveBooleanLiteral(
 }
 
 function resolveIntLiteral(
-    exp: A.AstNumber,
+    exp: Ast.Number,
     sctx: StatementContext,
     ctx: CompilerContext,
 ): CompilerContext {
@@ -80,7 +80,7 @@ function resolveIntLiteral(
 }
 
 function resolveNullLiteral(
-    exp: A.AstNull,
+    exp: Ast.Null,
     sctx: StatementContext,
     ctx: CompilerContext,
 ): CompilerContext {
@@ -88,7 +88,7 @@ function resolveNullLiteral(
 }
 
 function resolveAddressLiteral(
-    exp: A.AstAddress,
+    exp: Ast.Address,
     sctx: StatementContext,
     ctx: CompilerContext,
 ): CompilerContext {
@@ -100,7 +100,7 @@ function resolveAddressLiteral(
 }
 
 function resolveCellLiteral(
-    exp: A.AstCell,
+    exp: Ast.Cell,
     sctx: StatementContext,
     ctx: CompilerContext,
 ): CompilerContext {
@@ -112,7 +112,7 @@ function resolveCellLiteral(
 }
 
 function resolveSliceLiteral(
-    exp: A.AstSlice,
+    exp: Ast.Slice,
     sctx: StatementContext,
     ctx: CompilerContext,
 ): CompilerContext {
@@ -124,7 +124,7 @@ function resolveSliceLiteral(
 }
 
 function resolveStringLiteral(
-    exp: A.AstString | A.AstSimplifiedString,
+    exp: Ast.String | Ast.SimplifiedString,
     sctx: StatementContext,
     ctx: CompilerContext,
 ): CompilerContext {
@@ -136,7 +136,7 @@ function resolveStringLiteral(
 }
 
 function resolveStructNew(
-    exp: A.AstStructInstance | A.AstStructValue,
+    exp: Ast.StructInstance | Ast.StructValue,
     sctx: StatementContext,
     ctx: CompilerContext,
 ): CompilerContext {
@@ -207,7 +207,7 @@ function resolveStructNew(
 }
 
 function resolveBinaryOp(
-    exp: A.AstOpBinary,
+    exp: Ast.OpBinary,
     sctx: StatementContext,
     ctx: CompilerContext,
 ): CompilerContext {
@@ -352,7 +352,7 @@ function isEqualityType(ctx: CompilerContext, ty: TypeRef): boolean {
 }
 
 function resolveUnaryOp(
-    exp: A.AstOpUnary,
+    exp: Ast.OpUnary,
     sctx: StatementContext,
     ctx: CompilerContext,
 ): CompilerContext {
@@ -412,7 +412,7 @@ function resolveUnaryOp(
 }
 
 function resolveFieldAccess(
-    exp: A.AstFieldAccess,
+    exp: Ast.FieldAccess,
     sctx: StatementContext,
     ctx: CompilerContext,
 ): CompilerContext {
@@ -504,7 +504,7 @@ function resolveFieldAccess(
 }
 
 function checkParameterType(
-    expression: A.AstExpression,
+    expression: Ast.Expression,
     parameter: FunctionParameter,
     ctx: CompilerContext,
 ) {
@@ -518,7 +518,7 @@ function checkParameterType(
 }
 
 function resolveStaticCall(
-    exp: A.AstStaticCall,
+    exp: Ast.StaticCall,
     sctx: StatementContext,
     ctx: CompilerContext,
 ): CompilerContext {
@@ -586,7 +586,7 @@ function resolveStaticCall(
 }
 
 function resolveCall(
-    exp: A.AstMethodCall,
+    exp: Ast.MethodCall,
     sctx: StatementContext,
     ctx: CompilerContext,
 ): CompilerContext {
@@ -724,7 +724,7 @@ function resolveCall(
 }
 
 function resolveInitOf(
-    ast: A.AstInitOf,
+    ast: Ast.InitOf,
     sctx: StatementContext,
     ctx: CompilerContext,
 ): CompilerContext {
@@ -767,10 +767,7 @@ function resolveInitOf(
     });
 }
 
-function resolveCodeOf(
-    ast: A.AstCodeOf,
-    ctx: CompilerContext,
-): CompilerContext {
+function resolveCodeOf(ast: Ast.CodeOf, ctx: CompilerContext): CompilerContext {
     // Resolve type
     const type = getType(ctx, ast.contract);
     if (type.kind !== "contract") {
@@ -789,7 +786,7 @@ function resolveCodeOf(
 }
 
 function resolveConditional(
-    ast: A.AstConditional,
+    ast: Ast.Conditional,
     sctx: StatementContext,
     ctx: CompilerContext,
 ): CompilerContext {
@@ -829,7 +826,7 @@ function resolveConditional(
 }
 
 export function resolveExpression(
-    exp: A.AstExpression,
+    exp: Ast.Expression,
     sctx: StatementContext,
     ctx: CompilerContext,
 ) {

--- a/src/types/resolveSignatures.ts
+++ b/src/types/resolveSignatures.ts
@@ -15,7 +15,7 @@ import type {
     TypeDescription,
 } from "./types";
 import { throwCompilationError } from "../error/errors";
-import type { AstNumber, AstReceiver } from "../ast/ast";
+import type * as Ast from "../ast/ast";
 import type { FactoryAst } from "../ast/ast-helpers";
 import { commentPseudoOpcode } from "../generator/writers/writeRouter";
 import { dummySrcInfo } from "../grammar";
@@ -29,7 +29,7 @@ export function resolveSignatures(ctx: CompilerContext, Ast: FactoryAst) {
 
     const signatures: Map<
         string,
-        { signature: string; tlb: string; id: AstNumber | null }
+        { signature: string; tlb: string; id: Ast.Number | null }
     > = new Map();
     function createTypeFormat(
         type: string,
@@ -176,7 +176,7 @@ export function resolveSignatures(ctx: CompilerContext, Ast: FactoryAst) {
     function createTupleSignature(name: string): {
         signature: string;
         tlb: string;
-        id: AstNumber | null;
+        id: Ast.Number | null;
     } {
         if (signatures.has(name)) {
             return signatures.get(name)!;
@@ -221,7 +221,7 @@ export function resolveSignatures(ctx: CompilerContext, Ast: FactoryAst) {
 
         // Calculate signature and method id
         const signature = name + "{" + fields.join(",") + "}";
-        let id: AstNumber | null = null;
+        let id: Ast.Number | null = null;
         if (t.ast.kind === "message_decl") {
             if (t.ast.opcode !== undefined) {
                 // Currently, message opcode expressions do not get typechecked, so
@@ -299,7 +299,7 @@ export function resolveSignatures(ctx: CompilerContext, Ast: FactoryAst) {
     return ctx;
 }
 
-function newMessageOpcode(signature: string): AstNumber {
+function newMessageOpcode(signature: string): Ast.Number {
     return {
         kind: "number",
         base: 10,
@@ -314,7 +314,7 @@ type binOpcode = number;
 
 function checkBinaryMessageReceiver(
     rcv: BinaryReceiverSelector,
-    rcvAst: AstReceiver,
+    rcvAst: Ast.Receiver,
     usedOpcodes: Map<binOpcode, messageType>,
     ctx: CompilerContext,
 ) {
@@ -335,7 +335,7 @@ type commentOpcode = string;
 // "opcode" clashes are highly unlikely in this case, of course
 function checkCommentMessageReceiver(
     rcv: CommentReceiverSelector,
-    rcvAst: AstReceiver,
+    rcvAst: Ast.Receiver,
     usedOpcodes: Map<commentOpcode, messageType>,
 ) {
     const opcode1 = commentPseudoOpcode(rcv.comment, true, rcvAst.loc);

--- a/src/types/resolveStatements.ts
+++ b/src/types/resolveStatements.ts
@@ -1,4 +1,4 @@
-import type * as A from "../ast/ast";
+import type * as Ast from "../ast/ast";
 import type { CompilerContext } from "../context/context";
 import { isAssignable } from "./subtyping";
 import {
@@ -52,7 +52,7 @@ export function emptyContext(
 function checkVariableExists(
     ctx: CompilerContext,
     sctx: StatementContext,
-    name: A.AstId,
+    name: Ast.Id,
 ): void {
     if (sctx.vars.has(idText(name))) {
         throwCompilationError(
@@ -111,7 +111,7 @@ function removeRequiredVariable(
 }
 
 export function addVariable(
-    name: A.AstId,
+    name: Ast.Id,
     ref: TypeRef,
     ctx: CompilerContext,
     sctx: StatementContext,
@@ -127,7 +127,7 @@ export function addVariable(
 }
 
 function processCondition(
-    condition: A.AstStatementCondition,
+    condition: Ast.StatementCondition,
     sctx: StatementContext,
     ctx: CompilerContext,
 ): {
@@ -191,7 +191,7 @@ function processCondition(
 
 // Precondition: `self` here means a contract or a trait,
 // and not a `self` parameter of a mutating method
-export function isLvalue(path: A.AstId[], ctx: CompilerContext): boolean {
+export function isLvalue(path: Ast.Id[], ctx: CompilerContext): boolean {
     const headId = path[0]!;
     if (isSelfId(headId) && path.length > 1) {
         // we can be dealing with a contract/trait constant `self.constFoo`
@@ -213,7 +213,7 @@ export function isLvalue(path: A.AstId[], ctx: CompilerContext): boolean {
 }
 
 function processStatements(
-    statements: readonly A.AstStatement[],
+    statements: readonly Ast.Statement[],
     sctx: StatementContext,
     ctx: CompilerContext,
 ): {
@@ -751,7 +751,7 @@ function processStatements(
 }
 
 function processFunctionBody(
-    statements: readonly A.AstStatement[],
+    statements: readonly Ast.Statement[],
     sctx: StatementContext,
     ctx: CompilerContext,
 ): CompilerContext {

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -1,6 +1,6 @@
 import type { ABIField } from "@ton/core";
 import { throwInternalCompilerError } from "../error/errors";
-import type * as A from "../ast/ast";
+import type * as Ast from "../ast/ast";
 import type { SrcInfo } from "../grammar";
 import { idText } from "../ast/ast-helpers";
 import type { ItemOrigin } from "../imports/source";
@@ -11,7 +11,7 @@ export type TypeDescription = {
     origin: ItemOrigin;
     name: string;
     uid: number;
-    header: A.AstNumber | null;
+    header: Ast.Number | null;
     tlb: string | null;
     signature: string | null;
     fields: FieldDescription[];
@@ -20,7 +20,7 @@ export type TypeDescription = {
     functions: Map<string, FunctionDescription>;
     receivers: ReceiverDescription[];
     init: InitDescription | null;
-    ast: A.AstTypeDecl;
+    ast: Ast.TypeDecl;
     dependsOn: TypeDescription[];
     interfaces: string[];
     constants: ConstantDescription[];
@@ -54,7 +54,7 @@ export type TypeRef =
 // https://github.com/microsoft/TypeScript/pull/57293
 // eslint-disable-next-line @typescript-eslint/consistent-indexed-object-style
 
-export function showValue(val: A.AstLiteral): string {
+export function showValue(val: Ast.Literal): string {
     switch (val.kind) {
         case "number":
             return val.value.toString(val.base);
@@ -86,22 +86,22 @@ export type FieldDescription = {
     index: number;
     type: TypeRef;
     as: string | null;
-    default: A.AstLiteral | undefined;
+    default: Ast.Literal | undefined;
     loc: SrcInfo;
-    ast: A.AstFieldDecl;
+    ast: Ast.FieldDecl;
     abi: ABIField;
 };
 
 export type ConstantDescription = {
     name: string;
     type: TypeRef;
-    value: A.AstLiteral | undefined;
+    value: Ast.Literal | undefined;
     loc: SrcInfo;
-    ast: A.AstConstantDef | A.AstConstantDecl;
+    ast: Ast.ConstantDef | Ast.ConstantDecl;
 };
 
 export type FunctionParameter = {
-    name: A.AstId;
+    name: Ast.Id;
     type: TypeRef;
     loc: SrcInfo;
 };
@@ -120,28 +120,28 @@ export type FunctionDescription = {
     returns: TypeRef;
     params: FunctionParameter[];
     ast:
-        | A.AstFunctionDef
-        | A.AstNativeFunctionDecl
-        | A.AstFunctionDecl
-        | A.AstAsmFunctionDef;
+        | Ast.FunctionDef
+        | Ast.NativeFunctionDecl
+        | Ast.FunctionDecl
+        | Ast.AsmFunctionDef;
 };
 
 export type BinaryReceiverSelector =
     | {
           kind: "internal-binary";
           type: string;
-          name: A.AstId;
+          name: Ast.Id;
       }
     | {
           kind: "bounce-binary";
-          name: A.AstId;
+          name: Ast.Id;
           type: string;
           bounced: boolean;
       }
     | {
           kind: "external-binary";
           type: string;
-          name: A.AstId;
+          name: Ast.Id;
       };
 
 export type CommentReceiverSelector =
@@ -165,23 +165,23 @@ type EmptyReceiverSelector =
 export type FallbackReceiverSelector =
     | {
           kind: "internal-comment-fallback";
-          name: A.AstId;
+          name: Ast.Id;
       }
     | {
           kind: "internal-fallback";
-          name: A.AstId;
+          name: Ast.Id;
       }
     | {
           kind: "bounce-fallback";
-          name: A.AstId;
+          name: Ast.Id;
       }
     | {
           kind: "external-comment-fallback";
-          name: A.AstId;
+          name: Ast.Id;
       }
     | {
           kind: "external-fallback";
-          name: A.AstId;
+          name: Ast.Id;
       };
 
 export type ReceiverSelector =
@@ -215,12 +215,12 @@ export function receiverSelectorName(selector: ReceiverSelector): string {
 
 export type ReceiverDescription = {
     selector: ReceiverSelector;
-    ast: A.AstReceiver;
+    ast: Ast.Receiver;
     effects: ReadonlySet<Effect>;
 };
 
 export type InitParameter = {
-    name: A.AstId;
+    name: Ast.Id;
     type: TypeRef;
     as: string | null;
     loc: SrcInfo;
@@ -231,14 +231,14 @@ export type InitDescription = SeparateInitDescription | ContractInitDescription;
 type SeparateInitDescription = {
     kind: "init-function";
     params: InitParameter[];
-    ast: A.AstContractInit;
+    ast: Ast.ContractInit;
 };
 
 type ContractInitDescription = {
     kind: "contract-params";
     params: InitParameter[];
-    ast: A.AstContractInit;
-    contract: A.AstContract;
+    ast: Ast.ContractInit;
+    contract: Ast.Contract;
 };
 
 export function printTypeRef(src: TypeRef): string {


### PR DESCRIPTION
## Issue

Closes #2438.
