### PR TITLE
refactor: simplify `precompile()` and `build()` signatures

### DIFF
--- a/src/browser.ts
+++ b/src/browser.ts
@@ -3,6 +3,7 @@ import { verifyConfig } from "@/config/parseConfig";
 import type { ILogger } from "@/context/logger";
 import { build } from "@/pipeline/build";
 import { createVirtualFileSystem } from "@/vfs/createVirtualFileSystem";
+import files from "@/stdlib/stdlib";
 
 export async function run(args: {
     config: Config;
@@ -16,7 +17,7 @@ export async function run(args: {
     const project = createVirtualFileSystem("/", args.files, false);
 
     // Create stdlib path
-    const stdlib = "@stdlib";
+    const stdlib = createVirtualFileSystem("@stdlib", files);
 
     // Compile
     let success = true;

--- a/src/pipeline/build.ts
+++ b/src/pipeline/build.ts
@@ -10,12 +10,8 @@ import { createVirtualFileSystem } from "@/vfs/createVirtualFileSystem";
 import type { VirtualFileSystem } from "@/vfs/VirtualFileSystem";
 import { doCompileContracts } from "@/pipeline/compile";
 import { precompile } from "@/pipeline/precompile";
-import type { FactoryAst } from "@/ast/ast-helpers";
-import { getAstFactory } from "@/ast/ast-helpers";
 import type { TactErrorCollection } from "@/error/errors";
 import { TactError } from "@/error/errors";
-import type { Parser } from "@/grammar";
-import { getParser } from "@/grammar";
 import type { TypeDescription } from "@/types/types";
 import { doPackaging } from "@/pipeline/packaging";
 import { doBindings } from "@/pipeline/bindings";
@@ -75,16 +71,14 @@ export async function build(args: {
     readonly project: VirtualFileSystem;
     readonly stdlib: string | VirtualFileSystem;
     readonly logger?: ILogger;
-    readonly parser?: Parser;
-    readonly ast?: FactoryAst;
 }): Promise<BuildResult> {
     const { config, project } = args;
+
     const stdlib =
         typeof args.stdlib === "string"
             ? createVirtualFileSystem(args.stdlib, files)
             : args.stdlib;
-    const ast: FactoryAst = args.ast ?? getAstFactory();
-    const parser: Parser = args.parser ?? getParser(ast);
+
     const logger: ILogger = args.logger ?? new Logger();
 
     // Configure context
@@ -93,7 +87,7 @@ export async function build(args: {
 
     // Precompile
     try {
-        ctx = precompile(ctx, project, stdlib, config.path, parser, ast);
+        ctx = precompile(ctx, project, stdlib, config.path);
     } catch (e) {
         logger.error(
             config.mode === "checkOnly" || config.mode === "funcOnly"

--- a/src/pipeline/build.ts
+++ b/src/pipeline/build.ts
@@ -14,6 +14,8 @@ import type { TypeDescription } from "@/types/types";
 import { doPackaging } from "@/pipeline/packaging";
 import { doBindings } from "@/pipeline/bindings";
 import { doReports } from "@/pipeline/reports";
+import { createVirtualFileSystem } from "@/vfs/createVirtualFileSystem";
+import files from "@/stdlib/stdlib";
 
 export type BuildContext = {
     readonly project: VirtualFileSystem;
@@ -67,10 +69,15 @@ export const BuildFail = (error: TactErrorCollection[]): BuildResult => ({
 export async function build(args: {
     readonly config: Project;
     readonly project: VirtualFileSystem;
-    readonly stdlib: VirtualFileSystem;
+    readonly stdlib: string | VirtualFileSystem;
     readonly logger?: ILogger;
 }): Promise<BuildResult> {
-    const { config, stdlib, project, logger = new Logger() } = args;
+    const { config, project, logger = new Logger() } = args;
+
+    const stdlib =
+        typeof args.stdlib === "string"
+            ? createVirtualFileSystem(args.stdlib, files)
+            : args.stdlib;
 
     // Configure context
     let ctx = new CompilerContext();

--- a/src/pipeline/build.ts
+++ b/src/pipeline/build.ts
@@ -2,11 +2,9 @@ import type { WrappersConstantDescription } from "@/bindings/writeTypescript";
 import { featureEnable } from "@/config/features";
 import type { Project } from "@/config/parseConfig";
 import { CompilerContext } from "@/context/context";
-import files from "@/stdlib/stdlib";
 import type { ILogger } from "@/context/logger";
 import { Logger } from "@/context/logger";
 import { posixNormalize } from "@/utils/filePath";
-import { createVirtualFileSystem } from "@/vfs/createVirtualFileSystem";
 import type { VirtualFileSystem } from "@/vfs/VirtualFileSystem";
 import { doCompileContracts } from "@/pipeline/compile";
 import { precompile } from "@/pipeline/precompile";
@@ -69,17 +67,10 @@ export const BuildFail = (error: TactErrorCollection[]): BuildResult => ({
 export async function build(args: {
     readonly config: Project;
     readonly project: VirtualFileSystem;
-    readonly stdlib: string | VirtualFileSystem;
+    readonly stdlib: VirtualFileSystem;
     readonly logger?: ILogger;
 }): Promise<BuildResult> {
-    const { config, project } = args;
-
-    const stdlib =
-        typeof args.stdlib === "string"
-            ? createVirtualFileSystem(args.stdlib, files)
-            : args.stdlib;
-
-    const logger: ILogger = args.logger ?? new Logger();
+    const { config, stdlib, project, logger = new Logger() } = args;
 
     // Configure context
     let ctx = new CompilerContext();

--- a/src/pipeline/precompile.ts
+++ b/src/pipeline/precompile.ts
@@ -8,8 +8,8 @@ import { resolveSignatures } from "@/types/resolveSignatures";
 import { resolveImports } from "@/imports/resolveImports";
 import type { VirtualFileSystem } from "@/vfs/VirtualFileSystem";
 import type * as Ast from "@/ast/ast";
-import type { FactoryAst } from "@/ast/ast-helpers";
-import type { Parser } from "@/grammar";
+import { getAstFactory } from "@/ast/ast-helpers";
+import { getParser } from "@/grammar";
 import { evalComptimeExpressions } from "@/types/evalComptimeExpressions";
 import { computeReceiversEffects } from "@/types/effects";
 
@@ -18,21 +18,22 @@ export function precompile(
     project: VirtualFileSystem,
     stdlib: VirtualFileSystem,
     entrypoint: string,
-    parser: Parser,
-    ast: FactoryAst,
     parsedModules?: Ast.Module[],
 ) {
+    const ast = getAstFactory();
+    const parser = getParser(ast);
+
     // Load all sources
     const imported = resolveImports({ entrypoint, project, stdlib, parser });
 
     // Parse the sources and attach the given parsed modules
-    const finalModules = [
+    const nodules = [
         ...parseModules(imported.tact, parser),
         ...(parsedModules ?? []),
     ];
 
     // Add information about all the source code entries to the context
-    ctx = openContext(ctx, imported.tact, imported.func, finalModules);
+    ctx = openContext(ctx, imported.tact, imported.func, nodules);
 
     // First load type descriptors and check that
     //       they all have valid signatures
@@ -45,8 +46,8 @@ export function precompile(
 
     /* Evaluate all comp-time expressions:
        constants, default contract fields, default struct fields, method Ids
-       
-       The original code inside constant, field and method id initialization actually mutated the CompilerContext object, 
+
+       The original code inside constant, field and method id initialization actually mutated the CompilerContext object,
        while the rest of the typechecker's code built a new CompilerContext every time it changed something.
        Hence the reason of why this line is not written as:
 
@@ -54,7 +55,7 @@ export function precompile(
 
        The code mutates fields in ConstantDescription, FieldDescription and FunctionDescription.
 
-       Evaluation of Message op-codes is done later in resolveSignatures. It was left there because 
+       Evaluation of Message op-codes is done later in resolveSignatures. It was left there because
        the computation of those op-codes is more involved than the computation of method ids, and so
        it is hard to extract the call to evalConstantExpression in resolveSignatures.
     */

--- a/src/pipeline/precompile.ts
+++ b/src/pipeline/precompile.ts
@@ -27,13 +27,13 @@ export function precompile(
     const imported = resolveImports({ entrypoint, project, stdlib, parser });
 
     // Parse the sources and attach the given parsed modules
-    const nodules = [
+    const modules = [
         ...parseModules(imported.tact, parser),
         ...(parsedModules ?? []),
     ];
 
     // Add information about all the source code entries to the context
-    ctx = openContext(ctx, imported.tact, imported.func, nodules);
+    ctx = openContext(ctx, imported.tact, imported.func, modules);
 
     // First load type descriptors and check that
     //       they all have valid signatures

--- a/src/test/pipeline/precompile-ast.spec.ts
+++ b/src/test/pipeline/precompile-ast.spec.ts
@@ -6,7 +6,6 @@ import { precompile } from "@/pipeline/precompile";
 import files from "@/stdlib/stdlib";
 import { createVirtualFileSystem } from "@/vfs/createVirtualFileSystem";
 import fs from "fs";
-import { getParser } from "@/grammar";
 import { getMakeAst } from "@/ast/generated/make-factory";
 import type { MakeAstFactory } from "@/ast/generated/make-factory";
 
@@ -65,11 +64,8 @@ describe("pre-compilation of ASTs", () => {
 
         const project = createVirtualFileSystem("/", fileSystem, false);
         const stdlib = createVirtualFileSystem("@stdlib", files);
-        const parser = getParser(astF);
 
-        precompile(ctx, project, stdlib, "empty.tact", parser, astF, [
-            makeModule(mF),
-        ]);
+        precompile(ctx, project, stdlib, "empty.tact", [makeModule(mF)]);
     });
 
     it("should pass pre-compilation with no manual AST", () => {
@@ -85,9 +81,8 @@ describe("pre-compilation of ASTs", () => {
 
         const project = createVirtualFileSystem("/", fileSystem, false);
         const stdlib = createVirtualFileSystem("@stdlib", files);
-        const parser = getParser(astF);
 
-        precompile(ctx, project, stdlib, "dummy.tact", parser, astF, []);
+        precompile(ctx, project, stdlib, "dummy.tact", []);
     });
 
     it("should fail pre-compilation when source files and a manual AST have declaration clashes", () => {
@@ -103,13 +98,10 @@ describe("pre-compilation of ASTs", () => {
 
         const project = createVirtualFileSystem("/", fileSystem, false);
         const stdlib = createVirtualFileSystem("@stdlib", files);
-        const parser = getParser(astF);
 
         // So, a clash should occur here, since dummy.tact and makeModule() both declare the contract Test.
         expect(() =>
-            precompile(ctx, project, stdlib, "dummy.tact", parser, astF, [
-                makeModule(mF),
-            ]),
+            precompile(ctx, project, stdlib, "dummy.tact", [makeModule(mF)]),
         ).toThrowErrorMatchingSnapshot();
     });
 });


### PR DESCRIPTION
## Issue

Towards #1546
