### PR TITLE
fix(docs): clarify that exactly `emptyMap` allows omitting type ascriptions

### DIFF
--- a/docs/src/content/docs/book/maps.mdx
+++ b/docs/src/content/docs/book/maps.mdx
@@ -142,7 +142,8 @@ let myMap: map<Int as uint8, Int as uint16> = map<Int as uint8, Int as uint16> {
 let mismatch: map<Address, Cell> = map<Address, Int> {}; // COMPILATION ERROR! Type mismatch
 ```
 
-Empty map literals are also supported. They produce the same value as the [`emptyMap(){:tact}`](#emptymap) function but allow omitting type ascriptions.
+Empty map literals are also supported. They produce the same value as the [`emptyMap(){:tact}`](#emptymap) function,
+but `emptyMap(){:tact}` allow omitting type ascriptions.
 
 ```tact
 let myMap: map<Int as uint8, Cell> = map<Int as uint8, Cell> {};

--- a/docs/src/content/docs/book/maps.mdx
+++ b/docs/src/content/docs/book/maps.mdx
@@ -142,8 +142,7 @@ let myMap: map<Int as uint8, Int as uint16> = map<Int as uint8, Int as uint16> {
 let mismatch: map<Address, Cell> = map<Address, Int> {}; // COMPILATION ERROR! Type mismatch
 ```
 
-Empty map literals are also supported. They produce the same value as the [`emptyMap(){:tact}`](#emptymap) function,
-but `emptyMap(){:tact}` allow omitting type ascriptions.
+Map literals with an empty body are also supported. They produce the same value as the [`emptyMap(){:tact}`](#emptymap) function and also require type ascriptions for the variable declaration.
 
 ```tact
 let myMap: map<Int as uint8, Cell> = map<Int as uint8, Cell> {};


### PR DESCRIPTION
Towards #2940.