### PR TITLE
refactor(ast): remove `SimplifiedString`

### DIFF
--- a/src/abi/global.ts
+++ b/src/abi/global.ts
@@ -13,11 +13,7 @@ import type { AbiFunction } from "./AbiFunction";
 import path from "path";
 import { cwd } from "process";
 import { posixNormalize } from "../utils/filePath";
-import {
-    ensureSimplifiedString,
-    ensureString,
-    interpretEscapeSequences,
-} from "../optimizer/interpreter";
+import { ensureString } from "../optimizer/interpreter";
 import { isLiteral } from "../ast/ast-helpers";
 import { sha256 } from "../utils/sha256";
 import { ops } from "../generator/writers/ops";
@@ -57,12 +53,7 @@ export const GlobalFunctions: Map<string, AbiFunction> = new Map([
                     );
                 }
                 const resolved0 = resolved[0]!;
-                // FIXME: When optimizer step added, change the following line to:
-                // const str = ensureSimplifiedString(resolved0).value;
-                const str = interpretEscapeSequences(
-                    ensureString(resolved0).value,
-                    resolved0.loc,
-                );
+                const str = JSON.parse(`"${ensureString(resolved0).value}"`);
                 return toNano(str).toString(10);
             },
         },
@@ -114,12 +105,7 @@ export const GlobalFunctions: Map<string, AbiFunction> = new Map([
                     );
                 }
                 const resolved1 = resolved[1]!;
-                // FIXME: When optimizer step added, change the following line to:
-                // const str = ensureSimplifiedString(resolved1).value;
-                const str = interpretEscapeSequences(
-                    ensureString(resolved1).value,
-                    resolved1.loc,
-                );
+                const str = JSON.parse(`"${ensureString(resolved1).value}"`);
                 return `throw_unless(${getErrorId(str, ctx.ctx)}, ${writeExpression(resolved[0]!, ctx)})`;
             },
         },
@@ -158,12 +144,7 @@ export const GlobalFunctions: Map<string, AbiFunction> = new Map([
                     );
                 }
                 const resolved0 = resolved[0]!;
-                // FIXME: When optimizer step added, change the following line to:
-                // const str = ensureSimplifiedString(resolved0).value;
-                const str = interpretEscapeSequences(
-                    ensureString(resolved0).value,
-                    resolved0.loc,
-                );
+                const str = JSON.parse(`"${ensureString(resolved0).value}"`);
                 let address: Address;
                 try {
                     address = Address.parse(str);
@@ -214,12 +195,7 @@ export const GlobalFunctions: Map<string, AbiFunction> = new Map([
 
                 // Load cell data
                 const resolved0 = resolved[0]!;
-                // FIXME: When optimizer step added, change the following line to:
-                // const str = ensureSimplifiedString(resolved0).value;
-                const str = interpretEscapeSequences(
-                    ensureString(resolved0).value,
-                    resolved0.loc,
-                );
+                const str = JSON.parse(`"${ensureString(resolved0).value}"`);
                 let c: Cell;
                 try {
                     c = Cell.fromBase64(str);
@@ -406,7 +382,7 @@ export const GlobalFunctions: Map<string, AbiFunction> = new Map([
                     if (isLiteral(resolved0)) {
                         // FIXME: This one does not need fixing, because it is carried out inside a "isLiteral" check.
                         // Remove this comment once the optimization step is added
-                        const str = ensureSimplifiedString(resolved0).value;
+                        const str = ensureString(resolved0).value;
                         return sha256(str).value.toString(10);
                     }
 
@@ -458,12 +434,7 @@ export const GlobalFunctions: Map<string, AbiFunction> = new Map([
 
                 // Load slice data
                 const resolved0 = resolved[0]!;
-                // FIXME: When optimizer step added, change the following line to:
-                // const str = ensureSimplifiedString(resolved0).value;
-                const str = interpretEscapeSequences(
-                    ensureString(resolved0).value,
-                    resolved0.loc,
-                );
+                const str = JSON.parse(`"${ensureString(resolved0).value}"`);
                 let c: Cell;
                 try {
                     c = Cell.fromBase64(str);
@@ -513,12 +484,7 @@ export const GlobalFunctions: Map<string, AbiFunction> = new Map([
 
                 // Load slice data
                 const resolved0 = resolved[0]!;
-                // FIXME: When optimizer step added, change the following line to:
-                // const str = ensureSimplifiedString(resolved0).value;
-                const str = interpretEscapeSequences(
-                    ensureString(resolved0).value,
-                    resolved0.loc,
-                );
+                const str = JSON.parse(`"${ensureString(resolved0).value}"`);
                 let c: Cell;
                 try {
                     c = beginCell().storeBuffer(Buffer.from(str)).endCell();
@@ -562,13 +528,7 @@ export const GlobalFunctions: Map<string, AbiFunction> = new Map([
 
                 // Load slice data
                 const resolved0 = resolved[0]!;
-                // FIXME: When optimizer step added, change the following line to:
-                // const str = ensureSimplifiedString(resolved0).value;
-                const str = interpretEscapeSequences(
-                    ensureString(resolved0).value,
-                    resolved0.loc,
-                );
-
+                const str = JSON.parse(`"${ensureString(resolved0).value}"`);
                 if (str.length > 32) {
                     throwCompilationError(
                         `ascii() expects string argument with length <= 32`,
@@ -610,13 +570,7 @@ export const GlobalFunctions: Map<string, AbiFunction> = new Map([
 
                 // Load slice data
                 const resolved0 = resolved[0]!;
-                // FIXME: When optimizer step added, change the following line to:
-                // const str = ensureSimplifiedString(resolved0).value;
-                const str = interpretEscapeSequences(
-                    ensureString(resolved0).value,
-                    resolved0.loc,
-                );
-
+                const str = JSON.parse(`"${ensureString(resolved0).value}"`);
                 return `"${str}"c`;
             },
         },

--- a/src/abi/global.ts
+++ b/src/abi/global.ts
@@ -53,7 +53,7 @@ export const GlobalFunctions: Map<string, AbiFunction> = new Map([
                     );
                 }
                 const resolved0 = resolved[0]!;
-                const str = JSON.parse(`"${ensureString(resolved0).value}"`);
+                const str = ensureString(resolved0).value;
                 return toNano(str).toString(10);
             },
         },
@@ -105,7 +105,7 @@ export const GlobalFunctions: Map<string, AbiFunction> = new Map([
                     );
                 }
                 const resolved1 = resolved[1]!;
-                const str = JSON.parse(`"${ensureString(resolved1).value}"`);
+                const str = ensureString(resolved1).value;
                 return `throw_unless(${getErrorId(str, ctx.ctx)}, ${writeExpression(resolved[0]!, ctx)})`;
             },
         },
@@ -144,7 +144,7 @@ export const GlobalFunctions: Map<string, AbiFunction> = new Map([
                     );
                 }
                 const resolved0 = resolved[0]!;
-                const str = JSON.parse(`"${ensureString(resolved0).value}"`);
+                const str = ensureString(resolved0).value;
                 let address: Address;
                 try {
                     address = Address.parse(str);
@@ -195,7 +195,7 @@ export const GlobalFunctions: Map<string, AbiFunction> = new Map([
 
                 // Load cell data
                 const resolved0 = resolved[0]!;
-                const str = JSON.parse(`"${ensureString(resolved0).value}"`);
+                const str = ensureString(resolved0).value;
                 let c: Cell;
                 try {
                     c = Cell.fromBase64(str);
@@ -434,7 +434,7 @@ export const GlobalFunctions: Map<string, AbiFunction> = new Map([
 
                 // Load slice data
                 const resolved0 = resolved[0]!;
-                const str = JSON.parse(`"${ensureString(resolved0).value}"`);
+                const str = ensureString(resolved0).value;
                 let c: Cell;
                 try {
                     c = Cell.fromBase64(str);
@@ -484,7 +484,7 @@ export const GlobalFunctions: Map<string, AbiFunction> = new Map([
 
                 // Load slice data
                 const resolved0 = resolved[0]!;
-                const str = JSON.parse(`"${ensureString(resolved0).value}"`);
+                const str = ensureString(resolved0).value;
                 let c: Cell;
                 try {
                     c = beginCell().storeBuffer(Buffer.from(str)).endCell();
@@ -528,7 +528,7 @@ export const GlobalFunctions: Map<string, AbiFunction> = new Map([
 
                 // Load slice data
                 const resolved0 = resolved[0]!;
-                const str = JSON.parse(`"${ensureString(resolved0).value}"`);
+                const str = ensureString(resolved0).value;
                 if (str.length > 32) {
                     throwCompilationError(
                         `ascii() expects string argument with length <= 32`,
@@ -570,7 +570,7 @@ export const GlobalFunctions: Map<string, AbiFunction> = new Map([
 
                 // Load slice data
                 const resolved0 = resolved[0]!;
-                const str = JSON.parse(`"${ensureString(resolved0).value}"`);
+                const str = ensureString(resolved0).value;
                 return `"${str}"c`;
             },
         },

--- a/src/ast/ast-helpers.ts
+++ b/src/ast/ast-helpers.ts
@@ -157,8 +157,6 @@ export function eqExpressions(
             return ast1.value
                 .asCell()
                 .equals((ast2 as Ast.Slice).value.asCell());
-        case "simplified_string":
-            return ast1.value === (ast2 as Ast.SimplifiedString).value;
         case "struct_value":
             return (
                 eqNames(ast1.type, (ast2 as Ast.StructValue).type) &&
@@ -377,12 +375,11 @@ function checkLiteral<T>(
         case "address":
         case "cell":
         case "slice":
-        case "simplified_string":
+        case "string":
         case "struct_value":
             return t(ast);
 
         case "struct_instance":
-        case "string":
         case "id":
         case "method_call":
         case "init_of":

--- a/src/ast/ast-printer.ts
+++ b/src/ast/ast-printer.ts
@@ -193,9 +193,7 @@ export const ppAstId = ({ text }: Ast.Id) => text;
 export const ppAstOptionalId = (node: Ast.OptionalId) =>
     node.kind === "id" ? ppAstId(node) : "_";
 export const ppAstNull = (_expr: Ast.Null) => "null";
-export const ppAstString = ({ value }: Ast.String) => `"${value}"`;
-export const ppAstSimplifiedString = ({ value }: Ast.SimplifiedString) =>
-    JSON.stringify(value);
+export const ppAstString = ({ value }: Ast.String) => JSON.stringify(value);
 export const ppAstAddress = ({ value }: Ast.Address) =>
     `addr("${value.toRawString()}")`;
 export const ppAstCell = ({ value }: Ast.Cell) => `cell("${value.toString()}")`;
@@ -267,7 +265,6 @@ export const ppAstExpressionNested = makeVisitor<Ast.Expression>()({
     code_of: ppLeaf(ppAstCodeOf),
     string: ppLeaf(ppAstString),
     static_call: ppLeaf(ppAstStaticCall),
-    simplified_string: ppLeaf(ppAstSimplifiedString),
     address: ppLeaf(ppAstAddress),
     cell: ppLeaf(ppAstCell),
     slice: ppLeaf(ppAstSlice),
@@ -896,7 +893,6 @@ export const ppAstNode: Printer<Ast.AstNode> = makeVisitor<Ast.AstNode>()({
     id: exprNode(ppAstExpression),
     boolean: exprNode(ppAstExpression),
     string: exprNode(ppAstExpression),
-    simplified_string: exprNode(ppAstExpression),
     null: exprNode(ppAstExpression),
     address: exprNode(ppAstExpression),
     cell: exprNode(ppAstExpression),

--- a/src/ast/ast.ts
+++ b/src/ast/ast.ts
@@ -391,14 +391,13 @@ export type Expression =
     | Id
     | InitOf
     | CodeOf
-    | String
     | Literal;
 
 export type Literal =
     | Number
     | Boolean
     | Null
-    | SimplifiedString
+    | String
     | Address
     | Cell
     | Slice
@@ -574,20 +573,7 @@ export type ImportPath = {
 // from standard library is still import with origin: "stdlib"
 export type ImportType = "stdlib" | "relative";
 
-// An SimplifiedString is a string in which escaping characters, like '\\' has been simplified, e.g., '\\' simplified to '\'.
-// An String is not a literal because it may contain escaping characters that have not been simplified, like '\\'.
-// SimplifiedString is always produced by the interpreter, never directly by the parser. The parser produces Strings, which
-// then get transformed into SimplifiedString by the interpreter.
-export type SimplifiedString = {
-    readonly kind: "simplified_string";
-    readonly value: string;
-    readonly id: number;
-    readonly loc: SrcInfo;
-};
-
-/**
- * @deprecated SimplifiedString
- */
+// A String is a string in which escaping characters, like '\\' has been simplified, e.g., '\\' simplified to '\'.
 export type String = {
     readonly kind: "string";
     readonly value: string;

--- a/src/ast/iterators.ts
+++ b/src/ast/iterators.ts
@@ -326,7 +326,6 @@ export function traverseAndCheck(
         case "boolean":
         case "string":
         case "null":
-        case "simplified_string":
         case "address":
         case "cell":
         case "slice":

--- a/src/ast/random.infra.ts
+++ b/src/ast/random.infra.ts
@@ -69,13 +69,10 @@ function randomAstBoolean(): fc.Arbitrary<Ast.Boolean> {
 }
 
 function randomAstString(): fc.Arbitrary<Ast.String> {
-    const escapeString = (s: string): string =>
-        s.replace(/\\/g, "\\\\").replace(/"/g, '\\"');
-
     return dummyAstNode(
         fc.record({
             kind: fc.constant("string"),
-            value: fc.string().map((s) => escapeString(s)),
+            value: fc.string(),
         }),
     );
 }
@@ -285,7 +282,6 @@ function randomAstLiteral(maxDepth: number): fc.Arbitrary<Ast.Literal> {
                 randomAstNull(),
                 // Add Address, Cell, Slice
                 // randomAstCommentValue(),
-                // randomAstSimplifiedString(),
             );
         }
 
@@ -296,7 +292,6 @@ function randomAstLiteral(maxDepth: number): fc.Arbitrary<Ast.Literal> {
             randomAstBoolean(),
             randomAstNull(),
             // Add Address, Cell, Slice
-            // randomAstSimplifiedString(),
             // randomAstCommentValue(),
             randomAstStructValue(subLiteral()),
         );

--- a/src/ast/util.ts
+++ b/src/ast/util.ts
@@ -53,18 +53,6 @@ export const getAstUtil = ({ createNode }: FactoryAst) => {
         return result as Ast.Boolean;
     }
 
-    function makeSimplifiedStringLiteral(
-        s: string,
-        loc: SrcInfo,
-    ): Ast.SimplifiedString {
-        const result = createNode({
-            kind: "simplified_string",
-            value: s,
-            loc: loc,
-        });
-        return result as Ast.SimplifiedString;
-    }
-
     function makeNullLiteral(loc: SrcInfo): Ast.Null {
         const result = createNode({
             kind: "null",
@@ -137,7 +125,6 @@ export const getAstUtil = ({ createNode }: FactoryAst) => {
         makeBinaryExpression,
         makeNumberLiteral,
         makeBooleanLiteral,
-        makeSimplifiedStringLiteral,
         makeNullLiteral,
         makeCellLiteral,
         makeSliceLiteral,

--- a/src/generator/writers/writeExpression.ts
+++ b/src/generator/writers/writeExpression.ts
@@ -119,7 +119,7 @@ export function writeValue(val: Ast.Literal, wCtx: WriterContext): string {
     switch (val.kind) {
         case "number":
             return val.value.toString(10);
-        case "simplified_string": {
+        case "string": {
             const id = writeString(val.value, wCtx);
             wCtx.used(id);
             return `${id}()`;
@@ -824,7 +824,7 @@ export function writeTypescriptValue(
     switch (val.kind) {
         case "number":
             return val.value.toString(10) + "n";
-        case "simplified_string":
+        case "string":
             return JSON.stringify(val.value);
         case "boolean":
             return val.value ? "true" : "false";

--- a/src/grammar/__snapshots__/grammar.spec.ts.snap
+++ b/src/grammar/__snapshots__/grammar.spec.ts.snap
@@ -642,6 +642,14 @@ exports[`grammar should fail literal-non-binary-digits 1`] = `
 "
 `;
 
+exports[`grammar should fail literal-string-undefined-unicode-codepoint 1`] = `
+"<unknown>:1:19: Undefined Unicode code-point
+> 1 | const S: String = "\\u{11ffff}";
+                        ^~~~~~~~~~~~
+  2 | 
+"
+`;
+
 exports[`grammar should fail literal-underscore-after-leading-zero 1`] = `
 "<unknown>:2:12: Numbers with leading zeroes cannot use underscores for JS compatibility
   1 | fun test_fun(): Int {

--- a/src/grammar/expr-is-value.spec.ts
+++ b/src/grammar/expr-is-value.spec.ts
@@ -8,9 +8,6 @@ const valueExpressions: string[] = ["1", "true", "false", "null"];
 const notValueExpressions: string[] = [
     "g",
 
-    // Raw strings are not literals: they need to go through the interpreter to get transformed into simplified strings, which are literals.
-    '"one"',
-
     // Even if these three struct instances have literal fields, raw struct instances are not literals because they need to go through
     // the interpreter to get transformed into struct values.
     "Test {f1: 0, f2: true}",

--- a/src/grammar/index.ts
+++ b/src/grammar/index.ts
@@ -218,8 +218,60 @@ const parseIntegerLiteral =
 const parseStringLiteral =
     ({ value, loc }: $ast.StringLiteral): Handler<Ast.String> =>
     (ctx) => {
-        return ctx.ast.String(value, loc);
+        const simplifiedValue = replaceEscapeSequences(value, loc, ctx);
+        return ctx.ast.String(simplifiedValue, loc);
     };
+
+export function replaceEscapeSequences(
+    stringLiteral: string,
+    loc: $.Loc,
+    ctx: Context,
+): string {
+    return stringLiteral.replace(
+        /\\\\|\\"|\\n|\\r|\\t|\\v|\\b|\\f|\\u{([0-9A-Fa-f]{1,6})}|\\u([0-9A-Fa-f]{4})|\\x([0-9A-Fa-f]{2})/g,
+        (match, unicodeCodePoint, unicodeEscape, hexEscape) => {
+            switch (match) {
+                case "\\\\":
+                    return "\\";
+                case '\\"':
+                    return '"';
+                case "\\n":
+                    return "\n";
+                case "\\r":
+                    return "\r";
+                case "\\t":
+                    return "\t";
+                case "\\v":
+                    return "\v";
+                case "\\b":
+                    return "\b";
+                case "\\f":
+                    return "\f";
+                default:
+                    // Handle Unicode code point escape
+                    if (unicodeCodePoint) {
+                        const codePoint = parseInt(unicodeCodePoint, 16);
+                        if (codePoint > 0x10ffff) {
+                            ctx.err.undefinedUnicodeCodepoint()(loc);
+                            return match;
+                        }
+                        return String.fromCodePoint(codePoint);
+                    }
+                    // Handle Unicode escape
+                    if (unicodeEscape) {
+                        const codeUnit = parseInt(unicodeEscape, 16);
+                        return String.fromCharCode(codeUnit);
+                    }
+                    // Handle hex escape
+                    if (hexEscape) {
+                        const hexValue = parseInt(hexEscape, 16);
+                        return String.fromCharCode(hexValue);
+                    }
+                    return match;
+            }
+        },
+    );
+}
 
 const parseBoolLiteral =
     ({ value, loc }: $ast.BoolLiteral): Handler<Ast.Boolean> =>

--- a/src/grammar/parser-error.ts
+++ b/src/grammar/parser-error.ts
@@ -167,6 +167,9 @@ export const syntaxErrorSchema = <T, U>(
         noWildcard: () => {
             return handle(text(`Wildcard not allowed here`));
         },
+        undefinedUnicodeCodepoint: () => {
+            return handle(text(`Undefined Unicode code-point`));
+        },
     };
 };
 

--- a/src/grammar/test-failed/literal-string-undefined-unicode-codepoint.tact
+++ b/src/grammar/test-failed/literal-string-undefined-unicode-codepoint.tact
@@ -1,0 +1,2 @@
+const S: String = "\u{11ffff}";
+

--- a/src/optimizer/constEval.ts
+++ b/src/optimizer/constEval.ts
@@ -166,8 +166,6 @@ export const getOptimizer = (util: AstUtil) => {
             case "number":
                 return interpreter.interpretExpression(ast);
             case "string":
-                return interpreter.interpretExpression(ast);
-            case "simplified_string":
                 return ast;
             case "struct_value":
                 return ast;

--- a/src/optimizer/test/partial-eval.spec.ts
+++ b/src/optimizer/test/partial-eval.spec.ts
@@ -370,8 +370,6 @@ function dummyEval(
                 return ast;
             case "cell":
                 return ast;
-            case "simplified_string":
-                return ast;
             case "slice":
                 return ast;
             case "struct_value":

--- a/src/test/e2e-emulated/contracts/intrinsics.tact
+++ b/src/test/e2e-emulated/contracts/intrinsics.tact
@@ -23,6 +23,7 @@ contract IntrinsicsTester {
     u: Slice = rawSlice("8a0_");
     w: Slice = rawSlice("8_");
     v: Slice = rawSlice("00_");
+    x: Int = ascii("\n\t\r\b\f\"\\\v\u{4242}\xA9");
 
     init() {
 
@@ -158,6 +159,14 @@ contract IntrinsicsTester {
 
     get fun getAscii4(): Int {
         return self.l;
+    }
+
+    get fun getAscii5(): Int {
+        return ascii("\n\t\r\b\f\"\\\v\u{4242}\xA9");
+    }
+
+    get fun getAscii6(): Int {
+        return self.x;
     }
 
     get fun getCrc32(): Int {

--- a/src/test/e2e-emulated/contracts/text-message-receivers.tact
+++ b/src/test/e2e-emulated/contracts/text-message-receivers.tact
@@ -19,6 +19,12 @@ contract TextMessageReceivers with Deployable {
         self.counter += 4;
     }
 
+    receive(s: String) {
+        if (s == "test \n \t \r \b \f \" \\ \v \\\\ \u{4242} \xA9") {
+            self.counter += 5;
+        }
+    }
+
     get fun getCounter(): Int {
         return self.counter;
     }

--- a/src/test/e2e-emulated/intrinsics.spec.ts
+++ b/src/test/e2e-emulated/intrinsics.spec.ts
@@ -256,6 +256,12 @@ describe("intrinsics", () => {
         expect((await contract.getGetAscii4()).toString()).toBe(
             "1563963554659859369353828835329962428465513941646011501275668087180532385",
         );
+        expect((await contract.getGetAscii5()).toString(16)).toBe(
+            "a090d080c225c0be48982c2a9",
+        );
+        expect((await contract.getGetAscii6()).toString(16)).toBe(
+            "a090d080c225c0be48982c2a9",
+        );
 
         // Check `crc32`
         expect((await contract.getGetCrc32()).toString()).toBe("2235694568");

--- a/src/test/e2e-emulated/text-message-receivers.spec.ts
+++ b/src/test/e2e-emulated/text-message-receivers.spec.ts
@@ -56,11 +56,7 @@ describe("text-message-receivers", () => {
         expect(await contract.getGetCounter()).toBe(0n);
 
         const sendMessage = async (
-            message:
-                | "increment'"
-                | 'increment-2\\"'
-                | "increment-3`"
-                | "\\\\increment-4\\\\",
+            message: Parameters<typeof contract.send>[2],
         ) => {
             const incrementResult1 = await contract.send(
                 treasure.getSender(),
@@ -78,13 +74,16 @@ describe("text-message-receivers", () => {
         await sendMessage("increment'");
         expect(await contract.getGetCounter()).toBe(1n);
 
-        await sendMessage('increment-2\\"');
+        await sendMessage('increment-2"');
         expect(await contract.getGetCounter()).toBe(3n);
 
         await sendMessage("increment-3`");
         expect(await contract.getGetCounter()).toBe(6n);
 
-        await sendMessage("\\\\increment-4\\\\");
+        await sendMessage("\\increment-4\\");
         expect(await contract.getGetCounter()).toBe(10n);
+
+        await sendMessage('test \n \t \r \b \f " \\ \v \\\\ \u{4242} \xA9');
+        expect(await contract.getGetCounter()).toBe(15n);
     });
 });

--- a/src/types/effects.ts
+++ b/src/types/effects.ts
@@ -209,7 +209,6 @@ function expressionEffects(
         case "boolean":
         case "slice":
         case "null":
-        case "simplified_string":
         case "address":
         case "cell":
         case "struct_value":

--- a/src/types/resolveErrors.ts
+++ b/src/types/resolveErrors.ts
@@ -11,10 +11,10 @@ import {
     getAllTypes,
     getAllStaticConstants,
 } from "./resolveDescriptors";
-import { ensureSimplifiedString } from "../optimizer/interpreter";
 import type { AstUtil } from "../ast/util";
 import { getAstUtil } from "../ast/util";
 import { sha256, highest32ofSha256 } from "../utils/sha256";
+import { ensureString } from "../optimizer/interpreter";
 
 type Exception = { value: string; id: number };
 
@@ -38,7 +38,7 @@ function resolveStringsInAST(
             if (node.args.length !== 2) {
                 return;
             }
-            const resolved = ensureSimplifiedString(
+            const resolved = ensureString(
                 evalConstantExpression(node.args[1]!, ctx, util),
             ).value;
             if (!exceptions.get(ctx, resolved)) {

--- a/src/types/resolveExpression.ts
+++ b/src/types/resolveExpression.ts
@@ -124,7 +124,7 @@ function resolveSliceLiteral(
 }
 
 function resolveStringLiteral(
-    exp: Ast.String | Ast.SimplifiedString,
+    exp: Ast.String,
     sctx: StatementContext,
     ctx: CompilerContext,
 ): CompilerContext {
@@ -853,10 +853,6 @@ export function resolveExpression(
         }
         case "slice": {
             return resolveSliceLiteral(exp, sctx, ctx);
-        }
-        case "simplified_string": {
-            // A simplified string is resolved as a string
-            return resolveStringLiteral(exp, sctx, ctx);
         }
         case "struct_value": {
             // A struct value is resolved as a struct instance

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -58,7 +58,7 @@ export function showValue(val: Ast.Literal): string {
     switch (val.kind) {
         case "number":
             return val.value.toString(val.base);
-        case "simplified_string":
+        case "string":
             return val.value;
         case "boolean":
             return val.value ? "true" : "false";


### PR DESCRIPTION
Now the parser unescapes string literals

## Issue

Closes #1323.
