### PR TITLE
feat(fmt): show better error if code cannot be parsed in formatter

### DIFF
--- a/src/cli/tact-fmt/__snapshots__/e2e.spec.ts.snap
+++ b/src/cli/tact-fmt/__snapshots__/e2e.spec.ts.snap
@@ -32,3 +32,18 @@ exports[`tact-fmt foo.tact Default run with write to file 2`] = `
 }
 "
 `;
+
+exports[`tact-fmt foo.tact With syntax error 1`] = `
+{
+  "code": 1,
+  "kind": "exited",
+  "stderr": "src/cli/tact-fmt/output/contact.tact:4:33: Expected "!!", "!=", "%", "&", "&&", "(", ")", "*", "+", ",", "-", ".", "/", "<", "<<", "<=", "==", ">", ">=", ">>", "?", "^", "|", or "||"
+  3 |     get fun greeting(): String {
+> 4 |         return foo("hello world";
+                                      ^
+  5 |     }
+
+",
+  "stdout": "",
+}
+`;

--- a/src/cli/tact-fmt/e2e.spec.ts
+++ b/src/cli/tact-fmt/e2e.spec.ts
@@ -25,6 +25,14 @@ contract Test {
 }
 `;
 
+const contractWithSyntaxError = `
+contract Test {
+    get fun greeting(): String {
+        return foo("hello world";
+    }
+}
+`;
+
 describe("tact-fmt foo.tact", () => {
     testExceptWindows("Exits with correct code", async () => {
         await mkdir(outputDir, { recursive: true });
@@ -51,5 +59,13 @@ describe("tact-fmt foo.tact", () => {
 
         const newContent = readFileSync(file, "utf8");
         expect(newContent).toMatchSnapshot();
+    });
+
+    testExceptWindows("With syntax error", async () => {
+        await mkdir(outputDir, { recursive: true });
+        const file = join(outputDir, "contact.tact");
+        writeFileSync(file, contractWithSyntaxError);
+        const result = await tactFmt(file, "-w");
+        expect(result).toMatchSnapshot();
     });
 });

--- a/src/cli/tact-fmt/index.ts
+++ b/src/cli/tact-fmt/index.ts
@@ -85,7 +85,7 @@ const parseArgs = (Errors: FormatterErrors, Args: Args) => {
     const filePath = Args.single("immediate");
     if (filePath) {
         const fileContent = fs.readFileSync(filePath, "utf8");
-        const res = formatCode(fileContent);
+        const res = formatCode(filePath, fileContent);
         if (res.$ === "FormatCodeError") {
             console.error(res.message);
             process.exit(1);

--- a/src/fmt/fmt.ts
+++ b/src/fmt/fmt.ts
@@ -1,6 +1,9 @@
 import type { Cst } from "@/fmt/cst/cst-parser";
 import { format } from "@/fmt/formatter/formatter";
 import { parseCode, visit } from "@/fmt/cst/cst-helpers";
+import { getParser } from "@/grammar";
+import { getAstFactory } from "@/ast/ast-helpers";
+import { TactCompilationError } from "@/error/errors";
 
 interface FormatCodeError {
     $: "FormatCodeError";
@@ -12,16 +15,39 @@ interface FormattedCode {
     code: string;
 }
 
-export function formatCode(code: string): FormattedCode | FormatCodeError {
+export function formatCode(
+    path: string,
+    code: string,
+): FormattedCode | FormatCodeError {
     const root = parseCode(code);
     if (!root) {
-        return {
-            $: "FormatCodeError",
-            message: "cannot parse code",
-        };
+        return getCannotParseCodeError(code, path);
     }
     const formatted = format(root);
     return checkFormatting(root, code, formatted);
+}
+
+function getCannotParseCodeError(code: string, path: string): FormatCodeError {
+    const parser = getParser(getAstFactory());
+    try {
+        parser.parse({
+            code,
+            origin: "user",
+            path: path,
+        });
+    } catch (e) {
+        if (e instanceof TactCompilationError) {
+            return {
+                $: "FormatCodeError",
+                message: e.message,
+            };
+        }
+    }
+
+    return {
+        $: "FormatCodeError",
+        message: "cannot parse code",
+    };
 }
 
 function checkFormatting(


### PR DESCRIPTION
## Example

Old:

```
Cannot format file: cannot parse code
```

New:
```
Cannot format file: src/stdlib/stdlib/libs/config.tact:6:38: Expected "!!", "!=", "%", "&", "&&", "(", ")", "*", "+", ",", "-", ".", "/", "<", "<<", "<=", "==", ">", ">=", ">>", "?", "B", "O", "X", "^", "_", "b", "o", "x", "|", "||", or digit
  5 | fun getConfigAddress(): Address {
> 6 |     let cell: Cell = getConfigParam(0;
                                           ^
  7 |     let sc: Slice = cell.beginParse();
```

## Issue

Fixes #2796

