### PR TITLE
fix: show better error if there is cycle in structures

### DIFF
--- a/dev-docs/CHANGELOG.md
+++ b/dev-docs/CHANGELOG.md
@@ -25,6 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [fix] Compiler now checks that "override" functions and constants have a virtual or abstract modifier in the parent trait: PR [#2700](https://github.com/tact-lang/tact/pull/2700)
 - [fix] Compiler now throws an error if a non-optional method is called on an optional type: PR [#2770](https://github.com/tact-lang/tact/pull/2770)
 - [fix] Compiler now throws an error when inheriting from two traits that have methods with the same name: PR [#2773](https://github.com/tact-lang/tact/pull/2773)
+- [fix] Compiler now shows a better error message if there is a cycle in structures: PR [#2809](https://github.com/tact-lang/tact/pull/2809)
 - [fix] Generated TypeScript wrappers now export all functions for serialization/deserialization: PR [#2706](https://github.com/tact-lang/tact/pull/2706)
 - [fix] Processing of `null` values of optional types in the `dump` builtin: PR [#2730](https://github.com/tact-lang/tact/pull/2730)
 

--- a/src/bindings/writeTypescript.ts
+++ b/src/bindings/writeTypescript.ts
@@ -126,7 +126,7 @@ export function writeTypescript(
             }
             return res;
         };
-        const sortedTypes = topologicalSort(abi.types, refs);
+        const sortedTypes = topologicalSort(abi.types, refs, () => undefined);
         for (const f of sortedTypes) {
             const ops = f.fields.map((v) => ({
                 name: v.name,

--- a/src/generator/Writer.ts
+++ b/src/generator/Writer.ts
@@ -110,11 +110,11 @@ export class WriterContext {
         }
 
         // Sort functions
-        const sorted = topologicalSort(all, (f) =>
-            Array.from(f.depends).map((v) => this.#functions.get(v)!),
+        return topologicalSort(
+            all,
+            (f) => Array.from(f.depends).map((v) => this.#functions.get(v)!),
+            () => undefined,
         );
-
-        return sorted;
     }
 
     //

--- a/src/storage/resolveAllocation.ts
+++ b/src/storage/resolveAllocation.ts
@@ -58,7 +58,7 @@ export function getSortedTypes(ctx: CompilerContext): TypeDescription[] {
         }
         return res;
     };
-    structs = topologicalSort(structs, refs);
+    structs = topologicalSort(structs, refs, (s) => [s.name, s.ast.name.loc]);
     structs = [...structs, ...types.filter((v) => v.kind === "contract")];
     return structs;
 }

--- a/src/types/resolveSignatures.ts
+++ b/src/types/resolveSignatures.ts
@@ -181,6 +181,10 @@ export function resolveSignatures(ctx: CompilerContext, Ast: FactoryAst) {
         if (signatures.has(name)) {
             return signatures.get(name)!;
         }
+
+        // prevent endless recursion
+        signatures.set(name, { signature: name, id: null, tlb: "" });
+
         const t = getType(ctx, name);
         if (t.kind !== "struct" && t.kind !== "contract") {
             throwInternalCompilerError(`Unsupported type: ${name}`);

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -1,25 +1,61 @@
-import { throwInternalCompilerError } from "@/error/errors";
+import { throwCompilationError } from "@/error/errors";
+import type { SrcInfo } from "@/grammar";
 
-export function topologicalSort<T>(src: T[], references: (src: T) => T[]) {
+export function topologicalSort<T extends object>(
+    src: T[],
+    references: (src: T) => T[],
+    info: (src: T) => [string, SrcInfo] | undefined,
+) {
     const result: T[] = [];
     const visited: Set<T> = new Set();
     const visiting: Set<T> = new Set();
+    const path: T[] = [];
+
     const visit = (src: T) => {
         if (visiting.has(src)) {
-            throwInternalCompilerError("Cycle detected");
+            onCycleFound(path, src, info);
         }
+
         if (!visited.has(src)) {
             visiting.add(src);
+            path.push(src);
+
             for (const r of references(src)) {
                 visit(r);
             }
+
+            path.pop();
             visiting.delete(src);
             visited.add(src);
             result.push(src);
         }
     };
+
     for (const s of src) {
         visit(s);
     }
+
     return result;
+}
+
+function onCycleFound<T>(
+    path: T[],
+    src: T,
+    info: (src: T) => [string, SrcInfo] | undefined,
+) {
+    const cycleStart = path.indexOf(src);
+    const cycle = [...path.slice(cycleStart), src];
+
+    const infos = cycle
+        .map((it) => info(it))
+        .filter((it) => typeof it !== "undefined");
+    if (infos.length === 0) {
+        throwCompilationError(`Cycle detected`);
+    }
+
+    const cycleRepresentation = infos.map(([name]) => name).join(" -> ");
+    throwCompilationError(
+        `Cycle detected: ${cycleRepresentation}`,
+        infos[0]?.[1],
+    );
 }


### PR DESCRIPTION
## Issue

Closes #2677.

## Checklist

- [x] I have updated CHANGELOG.md
- [x] I have added tests to demonstrate the contribution is correctly implemented: this usually includes both positive and negative tests, showing the happy path(s) and featuring intentionally broken cases
