### PR TITLE
fix(fmt): fix formatting for trailing comment after the last field

### DIFF
--- a/dev-docs/CHANGELOG.md
+++ b/dev-docs/CHANGELOG.md
@@ -24,6 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Formatter now shortens `Foo { value: value }` to `Foo { value }`: PR [#2884](https://github.com/tact-lang/tact/pull/2884)
 - Formatter now supports formatting several files and directories: PR [#2906](https://github.com/tact-lang/tact/pull/2906)
+- [fix] Formatter now correctly formats trailing comments after the last field: PR [#2912](https://github.com/tact-lang/tact/pull/2912)
 
 ### Docs
 

--- a/src/fmt/formatter/format-structs.ts
+++ b/src/fmt/formatter/format-structs.ts
@@ -115,9 +115,9 @@ const formatFields: FormatRule = (code, node) => {
 
                 if (field.type === "Comment") {
                     if (needNewline) {
-                        code.add(" ");
+                        code.newLine();
                     }
-                    code.apply(formatComment, child);
+                    code.apply(formatComment, field);
                     code.newLine();
                     needNewline = false;
                 } else if (field.type === "FieldDecl") {

--- a/src/fmt/test/top-level-comments.spec.ts
+++ b/src/fmt/test/top-level-comments.spec.ts
@@ -96,6 +96,26 @@ describe("top level declarations comments formatting", () => {
     );
 
     it(
+        "comment after last field in struct",
+        intact(`
+        struct RequestBody {
+            field: Address;
+            // Other data fields...
+        }
+    `),
+    );
+
+    it(
+        "comment after last field in message",
+        intact(`
+        message RequestBody {
+            field: Address;
+            // Other data fields...
+        }
+    `),
+    );
+
+    it(
         "comments in message declarations",
         intact(`
         // before message


### PR DESCRIPTION
## Issue

Closes #2909.

## Checklist

- [x] I have updated CHANGELOG.md
- [x] I have added tests to demonstrate the contribution is correctly implemented: this usually includes both positive and negative tests, showing the happy path(s) and featuring intentionally broken cases
