### PR TITLE
refactor: split code in `build.ts` to several logical functions and types

### DIFF
--- a/src/bindings/writeTypescript.ts
+++ b/src/bindings/writeTypescript.ts
@@ -56,7 +56,7 @@ export type WrappersConstantDescription = {
 export function writeTypescript(
     abi: ContractABI,
     ctx: CompilerContext,
-    constants: WrappersConstantDescription[],
+    constants: readonly WrappersConstantDescription[],
     contract: undefined | TypeDescription,
     init?: {
         code: string;
@@ -73,22 +73,22 @@ export function writeTypescript(
     const w = new Writer();
 
     w.write(`
-        import { 
+        import {
             Cell,
-            Slice, 
-            Address, 
-            Builder, 
-            beginCell, 
-            ComputeError, 
-            TupleItem, 
-            TupleReader, 
-            Dictionary, 
-            contractAddress, 
-            address, 
-            ContractProvider, 
-            Sender, 
-            Contract, 
-            ContractABI, 
+            Slice,
+            Address,
+            Builder,
+            beginCell,
+            ComputeError,
+            TupleItem,
+            TupleReader,
+            Dictionary,
+            contractAddress,
+            address,
+            ContractProvider,
+            Sender,
+            Contract,
+            ContractABI,
             ABIType,
             ABIGetter,
             ABIReceiver,

--- a/src/generator/writeProgram.ts
+++ b/src/generator/writeProgram.ts
@@ -262,7 +262,7 @@ export async function writeProgram(
 
     return {
         entrypoint: `${basename}.fc`,
-        files: [{ name: `${basename}.fc`, code }],
+        funcFile: { name: `${basename}.fc`, code },
         constants,
         abi,
     };

--- a/src/generator/writeProgram.ts
+++ b/src/generator/writeProgram.ts
@@ -37,7 +37,7 @@ export async function writeProgram(
     ctx: CompilerContext,
     abiSrc: ContractABI,
     basename: string,
-    contractCodes: ContractsCodes,
+    contractCodes: Readonly<ContractsCodes>,
     debug: boolean,
 ) {
     //
@@ -318,7 +318,7 @@ function writeAll(
     wCtx: WriterContext,
     name: string,
     abiLink: string,
-    contractCodes: ContractsCodes,
+    contractCodes: Readonly<ContractsCodes>,
 ) {
     // Load all types
     const allTypes = getAllTypes(ctx);

--- a/src/generator/writers/writeContract.ts
+++ b/src/generator/writers/writeContract.ts
@@ -135,7 +135,7 @@ export function writeInit(
     t: TypeDescription,
     init: InitDescription,
     ctx: WriterContext,
-    codes: ContractsCodes,
+    codes: Readonly<ContractsCodes>,
 ) {
     ctx.fun(ops.contractInit(t.name, ctx), () => {
         const args = init.params.map(

--- a/src/pipeline/build.ts
+++ b/src/pipeline/build.ts
@@ -261,7 +261,7 @@ async function compileContract(
     ctx: CompilationCtx,
     contract: TypeDescription,
 ): Promise<boolean> {
-    const { config, logger, built } = ctx;
+    const { config, logger } = ctx;
 
     const contractName = contract.name;
 
@@ -289,7 +289,7 @@ async function compileContract(
 
     const { abi, constants } = compileRes;
 
-    built[contractName] = {
+    ctx.built[contractName] = {
         codeBoc,
         abi,
         constants,
@@ -417,14 +417,14 @@ async function compileTact(
     ctx: CompilationCtx,
     contract: string,
 ): Promise<CompileTactRes | undefined> {
-    const { project, config, built } = ctx;
+    const { project, config } = ctx;
 
     try {
         const res = await compile(
             ctx.ctx,
             contract,
             `${config.name}_${contract}`,
-            built,
+            ctx.built,
         );
 
         const { funcFile } = res.output;
@@ -514,10 +514,10 @@ function packageContract(
     ctx: CompilationCtx,
     contract: string,
 ): PackageFileFormat | undefined {
-    const { project, config, logger, built, errorMessages, stdlib } = ctx;
+    const { project, config, logger, errorMessages, stdlib } = ctx;
 
     logger.info("   > " + contract);
-    const artifacts = built[contract];
+    const artifacts = ctx.built[contract];
     if (!artifacts) {
         const message = `   > ${contract}: no artifacts found`;
         logger.error(message);
@@ -602,7 +602,7 @@ function packageContract(
 }
 
 function doBindings(ctx: CompilationCtx, packages: PackageFileFormat[]) {
-    const { project, config, logger, built } = ctx;
+    const { project, config, logger } = ctx;
 
     logger.info("   > Bindings");
 
@@ -619,8 +619,8 @@ function doBindings(ctx: CompilationCtx, packages: PackageFileFormat[]) {
             const bindingsServer = writeTypescript(
                 JSON.parse(pkg.abi),
                 ctx.ctx,
-                built[pkg.name]?.constants ?? [],
-                built[pkg.name]?.contract,
+                ctx.built[pkg.name]?.constants ?? [],
+                ctx.built[pkg.name]?.contract,
                 {
                     code: pkg.code,
                     prefix: pkg.init.prefix,

--- a/src/pipeline/build.ts
+++ b/src/pipeline/build.ts
@@ -425,7 +425,6 @@ async function compileTact(
 }
 
 function doPackage(ctx: CompilationCtx): PackageFileFormat[] | undefined {
-    // Package
     ctx.logger.info("   > Packaging");
 
     const packages: PackageFileFormat[] = [];

--- a/src/pipeline/compile.ts
+++ b/src/pipeline/compile.ts
@@ -7,7 +7,7 @@ export async function compile(
     ctx: CompilerContext,
     name: string,
     basename: string,
-    contractCodes: ContractsCodes,
+    contractCodes: Readonly<ContractsCodes>,
 ) {
     const abi = createABI(ctx, name);
     const output = await writeProgram(ctx, abi, basename, contractCodes, false);

--- a/src/types/resolveDescriptors.ts
+++ b/src/types/resolveDescriptors.ts
@@ -2247,10 +2247,8 @@ export function getAllTypes(ctx: CompilerContext): TypeDescription[] {
     return Array.from(getTypeStore(ctx).values());
 }
 
-export function getContracts(ctx: CompilerContext): string[] {
-    return getAllTypes(ctx)
-        .filter((v) => v.kind === "contract")
-        .map((v) => v.name);
+export function getContracts(ctx: CompilerContext): TypeDescription[] {
+    return getAllTypes(ctx).filter((v) => v.kind === "contract");
 }
 
 export function getStaticFunction(


### PR DESCRIPTION
NOTE: This code is far from perfect BUT we need to move forward since the current `build.ts` is too bad, this PR makes it just less shitty. It's big enough to make code better, and small enough to be quite easy to understand

Previous attempt: https://github.com/tact-lang/tact/pull/1363

Towards #1546