### PR TITLE
fix(wrappers): export all tuple parsers/load/store functions from TypeScript wrappers

### DIFF
--- a/dev-docs/CHANGELOG.md
+++ b/dev-docs/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [fix] Compiler now shows a more informative error message for unsupported assembly functions inside traits and contracts: PR [#2689](https://github.com/tact-lang/tact/pull/2689)
 - [fix] Compiler now shows a more informative error message for `Slice? as remaining` fields: PR [#2694](https://github.com/tact-lang/tact/pull/2694)
 - [fix] Compiler now shows a more informative error message for fields with unsupported trait types: PR [#2695](https://github.com/tact-lang/tact/pull/2695)
+- [fix] Generated TypeScript wrappers now export all functions for serialization/deserialization: PR [#2706](https://github.com/tact-lang/tact/pull/2706)
 
 ### Standard Library
 

--- a/src/bindings/typescript/writeStruct.ts
+++ b/src/bindings/typescript/writeStruct.ts
@@ -149,7 +149,7 @@ function writeSerializerField(gen: number, s: AllocationOperation, w: Writer) {
 }
 
 export function writeTupleParser(s: ABIType, w: Writer) {
-    w.append(`function loadTuple${s.name}(source: TupleReader) {`);
+    w.append(`export function loadTuple${s.name}(source: TupleReader) {`);
     w.inIndent(() => {
         if (s.fields.length <= maxTupleSize) {
             for (const f of s.fields) {
@@ -177,7 +177,7 @@ export function writeTupleParser(s: ABIType, w: Writer) {
 }
 
 export function writeGetterTupleParser(s: ABIType, w: Writer) {
-    w.append(`function loadGetterTuple${s.name}(source: TupleReader) {`);
+    w.append(`export function loadGetterTuple${s.name}(source: TupleReader) {`);
     w.inIndent(() => {
         for (const f of s.fields) {
             writeTupleFieldParser("_" + f.name, f.type, w, true);
@@ -211,7 +211,7 @@ function writeTupleFieldParser(
 }
 
 export function writeTupleSerializer(s: ABIType, w: Writer) {
-    w.append(`function storeTuple${s.name}(source: ${s.name}) {`);
+    w.append(`export function storeTuple${s.name}(source: ${s.name}) {`);
     w.inIndent(() => {
         w.append(`const builder = new TupleBuilder();`);
         for (const f of s.fields) {


### PR DESCRIPTION
## Issue

Closes #2559.

## Checklist

- [x] I have updated CHANGELOG.md
