### PR TITLE
fix: maximum size of useful data in bounced messages is 224 bits, not bytes

### DIFF
--- a/dev-docs/CHANGELOG.md
+++ b/dev-docs/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Language features
 
+- Fixed incorrect error message for bounced messages: PR [#2932](https://github.com/tact-lang/tact/pull/2932)
+- Added compile-time map literals: PR [#2881](https://github.com/tact-lang/tact/pull/2881)
+- Added the `inMsg()` built-in function as an optimized version of `msg.toSlice()`: PR [#2850](https://github.com/tact-lang/tact/pull/2850)
 - Compiler now generates more efficient code for structure fields serialization: PR [#2836](https://github.com/tact-lang/tact/pull/2836)
 - Compiler now generates more efficient code for `Address?` fields deserialization: PR [#2834](https://github.com/tact-lang/tact/pull/2834)
 - Optimized `self.notify`, `self.reply`, and `self.forward` in `BaseTrait` by using message directly where possible and avoiding unnecessary use of alias: PR [#2515](https://github.com/tact-lang/tact/pull/2515)
@@ -19,7 +22,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Standard Library
 
-- Added `inMsg()` function as an optimized version of `msg.toSlice()`: PR [#2850](https://github.com/tact-lang/tact/pull/2850)
+- Improved gas consumption of the `cashback` function: PR [#2882](https://github.com/tact-lang/tact/pull/2882)
+- Improved gas efficiency for the `BaseTrait` functions: PR [#2913](https://github.com/tact-lang/tact/pull/2913)
 
 ### Tooling
 
@@ -37,6 +41,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [Petr Makhnev](https://github.com/i582)
 - [Novus Nota](https://github.com/novusnota)
 - [skywardboundd](https://github.com/skywardboundd)
+- [verytactical](https://github.com/verytactical)
+- [Anton Trunov](https://github.com/anton-trunov)
 
 ## [1.6.6] - 2025-04-16
 

--- a/docs/src/content/docs/book/bounced.mdx
+++ b/docs/src/content/docs/book/bounced.mdx
@@ -7,7 +7,9 @@ When a contract sends a message with the flag `bounce` set to `true{:tact}`, and
 
 ## Caveats
 
-Currently, bounced messages in TON can have at most 256 bits of payload and no references, but the amount of useful data bits when handling messages in `bounced` receivers is at most 224, since the first 32 bits are occupied by the message opcode. This means that you can't recover much of the data from the bounced message, for instance you cannot fit an address into a bounced message, since regular internal addresses need 267 bits to be represented. Tact helps you to check if your message fits the limit, and if it doesn't, suggests using a special type constructor `bounced<M>{:tact}` for the bounced message receiver, which constructs a partial representation of the message that fits within the required limits.
+Currently, bounced messages in TON can have at most 256 bits of payload and no references, but the amount of useful data bits when handling messages in `bounced` receivers is at most 224, since the first 32 bits are occupied by the message opcode. This means that you can't recover much of the data from the bounced message, for instance you cannot fit an address into a bounced message, since regular internal addresses need 267 bits to be represented.
+
+Tact helps you to check if your message fits the limit, and if it doesn't, suggests using a special type constructor `bounced<M>{:tact}` for the bounced message receiver, which constructs a partial representation of the message that fits within the required limits. Only the first message fields that fit into the 224 bits will be available to use in bounced message receivers. Sometimes you need to rearrange the order of the fields in your message so the relevant ones would fit into the limit.
 
 ## Bounced message receiver
 

--- a/docs/src/content/docs/book/bounced.mdx
+++ b/docs/src/content/docs/book/bounced.mdx
@@ -7,7 +7,7 @@ When a contract sends a message with the flag `bounce` set to `true{:tact}`, and
 
 ## Caveats
 
-Currently, bounced messages in TON have only 224 usable data bits in the message body and don't have any references. This means that you can't recover much of the data from the bounced message. This is a limitation of the TON blockchain and will be fixed in the future. Tact helps you to check if your message fits the limit, and if it doesn't, suggests using a special type constructor `bounced<M>{:tact}` for the bounced message receiver, which constructs a partial representation of the message that fits within the required limits.
+Currently, bounced messages in TON can have at most 256 bits of payload and no references, but the amount of useful data bits when handling messages in `bounced` receivers is at most 224, since the first 32 bits are occupied by the message opcode. This means that you can't recover much of the data from the bounced message, for instance you cannot fit an address into a bounced message, since regular internal addresses need 267 bits to be represented. Tact helps you to check if your message fits the limit, and if it doesn't, suggests using a special type constructor `bounced<M>{:tact}` for the bounced message receiver, which constructs a partial representation of the message that fits within the required limits.
 
 ## Bounced message receiver
 

--- a/src/types/__snapshots__/resolveStatements.spec.ts.snap
+++ b/src/types/__snapshots__/resolveStatements.spec.ts.snap
@@ -73,7 +73,7 @@ exports[`resolveStatements should fail statements for assign-const-struct-global
 `;
 
 exports[`resolveStatements should fail statements for bounced-type-is-smaller 1`] = `
-"<unknown>:23:22: Maximum size of the bounced message is 224 bytes, but the "c" field of type "A" cannot fit into it due to the size of previous fields or its own size, so it cannot be accessed. Make the type of the fields before this one smaller, or reduce the type of this field so that it fits into 224 bytes
+"<unknown>:23:22: Maximum size of the bounced message is 224 bits, but the "c" field of type "A" cannot fit into it due to the size of previous fields or its own size, so it cannot be accessed. Make the type of the fields before this one smaller, or reduce the type of this field so that it fits into 224 bits
   22 |     let y: Bool = src.b;
 > 23 |     let z: Int = src.c;
                             ^
@@ -1351,7 +1351,7 @@ exports[`resolveStatements should fail statements for unknown-type-in-variable-d
 `;
 
 exports[`resolveStatements should fail statements for usage-of-bounced-field-in-type-that-is-too-big 1`] = `
-"<unknown>:14:29: Maximum size of the bounced message is 224 bytes, but the "amount" field of type "Withdraw" cannot fit into it due to the size of previous fields or its own size, so it cannot be accessed. Make the type of the fields before this one smaller, or reduce the type of this field so that it fits into 224 bytes
+"<unknown>:14:29: Maximum size of the bounced message is 224 bits, but the "amount" field of type "Withdraw" cannot fit into it due to the size of previous fields or its own size, so it cannot be accessed. Make the type of the fields before this one smaller, or reduce the type of this field so that it fits into 224 bits
   13 |         self.balance += msg.data; // ok
 > 14 |         self.balance += msg.amount;
                                    ^~~~~~
@@ -1360,7 +1360,7 @@ exports[`resolveStatements should fail statements for usage-of-bounced-field-in-
 `;
 
 exports[`resolveStatements should fail statements for usage-of-bounced-field-in-type-that-is-too-big-2 1`] = `
-"<unknown>:26:29: Maximum size of the bounced message is 224 bytes, but the "amount" field of type "Withdraw" cannot fit into it due to the size of previous fields or its own size, so it cannot be accessed. Make the type of the fields before this one smaller, or reduce the type of this field so that it fits into 224 bytes
+"<unknown>:26:29: Maximum size of the bounced message is 224 bits, but the "amount" field of type "Withdraw" cannot fit into it due to the size of previous fields or its own size, so it cannot be accessed. Make the type of the fields before this one smaller, or reduce the type of this field so that it fits into 224 bits
   25 | 
 > 26 |         self.balance += msg.amount;
                                    ^~~~~~
@@ -1369,7 +1369,7 @@ exports[`resolveStatements should fail statements for usage-of-bounced-field-in-
 `;
 
 exports[`resolveStatements should fail statements for usage-of-bounced-field-that-is-too-big 1`] = `
-"<unknown>:12:29: Maximum size of the bounced message is 224 bytes, but the "amount" field of type "Withdraw" cannot fit into it because its too big, so it cannot be accessed. Reduce the type of this field so that it fits into 224 bytes
+"<unknown>:12:29: Maximum size of the bounced message is 224 bits, but the "amount" field of type "Withdraw" cannot fit into it because its too big, so it cannot be accessed. Reduce the type of this field so that it fits into 224 bits
   11 |     bounced(msg: bounced<Withdraw>){
 > 12 |         self.balance += msg.amount;
                                    ^~~~~~

--- a/src/types/resolveExpression.ts
+++ b/src/types/resolveExpression.ts
@@ -496,7 +496,7 @@ function resolveFieldAccess(
     const fieldIndex = srcT.fields.findIndex((v) => eqNames(v.name, exp.field));
     const field = fieldIndex !== -1 ? srcT.fields[fieldIndex] : undefined;
 
-    // If we found a field of bounced<T>, check if the field doesn't fit in 224 bytes and cannot be accessed
+    // If we found a field of bounced<T>, check if the field doesn't fit in 224 bits and cannot be accessed
     if (
         src.kind === "ref_bounced" &&
         field &&
@@ -504,13 +504,13 @@ function resolveFieldAccess(
     ) {
         if (srcT.fields.length === 1) {
             throwCompilationError(
-                `Maximum size of the bounced message is 224 bytes, but the ${idTextErr(exp.field)} field of type ${idTextErr(src.name)} cannot fit into it because its too big, so it cannot be accessed. Reduce the type of this field so that it fits into 224 bytes`,
+                `Maximum size of the bounced message is 224 bits, but the ${idTextErr(exp.field)} field of type ${idTextErr(src.name)} cannot fit into it because its too big, so it cannot be accessed. Reduce the type of this field so that it fits into 224 bits`,
                 exp.field.loc,
             );
         }
 
         throwCompilationError(
-            `Maximum size of the bounced message is 224 bytes, but the ${idTextErr(exp.field)} field of type ${idTextErr(src.name)} cannot fit into it due to the size of previous fields or its own size, so it cannot be accessed. Make the type of the fields before this one smaller, or reduce the type of this field so that it fits into 224 bytes`,
+            `Maximum size of the bounced message is 224 bits, but the ${idTextErr(exp.field)} field of type ${idTextErr(src.name)} cannot fit into it due to the size of previous fields or its own size, so it cannot be accessed. Make the type of the fields before this one smaller, or reduce the type of this field so that it fits into 224 bits`,
             exp.field.loc,
         );
     }

--- a/src/types/stmts-failed/usage-of-bounced-field-in-type-that-is-too-big.tact
+++ b/src/types/stmts-failed/usage-of-bounced-field-in-type-that-is-too-big.tact
@@ -3,7 +3,7 @@ trait BaseTrait { }
 
 message Withdraw {
     data: Int as uint128;
-    amount: Int as uint128; // exceeds 224 bytes
+    amount: Int as uint128; // exceeds 224 bits
 }
 
 contract Fund {


### PR DESCRIPTION
Closes #2911.
Closes #1139.