### PR TITLE
fix: add check for ton() with invalid number value or negative numbers

### DIFF
--- a/dev-docs/CHANGELOG.md
+++ b/dev-docs/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Optimized message deserialization with native loading of `Maybe Cell` fields: PR [#2661](https://github.com/tact-lang/tact/pull/2661)
 - [fix] Compiler now disallows `ton()` with empty or blank string: PR [#2681](https://github.com/tact-lang/tact/pull/2681)
+- [fix] Compiler now disallows `ton()` with invalid number value or negative numbers: PR [#2684](https://github.com/tact-lang/tact/pull/2684)
 
 ### Standard Library
 

--- a/src/optimizer/interpreter.ts
+++ b/src/optimizer/interpreter.ts
@@ -465,17 +465,17 @@ class EnvironmentStack {
 
     /*
     Sets a binding for "name" in the **current** environment of the stack.
-    If a binding for "name" already exists in the current environment, it 
+    If a binding for "name" already exists in the current environment, it
     overwrites the binding with the provided value.
     As a special case, name "_" is ignored.
 
-    Note that this method does not check if binding "name" already exists in 
+    Note that this method does not check if binding "name" already exists in
     a parent environment.
-    This means that if binding "name" already exists in a parent environment, 
+    This means that if binding "name" already exists in a parent environment,
     it will be shadowed by the provided value in the current environment.
     This shadowing behavior is useful for modelling recursive function calls.
-    For example, consider the recursive implementation of factorial 
-    (for simplification purposes, it returns 1 for the factorial of 
+    For example, consider the recursive implementation of factorial
+    (for simplification purposes, it returns 1 for the factorial of
     negative numbers):
 
     1  fun factorial(a: Int): Int {
@@ -496,7 +496,7 @@ class EnvironmentStack {
 
     When factorial(1) = 1 finishes execution, the environment at the top
     of the stack is popped:
-    
+
     a = 4 <------- a = 3 <-------- a = 2
 
     and execution resumes at line 5 in the environment where a = 2,
@@ -506,7 +506,7 @@ class EnvironmentStack {
 
     a = 4 <------- a = 3
 
-    so that the return at line 5 (now in the environment a = 3) will 
+    so that the return at line 5 (now in the environment a = 3) will
     produce 3 * 2 = 6, and so on.
     */
     public setNewBinding(name: string, val: Ast.Literal) {
@@ -517,7 +517,7 @@ class EnvironmentStack {
 
     /*
     Searches the binding "name" in the stack, starting at the current
-    environment and moving towards the parent environments. 
+    environment and moving towards the parent environments.
     If it finds the binding, it updates its value
     to "val". If it does not find "name", the stack is unchanged.
     As a special case, name "_" is always ignored.
@@ -533,7 +533,7 @@ class EnvironmentStack {
 
     /*
     Searches the binding "name" in the stack, starting at the current
-    environment and moving towards the parent environments. 
+    environment and moving towards the parent environments.
     If it finds "name", it returns its value.
     If it does not find "name", it returns undefined.
     As a special case, name "_" always returns undefined.
@@ -626,19 +626,19 @@ const defaultInterpreterConfig: InterpreterConfig = {
 };
 
 /*
-Interprets Tact AST trees. 
-The constructor receives an optional CompilerContext which includes 
+Interprets Tact AST trees.
+The constructor receives an optional CompilerContext which includes
 all external declarations that the interpreter will use during interpretation.
-If no CompilerContext is provided, the interpreter will use an empty 
+If no CompilerContext is provided, the interpreter will use an empty
 CompilerContext.
 
-**IMPORTANT**: if a custom CompilerContext is provided, it should be the 
-CompilerContext provided by the typechecker. 
+**IMPORTANT**: if a custom CompilerContext is provided, it should be the
+CompilerContext provided by the typechecker.
 
-The reason for requiring a CompilerContext is that the interpreter should work 
+The reason for requiring a CompilerContext is that the interpreter should work
 in the use case where the interpreter only knows part of the code.
-For example, consider the following code (I marked with brackets [ ] the places 
-where the interpreter gets called during expression simplification in the 
+For example, consider the following code (I marked with brackets [ ] the places
+where the interpreter gets called during expression simplification in the
 compilation phase):
 
 const C: Int = [1];
@@ -650,10 +650,10 @@ contract TestContract {
    }
 }
 
-When the interpreter gets called inside the brackets, it does not know what 
-other code is surrounding those brackets, because the interpreter did not execute the 
-code outside the brackets. Hence, it relies on the typechecker to receive the 
-CompilerContext that includes the declarations in the code 
+When the interpreter gets called inside the brackets, it does not know what
+other code is surrounding those brackets, because the interpreter did not execute the
+code outside the brackets. Hence, it relies on the typechecker to receive the
+CompilerContext that includes the declarations in the code
 (the constant C for example).
 
 Since the interpreter relies on the typechecker, it assumes that the given AST tree
@@ -1165,11 +1165,22 @@ export class Interpreter {
                     );
                 }
                 try {
+                    const value = this.parseTonBuiltinValue(tons);
+                    if (typeof value === "undefined") {
+                        throwCompilationError(
+                            "ton() function requires a valid number with no more than 10 digits after the decimal point",
+                            tons.loc,
+                        );
+                    }
+                    if (value < 0) {
+                        throwCompilationError(
+                            "ton() function requires a non-negative number",
+                            tons.loc,
+                        );
+                    }
+
                     return ensureInt(
-                        this.util.makeNumberLiteral(
-                            BigInt(toNano(tons.value).toString(10)),
-                            ast.loc,
-                        ),
+                        this.util.makeNumberLiteral(value, ast.loc),
                     );
                 } catch (e) {
                     if (e instanceof Error && e.message === "Invalid number") {
@@ -1488,6 +1499,15 @@ export class Interpreter {
                         ast.loc,
                     );
                 }
+        }
+    }
+
+    private parseTonBuiltinValue(tons: Ast.String): bigint | undefined {
+        try {
+            const value = toNano(tons.value);
+            return BigInt(value.toString(10));
+        } catch {
+            return undefined;
         }
     }
 

--- a/src/optimizer/interpreter.ts
+++ b/src/optimizer/interpreter.ts
@@ -1164,21 +1164,22 @@ export class Interpreter {
                         tons.loc,
                     );
                 }
-                try {
-                    const value = this.parseTonBuiltinValue(tons);
-                    if (typeof value === "undefined") {
-                        throwCompilationError(
-                            "ton() function requires a valid number with no more than 10 digits after the decimal point",
-                            tons.loc,
-                        );
-                    }
-                    if (value < 0) {
-                        throwCompilationError(
-                            "ton() function requires a non-negative number",
-                            tons.loc,
-                        );
-                    }
 
+                const value = this.parseTonBuiltinValue(tons);
+                if (typeof value === "undefined") {
+                    throwCompilationError(
+                        "ton() function requires a valid number with no more than 10 digits after the decimal point",
+                        tons.loc,
+                    );
+                }
+                if (value < 0) {
+                    throwCompilationError(
+                        "ton() function requires a non-negative number",
+                        tons.loc,
+                    );
+                }
+
+                try {
                     return ensureInt(
                         this.util.makeNumberLiteral(value, ast.loc),
                     );

--- a/src/test/compilation-failed/const-eval-failed.spec.ts
+++ b/src/test/compilation-failed/const-eval-failed.spec.ts
@@ -48,7 +48,7 @@ describe("fail-const-eval", () => {
     });
     itShouldNotCompile({
         testName: "const-eval-int-overflow-ton1",
-        errorMessage: `Cannot evaluate expression to a constant: invalid "ton" argument`,
+        errorMessage: `ton() function requires a valid number with no more than 10 digits after the decimal point`,
     });
     itShouldNotCompile({
         testName: "const-eval-int-overflow-ton2",

--- a/src/types/__snapshots__/resolveDescriptors.spec.ts.snap
+++ b/src/types/__snapshots__/resolveDescriptors.spec.ts.snap
@@ -951,6 +951,33 @@ exports[`resolveDescriptors should fail descriptors for ton-with-empty-string 1`
 "
 `;
 
+exports[`resolveDescriptors should fail descriptors for ton-with-invalid-string 1`] = `
+"<unknown>:3:22: ton() function requires a valid number with no more than 10 digits after the decimal point
+  2 | 
+> 3 | const FOO: Int = ton("45,67");
+                           ^~~~~~~
+  4 | 
+"
+`;
+
+exports[`resolveDescriptors should fail descriptors for ton-with-invalid-string-2 1`] = `
+"<unknown>:3:22: ton() function requires a valid number with no more than 10 digits after the decimal point
+  2 | 
+> 3 | const FOO: Int = ton("40+2");
+                           ^~~~~~
+  4 | 
+"
+`;
+
+exports[`resolveDescriptors should fail descriptors for ton-with-invalid-string-3 1`] = `
+"<unknown>:3:22: ton() function requires a valid number with no more than 10 digits after the decimal point
+  2 | 
+> 3 | const FOO: Int = ton("hello");
+                           ^~~~~~~
+  4 | 
+"
+`;
+
 exports[`resolveDescriptors should fail descriptors for trait-circular-deps 1`] = `
 "<unknown>:3:1: Circular dependency detected for type "A"
   2 | 

--- a/src/types/__snapshots__/resolveDescriptors.spec.ts.snap
+++ b/src/types/__snapshots__/resolveDescriptors.spec.ts.snap
@@ -978,6 +978,15 @@ exports[`resolveDescriptors should fail descriptors for ton-with-invalid-string-
 "
 `;
 
+exports[`resolveDescriptors should fail descriptors for ton-with-invalid-string-11-diigits-after-dot 1`] = `
+"<unknown>:3:22: ton() function requires a valid number with no more than 10 digits after the decimal point
+  2 | 
+> 3 | const FOO: Int = ton("1.12345678901");
+                           ^~~~~~~~~~~~~~~
+  4 | 
+"
+`;
+
 exports[`resolveDescriptors should fail descriptors for trait-circular-deps 1`] = `
 "<unknown>:3:1: Circular dependency detected for type "A"
   2 | 

--- a/src/types/test-failed/ton-with-invalid-string-11-diigits-after-dot.tact
+++ b/src/types/test-failed/ton-with-invalid-string-11-diigits-after-dot.tact
@@ -1,0 +1,3 @@
+primitive Int;
+
+const FOO: Int = ton("1.12345678901");

--- a/src/types/test-failed/ton-with-invalid-string-2.tact
+++ b/src/types/test-failed/ton-with-invalid-string-2.tact
@@ -1,0 +1,3 @@
+primitive Int;
+
+const FOO: Int = ton("40+2");

--- a/src/types/test-failed/ton-with-invalid-string-3.tact
+++ b/src/types/test-failed/ton-with-invalid-string-3.tact
@@ -1,0 +1,3 @@
+primitive Int;
+
+const FOO: Int = ton("hello");

--- a/src/types/test-failed/ton-with-invalid-string.tact
+++ b/src/types/test-failed/ton-with-invalid-string.tact
@@ -1,0 +1,3 @@
+primitive Int;
+
+const FOO: Int = ton("45,67");


### PR DESCRIPTION
## Issue

Closes #2536.

## Checklist

- [x] I have updated CHANGELOG.md
- [x] I have added tests to demonstrate the contribution is correctly implemented: this usually includes both positive and negative tests, showing the happy path(s) and featuring intentionally broken cases
