### PR TITLE
fix: check static/instance contexts for method calls

### DIFF
--- a/src/abi/AbiFunction.ts
+++ b/src/abi/AbiFunction.ts
@@ -6,6 +6,7 @@ import type { SrcInfo } from "@/grammar";
 
 export type AbiFunction = {
     name: string;
+    isStatic?: boolean;
     resolve: (
         ctx: CompilerContext,
         args: readonly TypeRef[],

--- a/src/abi/struct.ts
+++ b/src/abi/struct.ts
@@ -52,6 +52,7 @@ export const StructFunctions: Map<string, AbiFunction> = new Map([
         "fromCell",
         {
             name: "fromCell",
+            isStatic: true,
             resolve: (ctx, args, ref) => {
                 if (args.length !== 2) {
                     throwCompilationError(
@@ -111,6 +112,7 @@ export const StructFunctions: Map<string, AbiFunction> = new Map([
         "opcode",
         {
             name: "opcode",
+            isStatic: true,
             resolve: (ctx, args, ref) => {
                 const [arg] = args;
                 if (typeof arg === "undefined" || args.length !== 1) {
@@ -210,6 +212,7 @@ export const StructFunctions: Map<string, AbiFunction> = new Map([
         "fromSlice",
         {
             name: "fromSlice",
+            isStatic: true,
             resolve: (ctx, args, ref) => {
                 if (args.length !== 2) {
                     throwCompilationError(

--- a/src/types/__snapshots__/resolveStatements.spec.ts.snap
+++ b/src/types/__snapshots__/resolveStatements.spec.ts.snap
@@ -900,6 +900,51 @@ exports[`resolveStatements should fail statements for map-literal-mismatch-var 1
 "
 `;
 
+exports[`resolveStatements should fail statements for method-fromcell-call-non-static-context 1`] = `
+"<unknown>:12:19: Cannot call static method "fromCell" using an instance.
+  11 |     init(cell: Cell) {
+> 12 |         let res = SomeMessage{}.fromCell(cell);
+                         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  13 |     }
+"
+`;
+
+exports[`resolveStatements should fail statements for method-fromslice-call-non-static-context 1`] = `
+"<unknown>:12:19: Cannot call static method "fromSlice" using an instance.
+  11 |     init(slice: Slice) {
+> 12 |         let res = SomeMessage{}.fromSlice(slice);
+                         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  13 |     }
+"
+`;
+
+exports[`resolveStatements should fail statements for method-opcode-call-non-static-context 1`] = `
+"<unknown>:11:19: Cannot call static method "opcode" using an instance.
+  10 |     receive() {
+> 11 |         let res = SomeMessage{}.opcode();
+                         ^~~~~~~~~~~~~~~~~~~~~~
+  12 |     }
+"
+`;
+
+exports[`resolveStatements should fail statements for method-tocell-call-non-instance-context 1`] = `
+"<unknown>:11:19: Cannot call non-static method "toCell" from a static context
+  10 |     receive() {
+> 11 |         let res = SomeMessage.toCell();
+                         ^~~~~~~~~~~~~~~~~~~~
+  12 |     }
+"
+`;
+
+exports[`resolveStatements should fail statements for method-toslice-call-non-instance-context 1`] = `
+"<unknown>:11:19: Cannot call non-static method "toSlice" from a static context
+  10 |     receive() {
+> 11 |         let res = SomeMessage.toSlice();
+                         ^~~~~~~~~~~~~~~~~~~~~
+  12 |     }
+"
+`;
+
 exports[`resolveStatements should fail statements for return-analysis-catch-if 1`] = `
 "<unknown>:4:1: Function does not always return a result. Adding 'return' statement(s) should fix the issue.
   3 | 
@@ -3351,6 +3396,84 @@ exports[`resolveStatements should resolve statements for init-vars-analysis-with
   ],
   [
     "self.value + 1",
+    "Int",
+  ],
+]
+`;
+
+exports[`resolveStatements should resolve statements for methods-call-instance-context 1`] = `
+[
+  [
+    "SomeMessage{}",
+    "SomeMessage",
+  ],
+  [
+    "SomeMessage{}",
+    "SomeMessage",
+  ],
+  [
+    "SomeMessage{}.toSlice()",
+    "Slice",
+  ],
+  [
+    "msg",
+    "SomeMessage",
+  ],
+  [
+    "msg.toSlice()",
+    "Slice",
+  ],
+  [
+    "SomeMessage{}",
+    "SomeMessage",
+  ],
+  [
+    "SomeMessage{}.toCell()",
+    "Cell",
+  ],
+  [
+    "msg",
+    "SomeMessage",
+  ],
+  [
+    "msg.toCell()",
+    "Cell",
+  ],
+]
+`;
+
+exports[`resolveStatements should resolve statements for methods-call-static-context 1`] = `
+[
+  [
+    "SomeMessage",
+    "SomeMessage",
+  ],
+  [
+    "slice",
+    "Slice",
+  ],
+  [
+    "SomeMessage.fromSlice(slice)",
+    "SomeMessage",
+  ],
+  [
+    "SomeMessage",
+    "SomeMessage",
+  ],
+  [
+    "cell",
+    "Cell",
+  ],
+  [
+    "SomeMessage.fromCell(cell)",
+    "SomeMessage",
+  ],
+  [
+    "SomeMessage",
+    "SomeMessage",
+  ],
+  [
+    "SomeMessage.opcode()",
     "Int",
   ],
 ]

--- a/src/types/resolveExpression.ts
+++ b/src/types/resolveExpression.ts
@@ -682,7 +682,8 @@ function resolveCall(
             if (StructFunctions.has(idText(exp.method))) {
                 const abi = StructFunctions.get(idText(exp.method))!;
                 const isInstanceCall = exp.self.kind !== "id";
-                const isStaticCallFromType = exp.self.kind === "id" && exp.self.text === src.name;
+                const isStaticCallFromType =
+                    exp.self.kind === "id" && exp.self.text === src.name;
 
                 if (abi.isStatic && isInstanceCall) {
                     throwCompilationError(

--- a/src/types/resolveExpression.ts
+++ b/src/types/resolveExpression.ts
@@ -681,6 +681,21 @@ function resolveCall(
         if (srcT.kind === "struct") {
             if (StructFunctions.has(idText(exp.method))) {
                 const abi = StructFunctions.get(idText(exp.method))!;
+                const isInstanceCall = exp.self.kind !== "id";
+                const isStaticCallFromType = exp.self.kind === "id" && exp.self.text === src.name;
+
+                if (abi.isStatic && isInstanceCall) {
+                    throwCompilationError(
+                        `Cannot call static method ${idTextErr(exp.method)} using an instance.`,
+                        exp.loc,
+                    );
+                }
+                if (!abi.isStatic && isStaticCallFromType) {
+                    throwCompilationError(
+                        `Cannot call non-static method ${idTextErr(exp.method)} from a static context`,
+                        exp.loc,
+                    );
+                }
                 const resolved = abi.resolve(
                     ctx,
                     [src, ...exp.args.map((v) => getExpType(ctx, v))],

--- a/src/types/stmts-failed/method-fromcell-call-non-static-context.tact
+++ b/src/types/stmts-failed/method-fromcell-call-non-static-context.tact
@@ -1,0 +1,14 @@
+primitive Cell;
+trait BaseTrait {
+
+}
+
+message SomeMessage {
+
+}
+
+contract SomeContract {
+    init(cell: Cell) {
+        let res = SomeMessage{}.fromCell(cell);
+    }
+}

--- a/src/types/stmts-failed/method-fromslice-call-non-static-context.tact
+++ b/src/types/stmts-failed/method-fromslice-call-non-static-context.tact
@@ -1,0 +1,14 @@
+primitive Slice;
+trait BaseTrait {
+
+}
+
+message SomeMessage {
+
+}
+
+contract SomeContract {
+    init(slice: Slice) {
+        let res = SomeMessage{}.fromSlice(slice);
+    }
+}

--- a/src/types/stmts-failed/method-opcode-call-non-static-context.tact
+++ b/src/types/stmts-failed/method-opcode-call-non-static-context.tact
@@ -1,0 +1,13 @@
+trait BaseTrait {
+
+}
+
+message SomeMessage {
+
+}
+
+contract SomeContract {
+    receive() {
+        let res = SomeMessage{}.opcode();
+    }
+}

--- a/src/types/stmts-failed/method-tocell-call-non-instance-context.tact
+++ b/src/types/stmts-failed/method-tocell-call-non-instance-context.tact
@@ -1,0 +1,13 @@
+trait BaseTrait {
+
+}
+
+message SomeMessage {
+
+}
+
+contract SomeContract {
+    receive() {
+        let res = SomeMessage.toCell();
+    }
+}

--- a/src/types/stmts-failed/method-toslice-call-non-instance-context.tact
+++ b/src/types/stmts-failed/method-toslice-call-non-instance-context.tact
@@ -1,0 +1,13 @@
+trait BaseTrait {
+
+}
+
+message SomeMessage {
+
+}
+
+contract SomeContract {
+    receive() {
+        let res = SomeMessage.toSlice();
+    }
+}

--- a/src/types/stmts/methods-call-instance-context.tact
+++ b/src/types/stmts/methods-call-instance-context.tact
@@ -1,0 +1,18 @@
+primitive Slice;
+trait BaseTrait {
+
+}
+
+message SomeMessage {
+
+}
+
+contract SomeContract {
+    receive() {
+        let msg = SomeMessage{};
+        let s1 = SomeMessage{}.toSlice();
+        let s2 = msg.toSlice();
+        let c1 = SomeMessage{}.toCell();
+        let c2 = msg.toCell();
+    }
+}

--- a/src/types/stmts/methods-call-static-context.tact
+++ b/src/types/stmts/methods-call-static-context.tact
@@ -1,0 +1,17 @@
+primitive Cell;
+primitive Slice;
+trait BaseTrait {
+
+}
+
+message SomeMessage {
+
+}
+
+contract SomeContract {
+    init(slice: Slice, cell: Cell) {
+        let mes1 = SomeMessage.fromSlice(slice);
+        let mes2 = SomeMessage.fromCell(cell);
+        let opcode = SomeMessage.opcode();
+    }
+}


### PR DESCRIPTION
## Issue

Closes #2952.

## Checklist

- [ ] I have updated CHANGELOG.md
- [ ] I have added tests to demonstrate the contribution is correctly implemented: this usually includes both positive and negative tests, showing the happy path(s) and featuring intentionally broken cases
