### PR TITLE
fix: better error for assembly functions inside traits and contracts

### DIFF
--- a/dev-docs/CHANGELOG.md
+++ b/dev-docs/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Optimized message deserialization with native loading of `Maybe Cell` fields: PR [#2661](https://github.com/tact-lang/tact/pull/2661)
 - [fix] Compiler now disallows `ton()` with empty or blank string: PR [#2681](https://github.com/tact-lang/tact/pull/2681)
 - [fix] Compiler now disallows `ton()` with invalid number value or negative numbers: PR [#2684](https://github.com/tact-lang/tact/pull/2684)
+- [fix] Compiler now shows a more informative error message for unsupported assembly functions inside traits and contracts: PR [#2689](https://github.com/tact-lang/tact/pull/2689)
 
 ### Standard Library
 

--- a/src/grammar/__snapshots__/grammar.spec.ts.snap
+++ b/src/grammar/__snapshots__/grammar.spec.ts.snap
@@ -28,7 +28,7 @@ exports[`should fail asm-function-in-trait.fail 1`] = `
 `;
 
 exports[`should fail asm-getter.fail 1`] = `
-"<unknown>:7:5: Assembly functions are only allowed at the module level (outside contracts/traits)
+"<unknown>:7:5: Assembly functions are only allowed at the module level - outside contracts or traits
   6 | contract Foo {
 > 7 |     asm get fun illegalGetter(): Int {
           ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/src/grammar/__snapshots__/grammar.spec.ts.snap
+++ b/src/grammar/__snapshots__/grammar.spec.ts.snap
@@ -10,7 +10,7 @@ exports[`should fail abstract-const-without-modifier.fail 1`] = `
 `;
 
 exports[`should fail asm-function-in-contract.fail 1`] = `
-"<unknown>:2:5: Assembly functions are only allowed at the module level
+"<unknown>:2:5: Assembly functions are only allowed at the module level (outside contracts/traits)
   1 | contract AssemblyTest {
 > 2 |     asm fun depth(): Int { DEPTH }
           ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -19,7 +19,7 @@ exports[`should fail asm-function-in-contract.fail 1`] = `
 `;
 
 exports[`should fail asm-function-in-trait.fail 1`] = `
-"<unknown>:2:5: Assembly functions are only allowed at the module level
+"<unknown>:2:5: Assembly functions are only allowed at the module level (outside contracts/traits)
   1 | trait AssemblyTest {
 > 2 |     asm fun depth(): Int { DEPTH }
           ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -28,7 +28,7 @@ exports[`should fail asm-function-in-trait.fail 1`] = `
 `;
 
 exports[`should fail asm-getter.fail 1`] = `
-"<unknown>:7:5: Assembly functions are only allowed at the module level
+"<unknown>:7:5: Assembly functions are only allowed at the module level (outside contracts/traits)
   6 | contract Foo {
 > 7 |     asm get fun illegalGetter(): Int {
           ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/src/grammar/__snapshots__/grammar.spec.ts.snap
+++ b/src/grammar/__snapshots__/grammar.spec.ts.snap
@@ -9,11 +9,29 @@ exports[`should fail abstract-const-without-modifier.fail 1`] = `
 "
 `;
 
+exports[`should fail asm-function-in-contract.fail 1`] = `
+"<unknown>:2:5: Assembly functions are only allowed at the module level
+  1 | contract AssemblyTest {
+> 2 |     asm fun depth(): Int { DEPTH }
+          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  3 | 
+"
+`;
+
+exports[`should fail asm-function-in-trait.fail 1`] = `
+"<unknown>:2:5: Assembly functions are only allowed at the module level
+  1 | trait AssemblyTest {
+> 2 |     asm fun depth(): Int { DEPTH }
+          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  3 | }
+"
+`;
+
 exports[`should fail asm-getter.fail 1`] = `
-"<unknown>:7:9: Expected ":"
+"<unknown>:7:5: Assembly functions are only allowed at the module level
   6 | contract Foo {
 > 7 |     asm get fun illegalGetter(): Int {
-              ^
+          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
   8 |         DEPTH
 "
 `;

--- a/src/grammar/__snapshots__/grammar.spec.ts.snap
+++ b/src/grammar/__snapshots__/grammar.spec.ts.snap
@@ -19,7 +19,7 @@ exports[`should fail asm-function-in-contract.fail 1`] = `
 `;
 
 exports[`should fail asm-function-in-trait.fail 1`] = `
-"<unknown>:2:5: Assembly functions are only allowed at the module level (outside contracts/traits)
+"<unknown>:2:5: Assembly functions are only allowed at the module level - outside contracts or traits
   1 | trait AssemblyTest {
 > 2 |     asm fun depth(): Int { DEPTH }
           ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/src/grammar/__snapshots__/grammar.spec.ts.snap
+++ b/src/grammar/__snapshots__/grammar.spec.ts.snap
@@ -10,7 +10,7 @@ exports[`should fail abstract-const-without-modifier.fail 1`] = `
 `;
 
 exports[`should fail asm-function-in-contract.fail 1`] = `
-"<unknown>:2:5: Assembly functions are only allowed at the module level (outside contracts/traits)
+"<unknown>:2:5: Assembly functions are only allowed at the module level - outside contracts or traits
   1 | contract AssemblyTest {
 > 2 |     asm fun depth(): Int { DEPTH }
           ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/src/grammar/grammar.gg
+++ b/src/grammar/grammar.gg
@@ -22,12 +22,14 @@ contractItemDecl
     = ContractInit
     / Receiver
     / Function
+    / AsmFunction
     / Constant
     / storageVar;
 
 traitItemDecl
     = Receiver
     / Function
+    / AsmFunction
     / Constant
     / storageVar;
 
@@ -48,7 +50,7 @@ FunctionDefinition = body:statements;
 
 FunctionDeclaration = semicolon;
 
-AsmFunction = 
+AsmFunction =
     "asm"
     shuffle:shuffle?
     attributes:FunctionAttribute*

--- a/src/grammar/grammar.ts
+++ b/src/grammar/grammar.ts
@@ -97,8 +97,8 @@ export namespace $ast {
   }>;
   export type semicolon = ";" | "}";
   export type storageVar = FieldDecl;
-  export type contractItemDecl = ContractInit | Receiver | $Function | Constant | storageVar;
-  export type traitItemDecl = Receiver | $Function | Constant | storageVar;
+  export type contractItemDecl = ContractInit | Receiver | $Function | AsmFunction | Constant | storageVar;
+  export type traitItemDecl = Receiver | $Function | AsmFunction | Constant | storageVar;
   export type FunctionDefinition = $.Located<{
     readonly $: "FunctionDefinition";
     readonly body: statements;
@@ -431,8 +431,8 @@ export const Receiver: $.Parser<$ast.Receiver> = $.loc($.field($.pure("Receiver"
 export const FieldDecl: $.Parser<$ast.FieldDecl> = $.loc($.field($.pure("FieldDecl"), "$", $.field($.lazy(() => Id), "name", $.field($.lazy(() => ascription), "type", $.field($.opt($.right($.str("="), $.lazy(() => expression))), "expression", $.eps)))));
 export const semicolon: $.Parser<$ast.semicolon> = $.alt($.str(";"), $.lookPos($.str("}")));
 export const storageVar: $.Parser<$ast.storageVar> = $.left(FieldDecl, semicolon);
-export const contractItemDecl: $.Parser<$ast.contractItemDecl> = $.alt(ContractInit, $.alt(Receiver, $.alt($Function, $.alt(Constant, storageVar))));
-export const traitItemDecl: $.Parser<$ast.traitItemDecl> = $.alt(Receiver, $.alt($Function, $.alt(Constant, storageVar)));
+export const contractItemDecl: $.Parser<$ast.contractItemDecl> = $.alt(ContractInit, $.alt(Receiver, $.alt($Function, $.alt(AsmFunction, $.alt(Constant, storageVar)))));
+export const traitItemDecl: $.Parser<$ast.traitItemDecl> = $.alt(Receiver, $.alt($Function, $.alt(AsmFunction, $.alt(Constant, storageVar))));
 export const FunctionDefinition: $.Parser<$ast.FunctionDefinition> = $.loc($.field($.pure("FunctionDefinition"), "$", $.field($.lazy(() => statements), "body", $.eps)));
 export const FunctionDeclaration: $.Parser<$ast.FunctionDeclaration> = $.loc($.field($.pure("FunctionDeclaration"), "$", $.right(semicolon, $.eps)));
 export const Id: $.Parser<$ast.Id> = $.named("identifier", $.loc($.field($.pure("Id"), "$", $.field($.lex($.stry($.right($.lookNeg($.lazy(() => reservedWord)), $.right($.regex<string | string | "_">("a-zA-Z_", [$.ExpRange("a", "z"), $.ExpRange("A", "Z"), $.ExpString("_")]), $.right($.star($.lazy(() => idPart)), $.eps))))), "name", $.eps))));

--- a/src/grammar/index.ts
+++ b/src/grammar/index.ts
@@ -1070,6 +1070,13 @@ const parseAsmShuffle =
         };
     };
 
+const parseUnsupportedAsmFunction =
+    (node: $ast.AsmFunction): Handler<Ast.AsmFunctionDef> =>
+    (ctx) => {
+        ctx.err.unsupportedAsmFunctionInContracts()(node.loc);
+        return parseAsmFunction(node)(ctx);
+    };
+
 const parseAsmFunction =
     (node: $ast.AsmFunction): Handler<Ast.AsmFunctionDef> =>
     (ctx) => {
@@ -1329,6 +1336,7 @@ const parseContractItem: (
     FieldDecl: parseFieldDecl,
     Receiver: parseReceiver,
     Function: parseFunctionDef,
+    AsmFunction: parseUnsupportedAsmFunction,
     Constant: parseConstantDefLocal,
 });
 
@@ -1338,6 +1346,7 @@ const parseTraitItem: (
     FieldDecl: parseFieldDecl,
     Receiver: parseReceiver,
     Function: parseFunction,
+    AsmFunction: parseUnsupportedAsmFunction,
     Constant: parseConstantLocal,
 });
 

--- a/src/grammar/parser-error.ts
+++ b/src/grammar/parser-error.ts
@@ -170,6 +170,11 @@ export const syntaxErrorSchema = <T, U>(
         undefinedUnicodeCodepoint: () => {
             return handle(text(`Undefined Unicode code-point`));
         },
+        unsupportedAsmFunctionInContracts: () => {
+            return handle(
+                sub`Assembly functions are only allowed at the module level`,
+            );
+        },
     };
 };
 

--- a/src/grammar/parser-error.ts
+++ b/src/grammar/parser-error.ts
@@ -172,7 +172,7 @@ export const syntaxErrorSchema = <T, U>(
         },
         unsupportedAsmFunctionInContracts: () => {
             return handle(
-                sub`Assembly functions are only allowed at the module level (outside contracts/traits)`,
+                sub`Assembly functions are only allowed at the module level - outside contracts or traits`,
             );
         },
     };

--- a/src/grammar/parser-error.ts
+++ b/src/grammar/parser-error.ts
@@ -172,7 +172,7 @@ export const syntaxErrorSchema = <T, U>(
         },
         unsupportedAsmFunctionInContracts: () => {
             return handle(
-                sub`Assembly functions are only allowed at the module level`,
+                sub`Assembly functions are only allowed at the module level (outside contracts/traits)`,
             );
         },
     };

--- a/src/grammar/test/asm-function-in-contract.fail.tact
+++ b/src/grammar/test/asm-function-in-contract.fail.tact
@@ -1,0 +1,7 @@
+contract AssemblyTest {
+    asm fun depth(): Int { DEPTH }
+
+    receive() {
+        dump(self.depth());
+    }
+}

--- a/src/grammar/test/asm-function-in-trait.fail.tact
+++ b/src/grammar/test/asm-function-in-trait.fail.tact
@@ -1,0 +1,3 @@
+trait AssemblyTest {
+    asm fun depth(): Int { DEPTH }
+}


### PR DESCRIPTION
## Issue

Closes #2539.

## Checklist

- [x] I have updated CHANGELOG.md
- [x] I have added tests to demonstrate the contribution is correctly implemented: this usually includes both positive and negative tests, showing the happy path(s) and featuring intentionally broken cases
