### PR TITLE
fix: bounced/trait returns from asm(shuffle/non-shuffle)

### DIFF
--- a/dev-docs/CHANGELOG.md
+++ b/dev-docs/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - [fix] Disallow self-inheritance for contracts and traits: PR [#3094](https://github.com/tact-lang/tact/pull/3094)
 - [fix] Added fixed-bytes support to bounced message size calculations: PR [#3129](https://github.com/tact-lang/tact/pull/3129)
+- [fix] Fixed compiler errors for bounced/trait return types
+- [fix] Added checks for bounced/trait returns in non-shuffle asm functions
 
 ### Docs
 

--- a/src/types/__snapshots__/resolveDescriptors.spec.ts.snap
+++ b/src/types/__snapshots__/resolveDescriptors.spec.ts.snap
@@ -1,5 +1,14 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`resolveDescriptors should fail descriptors for asm-fun-bounced-return 1`] = `
+"<unknown>:3:1: Function "foo" returns a <bounced> type, which cannot be returned from an "asm" function.
+  2 | 
+> 3 | asm (-> 0) fun foo(): bounced<Cell> { NOP }
+      ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  4 | 
+"
+`;
+
 exports[`resolveDescriptors should fail descriptors for asm-fun-shuffle-arg-duplicate 1`] = `
 "<unknown>:3:1: asm argument rearrangement cannot have duplicates
   2 | 
@@ -36,6 +45,15 @@ exports[`resolveDescriptors should fail descriptors for asm-fun-shuffle-arg-non-
 "
 `;
 
+exports[`resolveDescriptors should fail descriptors for asm-fun-shuffle-bounced-return 1`] = `
+"<unknown>:3:1: Function "foo" returns a <bounced> type, which cannot be returned from an "asm" function.
+  2 | 
+> 3 | asm (-> 0) fun foo(): bounced<Cell> { NOP }
+      ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  4 | 
+"
+`;
+
 exports[`resolveDescriptors should fail descriptors for asm-fun-shuffle-ret-duplicate 1`] = `
 "<unknown>:3:1: asm return rearrangement cannot have duplicates
   2 | 
@@ -60,6 +78,24 @@ exports[`resolveDescriptors should fail descriptors for asm-fun-shuffle-ret-non-
 > 4 | asm(-> 2 1 0) fun foo(x: Int, y: Int): Pair {
       ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
   5 |     SWAP
+"
+`;
+
+exports[`resolveDescriptors should fail descriptors for asm-fun-shuffle-trait-return 1`] = `
+"<unknown>:3:1: Function "foo" returns a trait, but returning traits from "asm" functions is not supported (yet).
+  2 | 
+> 3 | asm (-> 0) fun foo(): T { NOP }
+      ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  4 | 
+"
+`;
+
+exports[`resolveDescriptors should fail descriptors for asm-fun-trait-return 1`] = `
+"<unknown>:3:1: Function "foo" returns a trait, but returning traits from "asm" functions is not supported (yet).
+  2 | 
+> 3 | asm fun foo(): T { NOP }
+      ^~~~~~~~~~~~~~~~~~~~~~~~
+  4 | 
 "
 `;
 

--- a/src/types/test-failed/asm-fun-bounced-return.tact
+++ b/src/types/test-failed/asm-fun-bounced-return.tact
@@ -1,0 +1,3 @@
+primitive Cell;
+
+asm (-> 0) fun foo(): bounced<Cell> { NOP }

--- a/src/types/test-failed/asm-fun-shuffle-bounced-return.tact
+++ b/src/types/test-failed/asm-fun-shuffle-bounced-return.tact
@@ -1,0 +1,3 @@
+primitive Cell;
+
+asm (-> 0) fun foo(): bounced<Cell> { NOP }

--- a/src/types/test-failed/asm-fun-shuffle-trait-return.tact
+++ b/src/types/test-failed/asm-fun-shuffle-trait-return.tact
@@ -1,0 +1,3 @@
+trait T {}
+
+asm (-> 0) fun foo(): T { NOP }

--- a/src/types/test-failed/asm-fun-trait-return.tact
+++ b/src/types/test-failed/asm-fun-trait-return.tact
@@ -1,0 +1,3 @@
+trait T {}
+
+asm fun foo(): T { NOP }


### PR DESCRIPTION
- Added checks for bounced/trait returns in non-shuffle asm functions

## Issue

Closes #3130, #3158, #3132.

## Checklist

- [ ] I have updated CHANGELOG.md
- [ ] I have added tests to demonstrate the contribution is correctly implemented: this usually includes both positive and negative tests, showing the happy path(s) and featuring intentionally broken cases
