### PR TITLE
fix: add check for `ton()` with empty or blank string

### DIFF
--- a/dev-docs/CHANGELOG.md
+++ b/dev-docs/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Language features
 
 - Optimized message deserialization with native loading of `Maybe Cell` fields: PR [#2661](https://github.com/tact-lang/tact/pull/2661)
+- [fix] Compiler now disallows `ton()` with empty or blank string: PR [#2681](https://github.com/tact-lang/tact/pull/2681)
 
 ### Standard Library
 

--- a/src/abi/global.ts
+++ b/src/abi/global.ts
@@ -53,8 +53,14 @@ export const GlobalFunctions: Map<string, AbiFunction> = new Map([
                     );
                 }
                 const resolved0 = resolved[0]!;
-                const str = ensureString(resolved0).value;
-                return toNano(str).toString(10);
+                const tons = ensureString(resolved0);
+                if (tons.value.trim().length === 0) {
+                    throwCompilationError(
+                        "ton() function requires a non-empty value",
+                        tons.loc,
+                    );
+                }
+                return toNano(tons.value).toString(10);
             },
         },
     ],

--- a/src/abi/global.ts
+++ b/src/abi/global.ts
@@ -53,14 +53,8 @@ export const GlobalFunctions: Map<string, AbiFunction> = new Map([
                     );
                 }
                 const resolved0 = resolved[0]!;
-                const tons = ensureString(resolved0);
-                if (tons.value.trim().length === 0) {
-                    throwCompilationError(
-                        "ton() function requires a non-empty value",
-                        tons.loc,
-                    );
-                }
-                return toNano(tons.value).toString(10);
+                const str = ensureString(resolved0).value;
+                return toNano(str).toString(10);
             },
         },
     ],

--- a/src/optimizer/interpreter.ts
+++ b/src/optimizer/interpreter.ts
@@ -8,6 +8,7 @@ import {
     idTextErr,
     TactCompilationError,
     TactConstEvalError,
+    throwCompilationError,
     throwConstEvalError,
     throwInternalCompilerError,
 } from "@/error/errors";
@@ -1157,6 +1158,12 @@ export class Interpreter {
                 const tons = ensureString(
                     this.interpretExpressionInternal(ast.args[0]!),
                 );
+                if (tons.value.trim().length === 0) {
+                    throwCompilationError(
+                        "ton() function requires a non-empty value",
+                        tons.loc,
+                    );
+                }
                 try {
                     return ensureInt(
                         this.util.makeNumberLiteral(

--- a/src/types/__snapshots__/resolveDescriptors.spec.ts.snap
+++ b/src/types/__snapshots__/resolveDescriptors.spec.ts.snap
@@ -933,6 +933,24 @@ exports[`resolveDescriptors should fail descriptors for struct-field-with-contra
 "
 `;
 
+exports[`resolveDescriptors should fail descriptors for ton-with-blank-string 1`] = `
+"<unknown>:3:22: ton() function requires a non-empty value
+  2 | 
+> 3 | const FOO: Int = ton("      ");
+                           ^~~~~~~~
+  4 | 
+"
+`;
+
+exports[`resolveDescriptors should fail descriptors for ton-with-empty-string 1`] = `
+"<unknown>:3:22: ton() function requires a non-empty value
+  2 | 
+> 3 | const FOO: Int = ton("");
+                           ^~
+  4 | 
+"
+`;
+
 exports[`resolveDescriptors should fail descriptors for trait-circular-deps 1`] = `
 "<unknown>:3:1: Circular dependency detected for type "A"
   2 | 

--- a/src/types/test-failed/ton-with-blank-string.tact
+++ b/src/types/test-failed/ton-with-blank-string.tact
@@ -1,0 +1,3 @@
+primitive Int;
+
+const FOO: Int = ton("      ");

--- a/src/types/test-failed/ton-with-empty-string.tact
+++ b/src/types/test-failed/ton-with-empty-string.tact
@@ -1,0 +1,3 @@
+primitive Int;
+
+const FOO: Int = ton("");


### PR DESCRIPTION
## Issue

Closes #2538.

## Checklist

- [x] I have updated CHANGELOG.md
- [x] I have added tests to demonstrate the contribution is correctly implemented: this usually includes both positive and negative tests, showing the happy path(s) and featuring intentionally broken cases
