### PR TITLE
fix: show full error message for map with optional value

### DIFF
--- a/dev-docs/CHANGELOG.md
+++ b/dev-docs/CHANGELOG.md
@@ -25,6 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [fix] Compiler now checks that "override" functions and constants have a virtual or abstract modifier in the parent trait: PR [#2700](https://github.com/tact-lang/tact/pull/2700)
 - [fix] Compiler now throws an error if a non-optional method is called on an optional type: PR [#2770](https://github.com/tact-lang/tact/pull/2770)
 - [fix] Compiler now throws an error when inheriting from two traits that have methods with the same name: PR [#2773](https://github.com/tact-lang/tact/pull/2773)
+- [fix] Compiler now shows a full error message for maps with optional value: PR [#2810](https://github.com/tact-lang/tact/pull/2810)
 - [fix] Generated TypeScript wrappers now export all functions for serialization/deserialization: PR [#2706](https://github.com/tact-lang/tact/pull/2706)
 - [fix] Processing of `null` values of optional types in the `dump` builtin: PR [#2730](https://github.com/tact-lang/tact/pull/2730)
 

--- a/src/error/display-to-string.ts
+++ b/src/error/display-to-string.ts
@@ -12,7 +12,7 @@ export const displayToString: ErrorDisplay<string> = {
     text: (text) => text,
     sub: (parts, ...subst) => {
         const [head, ...tail] = parts;
-        if (!head) {
+        if (typeof head === "undefined") {
             return "";
         }
         return tail.reduce((acc, part, index) => {

--- a/src/grammar/__snapshots__/grammar.spec.ts.snap
+++ b/src/grammar/__snapshots__/grammar.spec.ts.snap
@@ -677,6 +677,15 @@ exports[`should fail literal-underscore-after-leading-zero.fail 1`] = `
 "
 `;
 
+exports[`should fail optional-map-value.fail 1`] = `
+"<unknown>:2:8: value cannot be optional
+  1 | contract TestContract {
+> 2 |     m: map<Int, Int?>; // Int? is invalid for values
+             ^~~~~~~~~~~~~~
+  3 | 
+"
+`;
+
 exports[`should fail stmt-destructuring-fields-non-existing-underscore.fail 1`] = `
 "<unknown>:15:12: Wildcard not allowed here
   14 |     let s = S{ a: 1, b: 2, c: 3 };

--- a/src/grammar/__snapshots__/grammar.spec.ts.snap
+++ b/src/grammar/__snapshots__/grammar.spec.ts.snap
@@ -677,11 +677,20 @@ exports[`should fail literal-underscore-after-leading-zero.fail 1`] = `
 "
 `;
 
+exports[`should fail optional-map-key.fail 1`] = `
+"<unknown>:2:12: map key types cannot be optional
+  1 | contract TestContract {
+> 2 |     m: map<Int?, Int>; // Int? is invalid for keys
+                 ^~~~
+  3 | 
+"
+`;
+
 exports[`should fail optional-map-value.fail 1`] = `
-"<unknown>:2:8: value cannot be optional
+"<unknown>:2:17: map value types cannot be optional
   1 | contract TestContract {
 > 2 |     m: map<Int, Int?>; // Int? is invalid for values
-             ^~~~~~~~~~~~~~
+                      ^~~~
   3 | 
 "
 `;

--- a/src/grammar/index.ts
+++ b/src/grammar/index.ts
@@ -871,7 +871,7 @@ const parseTypeOptional =
                 ctx.err.mapOnlyOneAs("key")(genericLoc);
             }
             if (key.type.optionals.length > 0) {
-                ctx.err.cannotBeOptional("key")(genericLoc);
+                ctx.err.cannotBeOptional("map key types")(key.loc);
             }
             if (key.type.type.$ !== "TypeRegular") {
                 ctx.err.onlyTypeId("key")(genericLoc);
@@ -882,7 +882,7 @@ const parseTypeOptional =
                 ctx.err.mapOnlyOneAs("value")(genericLoc);
             }
             if (value.type.optionals.length > 0) {
-                ctx.err.cannotBeOptional("value")(genericLoc);
+                ctx.err.cannotBeOptional("map value types")(value.loc);
             }
             if (value.type.type.$ !== "TypeRegular") {
                 ctx.err.onlyTypeId("value")(genericLoc);

--- a/src/grammar/parser-error.ts
+++ b/src/grammar/parser-error.ts
@@ -146,7 +146,7 @@ export const syntaxErrorSchema = <T, U>(
                 sub`Cannot use several "as" on ${text(name)} of a map`,
             );
         },
-        cannotBeOptional: (name: "key" | "value") => {
+        cannotBeOptional: (name: "map value types" | "map key types") => {
             return handle(sub`${text(name)} cannot be optional`);
         },
         onlyTypeId: (name: "key" | "value") => {

--- a/src/grammar/test/optional-map-key.fail.tact
+++ b/src/grammar/test/optional-map-key.fail.tact
@@ -1,0 +1,5 @@
+contract TestContract {
+    m: map<Int?, Int>; // Int? is invalid for keys
+
+    receive () {}
+}

--- a/src/grammar/test/optional-map-value.fail.tact
+++ b/src/grammar/test/optional-map-value.fail.tact
@@ -1,0 +1,5 @@
+contract TestContract {
+    m: map<Int, Int?>; // Int? is invalid for values
+
+    receive () {}
+}


### PR DESCRIPTION
## Issue

Closes #2534.

## Checklist

- [x] I have updated CHANGELOG.md
- [x] I have added tests to demonstrate the contribution is correctly implemented: this usually includes both positive and negative tests, showing the happy path(s) and featuring intentionally broken cases
