### PR TITLE
fix(typechecker): mutually recursive types detection

### DIFF
--- a/dev-docs/CHANGELOG.md
+++ b/dev-docs/CHANGELOG.md
@@ -27,6 +27,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [fix] Compiler now throws an error when inheriting from two traits that have methods with the same name: PR [#2773](https://github.com/tact-lang/tact/pull/2773)
 - [fix] Compiler now correctly generates code for unary plus operator: PR [#2807](https://github.com/tact-lang/tact/pull/2807)
 - [fix] Compiler now shows a full error message for maps with optional value: PR [#2810](https://github.com/tact-lang/tact/pull/2810)
+- [fix] Compiler now correctly detects mutually recursive types: PR [#2814](https://github.com/tact-lang/tact/pull/2814)
 - [fix] Generated TypeScript wrappers now export all functions for serialization/deserialization: PR [#2706](https://github.com/tact-lang/tact/pull/2706)
 - [fix] Processing of `null` values of optional types in the `dump` builtin: PR [#2730](https://github.com/tact-lang/tact/pull/2730)
 

--- a/src/types/__snapshots__/resolveDescriptors.spec.ts.snap
+++ b/src/types/__snapshots__/resolveDescriptors.spec.ts.snap
@@ -1041,6 +1041,15 @@ exports[`resolveDescriptors should fail descriptors for struct-decl-mutually-rec
 "
 `;
 
+exports[`resolveDescriptors should fail descriptors for struct-decl-mutually-recursive-2 1`] = `
+"<unknown>:8:8: Mutually recursive types are not supported: types "A1", "A2" form a cycle
+  7 | 
+> 8 | struct A1 {
+             ^~
+  9 |   a: Int;
+"
+`;
+
 exports[`resolveDescriptors should fail descriptors for struct-decl-remainder-in-the-middle 1`] = `
 "<unknown>:8:5: The "as remaining" field can only be the last field of the struct
   7 |     a: Int;

--- a/src/types/__snapshots__/resolveDescriptors.spec.ts.snap
+++ b/src/types/__snapshots__/resolveDescriptors.spec.ts.snap
@@ -1050,6 +1050,15 @@ exports[`resolveDescriptors should fail descriptors for struct-decl-mutually-rec
 "
 `;
 
+exports[`resolveDescriptors should fail descriptors for struct-decl-mutually-recursive-with-optional 1`] = `
+"<unknown>:8:8: Mutually recursive types are not supported: types "A1", "A2" form a cycle
+  7 | 
+> 8 | struct A1 {
+             ^~
+  9 |   a: Int;
+"
+`;
+
 exports[`resolveDescriptors should fail descriptors for struct-decl-remainder-in-the-middle 1`] = `
 "<unknown>:8:5: The "as remaining" field can only be the last field of the struct
   7 |     a: Int;

--- a/src/types/resolveDescriptors.ts
+++ b/src/types/resolveDescriptors.ts
@@ -2532,6 +2532,11 @@ function checkRecursiveTypes(ctx: CompilerContext): void {
                 );
             }
         }
+
+        indices.clear();
+        lowLinks.clear();
+        onStack.clear();
+        selfReferencingVertices.clear();
     }
 
     function strongConnect(struct: TypeDescription) {

--- a/src/types/test-failed/struct-decl-mutually-recursive-2.tact
+++ b/src/types/test-failed/struct-decl-mutually-recursive-2.tact
@@ -1,0 +1,16 @@
+primitive Int;
+trait BaseTrait {}
+
+struct A0 {
+  b: A1;
+}
+
+struct A1 {
+  a: Int;
+  b: A2;
+}
+
+struct A2 {
+  a: Int;
+  b: A1;
+}

--- a/src/types/test-failed/struct-decl-mutually-recursive-with-optional.tact
+++ b/src/types/test-failed/struct-decl-mutually-recursive-with-optional.tact
@@ -1,0 +1,16 @@
+primitive Int;
+trait BaseTrait {}
+
+struct A0 {
+  b: A1;
+}
+
+struct A1 {
+  a: Int;
+  b: A2;
+}
+
+struct A2 {
+  a: Int;
+  b: A1?;
+}


### PR DESCRIPTION
## Issue

Closes #2677.

## Checklist

- [x] I have updated CHANGELOG.md
- [x] I have added tests to demonstrate the contribution is correctly implemented: this usually includes both positive and negative tests, showing the happy path(s) and featuring intentionally broken cases
