### PR TITLE
fix(docs): code example of the `initOf` expression

### DIFF
--- a/dev-docs/CHANGELOG.md
+++ b/dev-docs/CHANGELOG.md
@@ -7,7 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### [1.6.5] - 2025-03-28
+### Docs
+
+- Fixed code example of the `initOf` expression to highlight support for contract parameters: PR [#2550](https://github.com/tact-lang/tact/pull/2550)
+
+### Release contributors
+
+- [Novus Nota](https://github.com/novusnota)
+
+## [1.6.5] - 2025-03-28
 
 ### Language features
 

--- a/docs/src/content/docs/book/assembly-functions.mdx
+++ b/docs/src/content/docs/book/assembly-functions.mdx
@@ -646,9 +646,9 @@ This example extends the [`ecrecover(){:tact}`](#ecrecover) example and adds mor
 ```tact
 // Calculates and returns the SHA-256 hash
 // as a 256-bit unsigned `Int` of the given `data`.
+//
 // Unlike the `sha256()` function from the Core library,
-// this one works purely on-chain (at runtime), hashing the strings completely,
-// whereas the `sha256()` reliably works only with their first 1023 bits of data.
+// this one works purely on-chain (at runtime).
 fun onchainSha256(data: String): Int {
     _onchainShaPush(data);
     while (_onchainShaShouldProceed()) {

--- a/docs/src/content/docs/book/expressions.mdx
+++ b/docs/src/content/docs/book/expressions.mdx
@@ -259,7 +259,7 @@ contract ExampleContract {
 The expression `initOf{:tact}` computes the initial state, i.e., `StateInit{:tact}`, of a [contract](/book/contracts):
 
 ```tact
-//                     argument values for the init() function of the contract
+//                     argument values of contract or init() parameters
 //                     ↓   ↓
 initOf ExampleContract(42, 100); // returns a Struct StateInit{}
 //     ---------------
@@ -273,7 +273,7 @@ initOf ExampleContract(
 );
 ```
 
-The `StateInit{:tact}` is a [Struct][s] consisting of the following fields:
+The `StateInit{:tact}` is a [struct][s] consisting of the following fields:
 
 Field  | Type                  | Description
 :----- | :-------------------- | :----------
@@ -317,7 +317,7 @@ codeOf ExampleContract; // a Cell with ExampleContract code
 If `codeOf{:tact}` is used for the current contract, its result is equivalent to calling [`myCode(){:tact}`](/ref/core-contextstate#mycode).
 
 ```tact
-contract ExampleContract {
+contract ExampleContract() {
     receive() {
         myCode() == codeOf ExampleContract; // true
     }

--- a/docs/src/content/docs/book/maps.mdx
+++ b/docs/src/content/docs/book/maps.mdx
@@ -455,7 +455,7 @@ contract Example {
 
 To iterate over map entries, there is a [`foreach{:tact}`](/book/statements#foreach-loop) loop statement:
 
-```tact
+```tact {9-11}
 // Empty map
 let fizz: map<Int, Int> = emptyMap();
 


### PR DESCRIPTION
## Issue

Closes #2540.

Also addressed two minor things:
1. Updated the comments for the `onchainSha256()` function on the assembly page, because the `sha256()` properly hashes whole Slices or Strings on-chain
2. Highlighted the `foreach` statement example on the maps page