### PR TITLE
fix(parser): disallow augmented assign with space between operator and `=`

### DIFF
--- a/dev-docs/CHANGELOG.md
+++ b/dev-docs/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [fix] Ternary operator with struct and null: PR [#2432](https://github.com/tact-lang/tact/pull/2432)
 - [fix] Show an error message for assembly functions with the `get` attribute: PR [#2484](https://github.com/tact-lang/tact/pull/2484)
 - [fix] The parser does not throw an internal compiler error if the error is reported after the end of the file: PR [#2485](https://github.com/tact-lang/tact/pull/2485)
+- [fix] Disallow augmented assign with space between operator and `=`: PR [#2492](https://github.com/tact-lang/tact/pull/2492)
 
 ### Standard Library
 

--- a/dev-docs/CHANGELOG.md
+++ b/dev-docs/CHANGELOG.md
@@ -14,7 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [fix] Show an error message for assembly functions with the `get` attribute: PR [#2484](https://github.com/tact-lang/tact/pull/2484)
 - [fix] The parser does not throw an internal compiler error if the error is reported after the end of the file: PR [#2485](https://github.com/tact-lang/tact/pull/2485)
 - [fix] Always show an error when calling the `dump()` function with an argument of the unsupported `StringBuilder` type: PR [#2491](https://github.com/tact-lang/tact/pull/2491)
-- [fix] Disallow augmented assign with space between operator and `=`: PR [#2492](https://github.com/tact-lang/tact/pull/2492)
+- [fix] The grammar now disallows the augmented assignment operators with whitespace between the operator and the equals sign: PR [#2492](https://github.com/tact-lang/tact/pull/2492)
 
 ### Standard Library
 

--- a/src/ast/ast-constants.ts
+++ b/src/ast/ast-constants.ts
@@ -5,18 +5,18 @@ const augmentedAssignOperationsRecord: Record<
     Ast.AugmentedAssignOperation,
     true
 > = {
-    "+": true,
-    "-": true,
-    "*": true,
-    "/": true,
-    "&&": true,
-    "||": true,
-    "%": true,
-    "|": true,
-    "<<": true,
-    ">>": true,
-    "&": true,
-    "^": true,
+    "+=": true,
+    "-=": true,
+    "*=": true,
+    "/=": true,
+    "&&=": true,
+    "||=": true,
+    "%=": true,
+    "|=": true,
+    "<<=": true,
+    ">>=": true,
+    "&=": true,
+    "^=": true,
 };
 
 export const astAugmentedAssignOperations = Object.freeze(

--- a/src/ast/ast-printer.ts
+++ b/src/ast/ast-printer.ts
@@ -745,9 +745,7 @@ export const ppAstStatementAugmentedAssign: Printer<
 > =
     ({ path, op, expression }) =>
     (c) =>
-        c.row(
-            `${ppAstExpression(path)} ${op}= ${ppAstExpression(expression)};`,
-        );
+        c.row(`${ppAstExpression(path)} ${op} ${ppAstExpression(expression)};`);
 
 export const ppAstStatementCondition: Printer<Ast.StatementCondition> =
     ({ condition, trueStatements, falseStatements }) =>

--- a/src/ast/ast.ts
+++ b/src/ast/ast.ts
@@ -243,18 +243,18 @@ export type StatementAssign = {
 };
 
 export type AugmentedAssignOperation =
-    | "+"
-    | "-"
-    | "*"
-    | "/"
-    | "&&"
-    | "||"
-    | "%"
-    | "|"
-    | "<<"
-    | ">>"
-    | "&"
-    | "^";
+    | "+="
+    | "-="
+    | "*="
+    | "/="
+    | "&&="
+    | "||="
+    | "%="
+    | "|="
+    | "<<="
+    | ">>="
+    | "&="
+    | "^=";
 
 export type StatementAugmentedAssign = {
     readonly kind: "statement_augmentedassign";

--- a/src/ast/util.ts
+++ b/src/ast/util.ts
@@ -184,3 +184,34 @@ export function checkIsName(ast: Ast.Expression): boolean {
 export function checkIsBoolean(ast: Ast.Expression, b: boolean): boolean {
     return ast.kind === "boolean" ? ast.value == b : false;
 }
+
+export function binaryOperationFromAugmentedAssignment(
+    op: Ast.AugmentedAssignOperation,
+): Ast.BinaryOperation {
+    switch (op) {
+        case "+=":
+            return "+";
+        case "-=":
+            return "-";
+        case "*=":
+            return "*";
+        case "/=":
+            return "/";
+        case "&&=":
+            return "&&";
+        case "||=":
+            return "||";
+        case "%=":
+            return "%";
+        case "|=":
+            return "|";
+        case "<<=":
+            return "<<";
+        case ">>=":
+            return ">>";
+        case "&=":
+            return "&";
+        case "^=":
+            return "^";
+    }
+}

--- a/src/ast/util.ts
+++ b/src/ast/util.ts
@@ -185,7 +185,7 @@ export function checkIsBoolean(ast: Ast.Expression, b: boolean): boolean {
     return ast.kind === "boolean" ? ast.value == b : false;
 }
 
-export function binaryOperationFromAugmentedAssignment(
+export function binaryOperationFromAugmentedAssignOperation(
     op: Ast.AugmentedAssignOperation,
 ): Ast.BinaryOperation {
     switch (op) {

--- a/src/generator/writers/writeFunction.ts
+++ b/src/generator/writers/writeFunction.ts
@@ -182,7 +182,7 @@ export function writeStatement(
             }
             const path = writePathExpression(lvaluePath);
             const t = getExpType(ctx.ctx, f.path);
-            const op = f.op === "&&" ? "&" : f.op === "||" ? "|" : f.op;
+            const op = f.op === "&&=" ? "&" : f.op === "||=" ? "|" : f.op;
             ctx.append(
                 `${path} = ${cast(t, t, `${path} ${op} ${writeExpression(f.expression, ctx)}`, ctx)};`,
             );

--- a/src/grammar/__snapshots__/grammar.spec.ts.snap
+++ b/src/grammar/__snapshots__/grammar.spec.ts.snap
@@ -7795,7 +7795,7 @@ exports[`grammar should parse stmt-augmented-assign-arith 1`] = `
           "id": 13,
           "kind": "statement_augmentedassign",
           "loc": a += b;,
-          "op": "+",
+          "op": "+=",
           "path": {
             "id": 11,
             "kind": "id",
@@ -7813,7 +7813,7 @@ exports[`grammar should parse stmt-augmented-assign-arith 1`] = `
           "id": 16,
           "kind": "statement_augmentedassign",
           "loc": b += a;,
-          "op": "+",
+          "op": "+=",
           "path": {
             "id": 14,
             "kind": "id",
@@ -7832,7 +7832,7 @@ exports[`grammar should parse stmt-augmented-assign-arith 1`] = `
           "id": 19,
           "kind": "statement_augmentedassign",
           "loc": a += 3;,
-          "op": "+",
+          "op": "+=",
           "path": {
             "id": 17,
             "kind": "id",
@@ -7863,7 +7863,7 @@ exports[`grammar should parse stmt-augmented-assign-arith 1`] = `
           "id": 24,
           "kind": "statement_augmentedassign",
           "loc": a += b + 4;,
-          "op": "+",
+          "op": "+=",
           "path": {
             "id": 20,
             "kind": "id",
@@ -7882,7 +7882,7 @@ exports[`grammar should parse stmt-augmented-assign-arith 1`] = `
           "id": 27,
           "kind": "statement_augmentedassign",
           "loc": b -= 1;,
-          "op": "-",
+          "op": "-=",
           "path": {
             "id": 25,
             "kind": "id",
@@ -7900,7 +7900,7 @@ exports[`grammar should parse stmt-augmented-assign-arith 1`] = `
           "id": 30,
           "kind": "statement_augmentedassign",
           "loc": a -= b;,
-          "op": "-",
+          "op": "-=",
           "path": {
             "id": 28,
             "kind": "id",
@@ -7931,7 +7931,7 @@ exports[`grammar should parse stmt-augmented-assign-arith 1`] = `
           "id": 35,
           "kind": "statement_augmentedassign",
           "loc": a -= b - 1;,
-          "op": "-",
+          "op": "-=",
           "path": {
             "id": 31,
             "kind": "id",
@@ -7950,7 +7950,7 @@ exports[`grammar should parse stmt-augmented-assign-arith 1`] = `
           "id": 38,
           "kind": "statement_augmentedassign",
           "loc": b *= 2;,
-          "op": "*",
+          "op": "*=",
           "path": {
             "id": 36,
             "kind": "id",
@@ -7968,7 +7968,7 @@ exports[`grammar should parse stmt-augmented-assign-arith 1`] = `
           "id": 41,
           "kind": "statement_augmentedassign",
           "loc": a *= b;,
-          "op": "*",
+          "op": "*=",
           "path": {
             "id": 39,
             "kind": "id",
@@ -7999,7 +7999,7 @@ exports[`grammar should parse stmt-augmented-assign-arith 1`] = `
           "id": 46,
           "kind": "statement_augmentedassign",
           "loc": a *= b * 2;,
-          "op": "*",
+          "op": "*=",
           "path": {
             "id": 42,
             "kind": "id",
@@ -8018,7 +8018,7 @@ exports[`grammar should parse stmt-augmented-assign-arith 1`] = `
           "id": 49,
           "kind": "statement_augmentedassign",
           "loc": b /= 2;,
-          "op": "/",
+          "op": "/=",
           "path": {
             "id": 47,
             "kind": "id",
@@ -8036,7 +8036,7 @@ exports[`grammar should parse stmt-augmented-assign-arith 1`] = `
           "id": 52,
           "kind": "statement_augmentedassign",
           "loc": a /= b;,
-          "op": "/",
+          "op": "/=",
           "path": {
             "id": 50,
             "kind": "id",
@@ -8067,7 +8067,7 @@ exports[`grammar should parse stmt-augmented-assign-arith 1`] = `
           "id": 57,
           "kind": "statement_augmentedassign",
           "loc": a /= b / 2;,
-          "op": "/",
+          "op": "/=",
           "path": {
             "id": 53,
             "kind": "id",
@@ -8086,7 +8086,7 @@ exports[`grammar should parse stmt-augmented-assign-arith 1`] = `
           "id": 60,
           "kind": "statement_augmentedassign",
           "loc": a %= 2;,
-          "op": "%",
+          "op": "%=",
           "path": {
             "id": 58,
             "kind": "id",
@@ -8104,7 +8104,7 @@ exports[`grammar should parse stmt-augmented-assign-arith 1`] = `
           "id": 63,
           "kind": "statement_augmentedassign",
           "loc": a %= b;,
-          "op": "%",
+          "op": "%=",
           "path": {
             "id": 61,
             "kind": "id",
@@ -8135,7 +8135,7 @@ exports[`grammar should parse stmt-augmented-assign-arith 1`] = `
           "id": 68,
           "kind": "statement_augmentedassign",
           "loc": a %= b % 2;,
-          "op": "%",
+          "op": "%=",
           "path": {
             "id": 64,
             "kind": "id",
@@ -8154,7 +8154,7 @@ exports[`grammar should parse stmt-augmented-assign-arith 1`] = `
           "id": 71,
           "kind": "statement_augmentedassign",
           "loc": a <<= 2;,
-          "op": "<<",
+          "op": "<<=",
           "path": {
             "id": 69,
             "kind": "id",
@@ -8172,7 +8172,7 @@ exports[`grammar should parse stmt-augmented-assign-arith 1`] = `
           "id": 74,
           "kind": "statement_augmentedassign",
           "loc": a <<= b;,
-          "op": "<<",
+          "op": "<<=",
           "path": {
             "id": 72,
             "kind": "id",
@@ -8203,7 +8203,7 @@ exports[`grammar should parse stmt-augmented-assign-arith 1`] = `
           "id": 79,
           "kind": "statement_augmentedassign",
           "loc": a <<= b << 2;,
-          "op": "<<",
+          "op": "<<=",
           "path": {
             "id": 75,
             "kind": "id",
@@ -8222,7 +8222,7 @@ exports[`grammar should parse stmt-augmented-assign-arith 1`] = `
           "id": 82,
           "kind": "statement_augmentedassign",
           "loc": a >>= 2;,
-          "op": ">>",
+          "op": ">>=",
           "path": {
             "id": 80,
             "kind": "id",
@@ -8240,7 +8240,7 @@ exports[`grammar should parse stmt-augmented-assign-arith 1`] = `
           "id": 85,
           "kind": "statement_augmentedassign",
           "loc": a >>= b;,
-          "op": ">>",
+          "op": ">>=",
           "path": {
             "id": 83,
             "kind": "id",
@@ -8271,7 +8271,7 @@ exports[`grammar should parse stmt-augmented-assign-arith 1`] = `
           "id": 90,
           "kind": "statement_augmentedassign",
           "loc": a >>= b >> 2;,
-          "op": ">>",
+          "op": ">>=",
           "path": {
             "id": 86,
             "kind": "id",
@@ -8395,7 +8395,7 @@ exports[`grammar should parse stmt-augmented-assign-bitwise 1`] = `
           "id": 13,
           "kind": "statement_augmentedassign",
           "loc": a |= b;,
-          "op": "|",
+          "op": "|=",
           "path": {
             "id": 11,
             "kind": "id",
@@ -8413,7 +8413,7 @@ exports[`grammar should parse stmt-augmented-assign-bitwise 1`] = `
           "id": 16,
           "kind": "statement_augmentedassign",
           "loc": b |= a;,
-          "op": "|",
+          "op": "|=",
           "path": {
             "id": 14,
             "kind": "id",
@@ -8432,7 +8432,7 @@ exports[`grammar should parse stmt-augmented-assign-bitwise 1`] = `
           "id": 19,
           "kind": "statement_augmentedassign",
           "loc": a |= 3;,
-          "op": "|",
+          "op": "|=",
           "path": {
             "id": 17,
             "kind": "id",
@@ -8463,7 +8463,7 @@ exports[`grammar should parse stmt-augmented-assign-bitwise 1`] = `
           "id": 24,
           "kind": "statement_augmentedassign",
           "loc": a |= b | 4;,
-          "op": "|",
+          "op": "|=",
           "path": {
             "id": 20,
             "kind": "id",
@@ -8482,7 +8482,7 @@ exports[`grammar should parse stmt-augmented-assign-bitwise 1`] = `
           "id": 27,
           "kind": "statement_augmentedassign",
           "loc": b &= 1;,
-          "op": "&",
+          "op": "&=",
           "path": {
             "id": 25,
             "kind": "id",
@@ -8500,7 +8500,7 @@ exports[`grammar should parse stmt-augmented-assign-bitwise 1`] = `
           "id": 30,
           "kind": "statement_augmentedassign",
           "loc": a &= b;,
-          "op": "&",
+          "op": "&=",
           "path": {
             "id": 28,
             "kind": "id",
@@ -8518,7 +8518,7 @@ exports[`grammar should parse stmt-augmented-assign-bitwise 1`] = `
           "id": 33,
           "kind": "statement_augmentedassign",
           "loc": b &= a;,
-          "op": "&",
+          "op": "&=",
           "path": {
             "id": 31,
             "kind": "id",
@@ -8549,7 +8549,7 @@ exports[`grammar should parse stmt-augmented-assign-bitwise 1`] = `
           "id": 38,
           "kind": "statement_augmentedassign",
           "loc": a &= b & 1;,
-          "op": "&",
+          "op": "&=",
           "path": {
             "id": 34,
             "kind": "id",
@@ -8568,7 +8568,7 @@ exports[`grammar should parse stmt-augmented-assign-bitwise 1`] = `
           "id": 41,
           "kind": "statement_augmentedassign",
           "loc": b ^= 2;,
-          "op": "^",
+          "op": "^=",
           "path": {
             "id": 39,
             "kind": "id",
@@ -8586,7 +8586,7 @@ exports[`grammar should parse stmt-augmented-assign-bitwise 1`] = `
           "id": 44,
           "kind": "statement_augmentedassign",
           "loc": a ^= b;,
-          "op": "^",
+          "op": "^=",
           "path": {
             "id": 42,
             "kind": "id",
@@ -8604,7 +8604,7 @@ exports[`grammar should parse stmt-augmented-assign-bitwise 1`] = `
           "id": 47,
           "kind": "statement_augmentedassign",
           "loc": b ^= a;,
-          "op": "^",
+          "op": "^=",
           "path": {
             "id": 45,
             "kind": "id",
@@ -8635,7 +8635,7 @@ exports[`grammar should parse stmt-augmented-assign-bitwise 1`] = `
           "id": 52,
           "kind": "statement_augmentedassign",
           "loc": a ^= b ^ 2;,
-          "op": "^",
+          "op": "^=",
           "path": {
             "id": 48,
             "kind": "id",
@@ -8751,7 +8751,7 @@ exports[`grammar should parse stmt-augmented-assign-logic 1`] = `
           "id": 13,
           "kind": "statement_augmentedassign",
           "loc": a ||= true;,
-          "op": "||",
+          "op": "||=",
           "path": {
             "id": 11,
             "kind": "id",
@@ -8769,7 +8769,7 @@ exports[`grammar should parse stmt-augmented-assign-logic 1`] = `
           "id": 16,
           "kind": "statement_augmentedassign",
           "loc": a ||= b;,
-          "op": "||",
+          "op": "||=",
           "path": {
             "id": 14,
             "kind": "id",
@@ -8799,7 +8799,7 @@ exports[`grammar should parse stmt-augmented-assign-logic 1`] = `
           "id": 21,
           "kind": "statement_augmentedassign",
           "loc": a ||= b || true;,
-          "op": "||",
+          "op": "||=",
           "path": {
             "id": 17,
             "kind": "id",
@@ -8817,7 +8817,7 @@ exports[`grammar should parse stmt-augmented-assign-logic 1`] = `
           "id": 24,
           "kind": "statement_augmentedassign",
           "loc": a &&= true;,
-          "op": "&&",
+          "op": "&&=",
           "path": {
             "id": 22,
             "kind": "id",
@@ -8835,7 +8835,7 @@ exports[`grammar should parse stmt-augmented-assign-logic 1`] = `
           "id": 27,
           "kind": "statement_augmentedassign",
           "loc": a &&= b;,
-          "op": "&&",
+          "op": "&&=",
           "path": {
             "id": 25,
             "kind": "id",
@@ -8865,7 +8865,7 @@ exports[`grammar should parse stmt-augmented-assign-logic 1`] = `
           "id": 32,
           "kind": "statement_augmentedassign",
           "loc": a &&= b && true;,
-          "op": "&&",
+          "op": "&&=",
           "path": {
             "id": 28,
             "kind": "id",
@@ -10057,7 +10057,7 @@ exports[`grammar should parse stmt-optional-semicolon-for-last-statement 1`] = `
               "id": 15,
               "kind": "statement_augmentedassign",
               "loc": i += 1,
-              "op": "+",
+              "op": "+=",
               "path": {
                 "id": 13,
                 "kind": "id",

--- a/src/grammar/__snapshots__/grammar.spec.ts.snap
+++ b/src/grammar/__snapshots__/grammar.spec.ts.snap
@@ -18,6 +18,15 @@ exports[`grammar should fail asm-getter 1`] = `
 "
 `;
 
+exports[`grammar should fail augmented-assign-with-space 1`] = `
+"<unknown>:7:14: Expected "!", "(", "+", "-", "0", "\\"", "codeOf", "false", "initOf", "null", "true", "~", capitalized identifier, digit, or identifier
+  6 |     fun foo() {
+> 7 |         a << = 10;
+                   ^
+  8 |     }
+"
+`;
+
 exports[`grammar should fail const-abstract-abstract 1`] = `
 "<unknown>:4:1: Module-level constants do not support attributes
   3 | 

--- a/src/grammar/grammar.gg
+++ b/src/grammar/grammar.gg
@@ -203,7 +203,7 @@ StatementDestruct   = keyword<"let"> type:TypeId "{" fields:inter<destructItem, 
 StatementBlock      = body:statements;
 StatementReturn     = keyword<"return"> expression:expression? semicolon;
 StatementExpression = expression:expression semicolon;
-StatementAssign     = left:expression operator:augmentedOp? "=" right:expression semicolon;
+StatementAssign     = left:expression operator:(augmentedOp / "=") right:expression semicolon;
 StatementCondition  = keyword<"if"> condition:expression trueBranch:statements falseBranch:(keyword<"else"> @(FalseBranch / StatementCondition))?;
 StatementWhile      = keyword<"while"> condition:parens body:statements;
 StatementRepeat     = keyword<"repeat"> condition:parens body:statements;
@@ -211,7 +211,7 @@ StatementUntil      = keyword<"do"> body:statements keyword<"until"> condition:p
 StatementTry        = keyword<"try"> body:statements handler:(keyword<"catch"> "(" name:Id ")" body:statements)?;
 StatementForEach    = keyword<"foreach"> "(" key:Id "," value:Id "in" expression:expression ")" body:statements;
 
-augmentedOp = "||" / "&&" / ">>" / "<<" / [-+*/%|&^];
+augmentedOp = "||=" / "&&=" / ">>=" / "<<=" / "-=" / "+=" / "*=" / "/=" / "%=" / "|=" / "&=" / "^=";
 FalseBranch = body:statements;
 semicolon = ";" / &"}";
 

--- a/src/grammar/grammar.ts
+++ b/src/grammar/grammar.ts
@@ -268,12 +268,12 @@ export namespace $ast {
   export type StatementAssign = $.Located<{
     readonly $: "StatementAssign";
     readonly left: expression;
-    readonly operator: augmentedOp | undefined;
+    readonly operator: augmentedOp | "=";
     readonly right: expression;
   }>;
   export type statement = StatementLet | StatementDestruct | StatementBlock | StatementReturn | StatementCondition | StatementWhile | StatementRepeat | StatementUntil | StatementTry | StatementForEach | StatementExpression | StatementAssign;
   export type statements = readonly statement[];
-  export type augmentedOp = "||" | "&&" | ">>" | "<<" | "-" | "+" | "*" | "/" | "%" | "|" | "&" | "^";
+  export type augmentedOp = "||=" | "&&=" | ">>=" | "<<=" | "-=" | "+=" | "*=" | "/=" | "%=" | "|=" | "&=" | "^=";
   export type FalseBranch = $.Located<{
     readonly $: "FalseBranch";
     readonly body: statements;
@@ -480,10 +480,10 @@ export const StatementUntil: $.Parser<$ast.StatementUntil> = $.loc($.field($.pur
 export const StatementTry: $.Parser<$ast.StatementTry> = $.loc($.field($.pure("StatementTry"), "$", $.right(keyword($.str("try")), $.field($.lazy(() => statements), "body", $.field($.opt($.right(keyword($.str("catch")), $.right($.str("("), $.field(Id, "name", $.right($.str(")"), $.field($.lazy(() => statements), "body", $.eps)))))), "handler", $.eps)))));
 export const StatementForEach: $.Parser<$ast.StatementForEach> = $.loc($.field($.pure("StatementForEach"), "$", $.right(keyword($.str("foreach")), $.right($.str("("), $.field(Id, "key", $.right($.str(","), $.field(Id, "value", $.right($.str("in"), $.field($.lazy(() => expression), "expression", $.right($.str(")"), $.field($.lazy(() => statements), "body", $.eps)))))))))));
 export const StatementExpression: $.Parser<$ast.StatementExpression> = $.loc($.field($.pure("StatementExpression"), "$", $.field($.lazy(() => expression), "expression", $.right(semicolon, $.eps))));
-export const StatementAssign: $.Parser<$ast.StatementAssign> = $.loc($.field($.pure("StatementAssign"), "$", $.field($.lazy(() => expression), "left", $.field($.opt($.lazy(() => augmentedOp)), "operator", $.right($.str("="), $.field($.lazy(() => expression), "right", $.right(semicolon, $.eps)))))));
+export const StatementAssign: $.Parser<$ast.StatementAssign> = $.loc($.field($.pure("StatementAssign"), "$", $.field($.lazy(() => expression), "left", $.field($.alt($.lazy(() => augmentedOp), $.str("=")), "operator", $.field($.lazy(() => expression), "right", $.right(semicolon, $.eps))))));
 export const statement: $.Parser<$ast.statement> = $.alt(StatementLet, $.alt(StatementDestruct, $.alt(StatementBlock, $.alt(StatementReturn, $.alt(StatementCondition, $.alt(StatementWhile, $.alt(StatementRepeat, $.alt(StatementUntil, $.alt(StatementTry, $.alt(StatementForEach, $.alt(StatementExpression, StatementAssign)))))))))));
 export const statements: $.Parser<$ast.statements> = $.right($.str("{"), $.left($.star(statement), $.str("}")));
-export const augmentedOp: $.Parser<$ast.augmentedOp> = $.alt($.str("||"), $.alt($.str("&&"), $.alt($.str(">>"), $.alt($.str("<<"), $.regex<"-" | "+" | "*" | "/" | "%" | "|" | "&" | "^">("-+*/%|&^", [$.ExpString("-"), $.ExpString("+"), $.ExpString("*"), $.ExpString("/"), $.ExpString("%"), $.ExpString("|"), $.ExpString("&"), $.ExpString("^")])))));
+export const augmentedOp: $.Parser<$ast.augmentedOp> = $.alt($.str("||="), $.alt($.str("&&="), $.alt($.str(">>="), $.alt($.str("<<="), $.alt($.str("-="), $.alt($.str("+="), $.alt($.str("*="), $.alt($.str("/="), $.alt($.str("%="), $.alt($.str("|="), $.alt($.str("&="), $.str("^="))))))))))));
 export const FalseBranch: $.Parser<$ast.FalseBranch> = $.loc($.field($.pure("FalseBranch"), "$", $.field(statements, "body", $.eps)));
 export const RegularField: $.Parser<$ast.RegularField> = $.loc($.field($.pure("RegularField"), "$", $.field(Id, "fieldName", $.right($.str(":"), $.field(Id, "varName", $.eps)))));
 export const PunnedField: $.Parser<$ast.PunnedField> = $.loc($.field($.pure("PunnedField"), "$", $.field(Id, "name", $.eps)));

--- a/src/grammar/index.ts
+++ b/src/grammar/index.ts
@@ -619,7 +619,7 @@ const parseStatementAssign =
         Ast.StatementAssign | Ast.StatementAugmentedAssign
     > =>
     (ctx) => {
-        if (typeof operator === "undefined") {
+        if (operator === "=") {
             return ctx.ast.StatementAssign(
                 parseExpression(left)(ctx),
                 parseExpression(right)(ctx),

--- a/src/grammar/test-failed/augmented-assign-with-space.tact
+++ b/src/grammar/test-failed/augmented-assign-with-space.tact
@@ -1,0 +1,9 @@
+primitive Int;
+
+trait BaseTrait {}
+
+contract Foo {
+    fun foo() {
+        a << = 10;
+    }
+}

--- a/src/optimizer/interpreter.ts
+++ b/src/optimizer/interpreter.ts
@@ -12,6 +12,7 @@ import {
     throwInternalCompilerError,
 } from "../error/errors";
 import type { AstUtil } from "../ast/util";
+import { binaryOperationFromAugmentedAssignment } from "../ast/util";
 import { getAstUtil } from "../ast/util";
 import {
     getStaticConstant,
@@ -1749,7 +1750,7 @@ export class Interpreter {
                 );
             }
             const newVal = evalBinaryOp(
-                ast.op,
+                binaryOperationFromAugmentedAssignment(ast.op),
                 currentPathValue,
                 updateVal,
                 ast.loc,

--- a/src/optimizer/interpreter.ts
+++ b/src/optimizer/interpreter.ts
@@ -12,7 +12,7 @@ import {
     throwInternalCompilerError,
 } from "../error/errors";
 import type { AstUtil } from "../ast/util";
-import { binaryOperationFromAugmentedAssignment } from "../ast/util";
+import { binaryOperationFromAugmentedAssignOperation } from "../ast/util";
 import { getAstUtil } from "../ast/util";
 import {
     getStaticConstant,
@@ -1750,7 +1750,7 @@ export class Interpreter {
                 );
             }
             const newVal = evalBinaryOp(
-                binaryOperationFromAugmentedAssignment(ast.op),
+                binaryOperationFromAugmentedAssignOperation(ast.op),
                 currentPathValue,
                 updateVal,
                 ast.loc,

--- a/src/types/resolveStatements.ts
+++ b/src/types/resolveStatements.ts
@@ -355,29 +355,29 @@ function processStatements(
                         );
                     }
 
-                    if (s.op === "&&" || s.op === "||") {
+                    if (s.op === "&&=" || s.op === "||=") {
                         if (tailType.name !== "Bool") {
                             throwCompilationError(
-                                `Type error: Augmented assignment ${s.op}= is only allowed for Bool type`,
+                                `Type error: Augmented assignment ${s.op} is only allowed for Bool type`,
                                 s.path.loc,
                             );
                         }
                         if (expressionType.name !== "Bool") {
                             throwCompilationError(
-                                `Type error: Augmented assignment ${s.op}= is only allowed for Bool type`,
+                                `Type error: Augmented assignment ${s.op} is only allowed for Bool type`,
                                 s.expression.loc,
                             );
                         }
                     } else {
                         if (tailType.name !== "Int") {
                             throwCompilationError(
-                                `Type error: Augmented assignment ${s.op}= is only allowed for Int type`,
+                                `Type error: Augmented assignment ${s.op} is only allowed for Int type`,
                                 s.path.loc,
                             );
                         }
                         if (expressionType.name !== "Int") {
                             throwCompilationError(
-                                `Type error: Augmented assignment ${s.op}= is only allowed for Int type`,
+                                `Type error: Augmented assignment ${s.op} is only allowed for Int type`,
                                 s.expression.loc,
                             );
                         }


### PR DESCRIPTION
## Issue

Closes #2486.

## Checklist

- [x] I have updated CHANGELOG.md
- [x] I have added tests to demonstrate the contribution is correctly implemented: this usually includes both positive and negative tests, showing the happy path(s) and featuring intentionally broken cases
