### PR TITLE
fix(docs): highlighting of the `message()` function and the `message` keyword

### DIFF
--- a/docs/grammars/grammar-tact.json
+++ b/docs/grammars/grammar-tact.json
@@ -542,7 +542,7 @@
             "name": "keyword.other.struct.tact"
           },
           {
-            "match": "(?<!\\.)\\b(message)\\b",
+            "match": "(?<!\\.)\\b(message(?!\\s*\\((?:MessageParameters|\\))))\\b",
             "name": "keyword.other.message.tact"
           },
           {


### PR DESCRIPTION
## Issue

Closes #2617.
