### PR TITLE
fix: improve error message for abstract functions and constants without a body

### DIFF
--- a/dev-docs/CHANGELOG.md
+++ b/dev-docs/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Optimized message deserialization with native loading of `Maybe Cell` fields: PR [#2661](https://github.com/tact-lang/tact/pull/2661)
 - [fix] Compiler now disallows `ton()` with empty or blank string: PR [#2681](https://github.com/tact-lang/tact/pull/2681)
 - [fix] Compiler now disallows `ton()` with invalid number value or negative numbers: PR [#2684](https://github.com/tact-lang/tact/pull/2684)
+- [fix] Compiler now shows a more informative error message for abstract functions and constants without a body: PR [#2688](https://github.com/tact-lang/tact/pull/2688)
 
 ### Standard Library
 

--- a/src/grammar/__snapshots__/grammar.spec.ts.snap
+++ b/src/grammar/__snapshots__/grammar.spec.ts.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`should fail abstract-const-without-modifier.fail 1`] = `
-"<unknown>:2:5: Abstract constant doesn't have abstract modifier
+"<unknown>:2:5: Abstract constant can only be declared inside traits and should have the abstract modifier
   1 | trait t {
 > 2 |     const c: Int;
           ^~~~~~~~~~~~~
@@ -525,7 +525,7 @@ exports[`should fail item-fun-void-trailing-comma-no-params.fail 1`] = `
 `;
 
 exports[`should fail item-fun-without-body.fail 1`] = `
-"<unknown>:1:1: Abstract function doesn't have abstract modifier
+"<unknown>:1:1: Abstract function can only be declared inside traits and should have the abstract modifier
 > 1 | fun testFunc(): Int;
       ^~~~~~~~~~~~~~~~~~~~
 "

--- a/src/grammar/parser-error.ts
+++ b/src/grammar/parser-error.ts
@@ -10,7 +10,7 @@ const attributeSchema =
         },
         notAbstract: () => {
             return handle(
-                sub`Abstract ${text(name)} doesn't have abstract modifier`,
+                sub`Abstract ${text(name)} can only be declared inside traits and should have the abstract modifier`,
             );
         },
         tooAbstract: () => {


### PR DESCRIPTION
## Issue

Closes #2651.

## Checklist

- [x] I have updated CHANGELOG.md
- [x] I have added tests to demonstrate the contribution is correctly implemented: this usually includes both positive and negative tests, showing the happy path(s) and featuring intentionally broken cases
