### PR TITLE
fix(codegen): add short-circuit behavior for `&&=` and `||=` operators

### DIFF
--- a/dev-docs/CHANGELOG.md
+++ b/dev-docs/CHANGELOG.md
@@ -15,7 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [fix] The parser does not throw an internal compiler error if the error is reported after the end of the file: PR [#2485](https://github.com/tact-lang/tact/pull/2485)
 - [fix] Always show an error when calling the `dump()` function with an argument of the unsupported `StringBuilder` type: PR [#2491](https://github.com/tact-lang/tact/pull/2491)
 - [fix] The grammar now disallows the augmented assignment operators with whitespace between the operator and the equals sign: PR [#2492](https://github.com/tact-lang/tact/pull/2492)
-- [fix] Add short-circuit behavior for `&&=` and `||=` operators: PR [#2494](https://github.com/tact-lang/tact/pull/2494)
+- [fix] Generated code now short-circuits `&&=` and `||=` operators: PR [#2494](https://github.com/tact-lang/tact/pull/2494)
 
 ### Standard Library
 

--- a/dev-docs/CHANGELOG.md
+++ b/dev-docs/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [fix] The parser does not throw an internal compiler error if the error is reported after the end of the file: PR [#2485](https://github.com/tact-lang/tact/pull/2485)
 - [fix] Always show an error when calling the `dump()` function with an argument of the unsupported `StringBuilder` type: PR [#2491](https://github.com/tact-lang/tact/pull/2491)
 - [fix] The grammar now disallows the augmented assignment operators with whitespace between the operator and the equals sign: PR [#2492](https://github.com/tact-lang/tact/pull/2492)
+- [fix] Add short-circuit behavior for `&&=` and `||=` operators: PR [#2494](https://github.com/tact-lang/tact/pull/2494)
 
 ### Standard Library
 

--- a/src/generator/writers/writeFunction.ts
+++ b/src/generator/writers/writeFunction.ts
@@ -182,9 +182,19 @@ export function writeStatement(
             }
             const path = writePathExpression(lvaluePath);
             const t = getExpType(ctx.ctx, f.path);
-            const op = f.op === "&&=" ? "&" : f.op === "||=" ? "|" : f.op;
+
+            if (f.op === "&&=" || f.op === "||=") {
+                const rendered =
+                    f.op === "&&="
+                        ? `(${path} ? ${writeExpression(f.expression, ctx)} : (false))`
+                        : `(${path} ? (true) : ${writeExpression(f.expression, ctx)})`;
+
+                ctx.append(`${path} = ${cast(t, t, rendered, ctx)};`);
+                return;
+            }
+
             ctx.append(
-                `${path} = ${cast(t, t, `${path} ${op} ${writeExpression(f.expression, ctx)}`, ctx)};`,
+                `${path} = ${cast(t, t, `${path} ${f.op} ${writeExpression(f.expression, ctx)}`, ctx)};`,
             );
             return;
         }

--- a/src/test/e2e-emulated/augmented-assign-short-circuit.spec.ts
+++ b/src/test/e2e-emulated/augmented-assign-short-circuit.spec.ts
@@ -1,0 +1,40 @@
+import { toNano } from "@ton/core";
+import type { SandboxContract, TreasuryContract } from "@ton/sandbox";
+import { Blockchain } from "@ton/sandbox";
+import { Test } from "./contracts/output/augmented-assign-short-circuit_Test";
+import "@ton/test-utils";
+
+describe("augmented assign short circuit", () => {
+    let blockchain: Blockchain;
+    let treasure: SandboxContract<TreasuryContract>;
+    let contract: SandboxContract<Test>;
+
+    beforeEach(async () => {
+        blockchain = await Blockchain.create();
+        blockchain.verbosity.print = false;
+        treasure = await blockchain.treasury("treasure");
+        contract = blockchain.openContract(await Test.fromInit());
+
+        const result = await contract.send(
+            treasure.getSender(),
+            {
+                value: toNano("10"),
+            },
+            null,
+        );
+
+        expect(result.transactions).toHaveTransaction({
+            from: treasure.address,
+            to: contract.address,
+            success: true,
+            deploy: true,
+        });
+    });
+
+    it("should successfully run getters", async () => {
+        expect(await contract.getAnd()).toEqual(false);
+        expect(await contract.getOr()).toEqual(true);
+        expect(await contract.getAndAssign()).toEqual(false);
+        expect(await contract.getOrAssign()).toEqual(true);
+    });
+});

--- a/src/test/e2e-emulated/contracts/augmented-assign-short-circuit.tact
+++ b/src/test/e2e-emulated/contracts/augmented-assign-short-circuit.tact
@@ -1,0 +1,29 @@
+contract Test {
+    t: Int = 0;
+
+    receive() {}
+
+    get fun and(): Bool {
+        let x = false;
+        x = x && (1 / self.t == 0);
+        return x;
+    }
+
+    get fun or(): Bool {
+        let x = true;
+        x = x || (1 / self.t == 0);
+        return x;
+    }
+
+    get fun andAssign(): Bool {
+        let x = false;
+        x &&= (1 / self.t == 0);
+        return x;
+    }
+
+    get fun orAssign(): Bool {
+        let x = true;
+        x ||= (1 / self.t == 0);
+        return x;
+    }
+}


### PR DESCRIPTION
## Issue

Closes #2493.

## Checklist

- [x] I have updated CHANGELOG.md
- [x] I have added tests to demonstrate the contribution is correctly implemented: this usually includes both positive and negative tests, showing the happy path(s) and featuring intentionally broken cases
