### PR TITLE
fix: better error message for `Slice? as remaining`

### DIFF
--- a/dev-docs/CHANGELOG.md
+++ b/dev-docs/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [fix] Compiler now correctly processes nested structs with default values in the interpreter: PR [#2687](https://github.com/tact-lang/tact/pull/2687)
 - [fix] Compiler now correctly compiles contracts with optional struct fields with default values: PR [#2683](https://github.com/tact-lang/tact/pull/2683)
 - [fix] Compiler now shows a more informative error message for unsupported assembly functions inside traits and contracts: PR [#2689](https://github.com/tact-lang/tact/pull/2689)
+- [fix] Compiler now shows a more informative error message for `Slice? as remaining` fields: PR [#2694](https://github.com/tact-lang/tact/pull/2694)
 
 ### Standard Library
 

--- a/src/types/__snapshots__/resolveDescriptors.spec.ts.snap
+++ b/src/types/__snapshots__/resolveDescriptors.spec.ts.snap
@@ -446,6 +446,15 @@ exports[`resolveDescriptors should fail descriptors for message-decl-remainder-i
 "
 `;
 
+exports[`resolveDescriptors should fail descriptors for message-decl-remaining-field-with-optional-type 1`] = `
+"<unknown>:8:8: The "as remaining" field cannot have optional type
+  7 |     a: Int;
+> 8 |     s: Cell? as remaining;
+             ^~~~~
+  9 | }
+"
+`;
+
 exports[`resolveDescriptors should fail descriptors for message-field-with-contract-type 1`] = `
 "<unknown>:6:5: Fields with a contract type are not supported yet
   5 | message TakeEscrowData {

--- a/src/types/__snapshots__/resolveDescriptors.spec.ts.snap
+++ b/src/types/__snapshots__/resolveDescriptors.spec.ts.snap
@@ -455,6 +455,15 @@ exports[`resolveDescriptors should fail descriptors for message-decl-remaining-f
 "
 `;
 
+exports[`resolveDescriptors should fail descriptors for message-decl-remaining-field-with-optional-type-2 1`] = `
+"<unknown>:7:5: The "as remaining" field can only be the last field of the message
+  6 | message Test {
+> 7 |     s: Cell? as remaining;
+          ^~~~~~~~~~~~~~~~~~~~~
+  8 |     a: Int;
+"
+`;
+
 exports[`resolveDescriptors should fail descriptors for message-field-with-contract-type 1`] = `
 "<unknown>:6:5: Fields with a contract type are not supported yet
   5 | message TakeEscrowData {

--- a/src/types/resolveSignatures.ts
+++ b/src/types/resolveSignatures.ts
@@ -217,6 +217,17 @@ export function resolveSignatures(ctx: CompilerContext, Ast: FactoryAst) {
             }
         }
 
+        const lastField = t.fields.at(-1);
+        if (lastField?.as === "remaining") {
+            const type = lastField.type;
+            if (type.kind === "ref" && type.optional) {
+                throwCompilationError(
+                    `The "as remaining" field cannot have optional type`,
+                    lastField.ast.type.loc,
+                );
+            }
+        }
+
         const fields = t.fields.map((v) => createTLBField(v.abi));
 
         // Calculate signature and method id

--- a/src/types/resolveSignatures.ts
+++ b/src/types/resolveSignatures.ts
@@ -217,14 +217,15 @@ export function resolveSignatures(ctx: CompilerContext, Ast: FactoryAst) {
             }
         }
 
-        const lastField = t.fields.at(-1);
-        if (lastField?.as === "remaining") {
-            const type = lastField.type;
-            if (type.kind === "ref" && type.optional) {
-                throwCompilationError(
-                    `The "as remaining" field cannot have optional type`,
-                    lastField.ast.type.loc,
-                );
+        for (const field of t.fields) {
+            if (field.as === "remaining") {
+                const type = field.type;
+                if (type.kind === "ref" && type.optional) {
+                    throwCompilationError(
+                        `The "as remaining" field cannot have optional type`,
+                        field.ast.type.loc,
+                    );
+                }
             }
         }
 

--- a/src/types/test-failed/message-decl-remaining-field-with-optional-type-2.tact
+++ b/src/types/test-failed/message-decl-remaining-field-with-optional-type-2.tact
@@ -1,0 +1,9 @@
+trait BaseTrait {}
+
+primitive Int;
+primitive Cell;
+
+message Test {
+    s: Cell? as remaining;
+    a: Int;
+}

--- a/src/types/test-failed/message-decl-remaining-field-with-optional-type.tact
+++ b/src/types/test-failed/message-decl-remaining-field-with-optional-type.tact
@@ -1,0 +1,9 @@
+trait BaseTrait {}
+
+primitive Int;
+primitive Cell;
+
+message Test {
+    a: Int;
+    s: Cell? as remaining;
+}


### PR DESCRIPTION
## Issue

Closes #2674.

## Checklist

- [x] I have updated CHANGELOG.md
- [x] I have added tests to demonstrate the contribution is correctly implemented: this usually includes both positive and negative tests, showing the happy path(s) and featuring intentionally broken cases
