### PR TITLE
fix(fmt): fix formatting comments between imports and declarations

### DIFF
--- a/src/fmt/test/top-level-comments.spec.ts
+++ b/src/fmt/test/top-level-comments.spec.ts
@@ -1,4 +1,4 @@
-import { intact } from "@/fmt/test/helpers";
+import { intact, test } from "@/fmt/test/helpers";
 
 describe("top level declarations comments formatting", () => {
     it(
@@ -430,5 +430,71 @@ describe("top level declarations comments formatting", () => {
 
             fun sqrt(x: Int): Int {}
         `),
+    );
+
+    it(
+        "several floating comments between import and declaration",
+        intact(`
+            import "";
+
+            // func reference
+
+            // int math::sqrt(int x) inline {
+            //   if (x == 0) { return x; }
+            // }
+
+            fun sqrt(x: Int): Int {}
+        `),
+    );
+
+    it(
+        "several floating comments between import and declaration 2",
+        intact(`
+            import "";
+
+            // some reference
+
+            // other reference
+            // with multiline comment
+
+            // bla bla
+
+            // func reference
+
+            // int math::sqrt(int x) inline {
+            //   if (x == 0) { return x; }
+            // }
+
+            fun sqrt(x: Int): Int {}
+        `),
+    );
+
+    it(
+        "several floating comments between import and declaration with several empty lines",
+        test(
+            `
+                import "";
+
+                // func reference
+
+
+                // int math::sqrt(int x) inline {
+                //   if (x == 0) { return x; }
+                // }
+
+                fun sqrt(x: Int): Int {}
+            `,
+            `
+                import "";
+
+                // func reference
+
+                // int math::sqrt(int x) inline {
+                //   if (x == 0) { return x; }
+                // }
+
+                fun sqrt(x: Int): Int {}
+            `,
+        ),
     );
 });


### PR DESCRIPTION
## Issue

Closes #2959.

## Checklist

- [x] I have updated CHANGELOG.md (we already have similar entry about floating comments)
- [x] I have added tests to demonstrate the contribution is correctly implemented: this usually includes both positive and negative tests, showing the happy path(s) and featuring intentionally broken cases
