### PR TITLE
feat(ci): run `gen:stdlib` in `lint:all`, which is used for pre-push git hooks

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "fmt:check": "yarn prettier --check .",
     "spell": "yarn cspell --no-progress \"**\"",
     "knip": "knip",
-    "lint:all": "yarn lint && yarn fmt:check && yarn spell && yarn knip",
+    "lint:all": "yarn gen:stdlib && yarn lint && yarn fmt:check && yarn spell && yarn knip",
     "all": "yarn clean && yarn gen && yarn build && yarn coverage && yarn lint:all",
     "next-version": "ts-node version.build.ts",
     "random-ast": "ts-node ./src/ast/random-ast.ts",


### PR DESCRIPTION
## Issue

Closes #2458.

Since we've removed the `postinstall` script, I thought it would be better to keep the `.husky/pre-push` hook as is and instead extend the script that's used in that hook. Namely, the `lint:all` script from `package.json`.

Feel free to disagree, in which case we'd need to make the `husky` command more visible. Like, to place it in CONTRIBUTING or something, just so people would (?) update their hooks.