### PR TITLE
feat(docs): map key-value types and `bounced<>` inner message type cannot be nullable (optional)

### DIFF
--- a/dev-docs/CHANGELOG.md
+++ b/dev-docs/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Enabled format checking across the Cookbook: PR [#2980](https://github.com/tact-lang/tact/pull/2980)
 - Added references to https://github.com/tact-lang/defi-cookbook: PR [#2985](https://github.com/tact-lang/tact/pull/2985)
 - Fixed description of the unary plus `+` operator: PR [#3016](https://github.com/tact-lang/tact/pull/3016)
+- Documented that map key-value types and the inner message type of the `bounced<M>` type constructor cannot be nullable: PR [#3017](https://github.com/tact-lang/tact/pull/3017)
 
 ### Release contributors
 

--- a/docs/src/content/docs/book/bounced.mdx
+++ b/docs/src/content/docs/book/bounced.mdx
@@ -9,7 +9,36 @@ When a contract sends a message with the flag `bounce` set to `true{:tact}`, and
 
 Currently, bounced messages in TON can have at most 256 bits of payload and no references, but the amount of useful data bits when handling messages in `bounced` receivers is at most 224, since the first 32 bits are occupied by the message opcode. This means that you can't recover much of the data from the bounced message, for instance you cannot fit an address into a bounced message, since regular internal addresses need 267 bits to be represented.
 
-Tact helps you to check if your message fits the limit, and if it doesn't, suggests using a special type constructor `bounced<M>{:tact}` for the bounced message receiver, which constructs a partial representation of the message that fits within the required limits. Only the first message fields that fit into the 224 bits will be available to use in bounced message receivers. Sometimes you need to rearrange the order of the fields in your message so the relevant ones would fit into the limit.
+Tact helps you to check if your message fits the limit, and if it doesn't, suggests using a special type constructor `bounced<M>{:tact}` for the bounced message receiver, which constructs a partial representation of the message that fits within the required limits.
+
+Note that the inner [message struct][message] of the `bounced<M>{:tact}` type constructor cannot be [optional](/book/optionals).
+
+```tact
+contract Bounce() {
+    // COMPILATION ERROR! Only named type can be bounced<>
+    bounced(msg: bounced<BB?>) {}
+    //           ~~~~~~~~~~~~
+}
+
+message BB {}
+```
+
+Only the first message fields that fit into the 224 bits will be available to use in bounced message receivers. Sometimes you need to rearrange the order of the fields in your message so the relevant ones would fit into the limit.
+
+```tact
+contract Bounce() {
+    bounced(msg: bounced<TwoFields>) {
+        // COMPILATION ERROR! Maximum size of the bounced message is 224 bits...
+        msg.f2;
+        //  ~~
+    }
+}
+
+message TwoFields {
+    f1: Int as uint224; // only this field will fit in a bounced message body
+    f2: Int;
+}
+```
 
 ## Bounced message receiver
 
@@ -38,3 +67,5 @@ contract MyContract {
     }
 }
 ```
+
+[message]: /book/structs-and-messages#messages

--- a/docs/src/content/docs/book/maps.mdx
+++ b/docs/src/content/docs/book/maps.mdx
@@ -65,6 +65,14 @@ Allowed value types:
 * [Struct][struct]
 * [Message][message]
 
+Neither key nor value types can be made [optional](/book/optionals).
+
+```tact
+// COMPILATION ERROR! Map key types cannot be optional
+let myMap: map<Int?, Int> = emptyMap();
+//             ~~~~
+```
+
 ## Serialization
 
 It is possible to perform [integer serialization](/book/integers#common-serialization-types) of map keys, values, or both to [preserve space and reduce storage costs](/book/integers#serialization):


### PR DESCRIPTION
## Issue

Closes #2554.
