### PR TITLE
fix(codegen): don't generate `__tact_nop()` for `dump()` and `dumpStack()` with debug=false

### DIFF
--- a/dev-docs/CHANGELOG.md
+++ b/dev-docs/CHANGELOG.md
@@ -12,7 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [fix] Disallow self-inheritance for contracts and traits: PR [#3094](https://github.com/tact-lang/tact/pull/3094)
 - [fix] Added fixed-bytes support to bounced message size calculations: PR [#3129](https://github.com/tact-lang/tact/pull/3129)
 - Compiler now generates more efficient code for serialization: PR [#3213](https://github.com/tact-lang/tact/pull/3213)
-- [fix] Compiler now don't generate `__tact_nop()` for `dump()` and `dumpStack()` in default mode: PR [#3218](https://github.com/tact-lang/tact/pull/3218)
+- [fix] Compiler now doesn't generate `__tact_nop()` for `dump()` and `dumpStack()` in default mode: PR [#3218](https://github.com/tact-lang/tact/pull/3218)
 
 ### Docs
 

--- a/dev-docs/CHANGELOG.md
+++ b/dev-docs/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [fix] Disallow self-inheritance for contracts and traits: PR [#3094](https://github.com/tact-lang/tact/pull/3094)
 - [fix] Added fixed-bytes support to bounced message size calculations: PR [#3129](https://github.com/tact-lang/tact/pull/3129)
 - Compiler now generates more efficient code for serialization: PR [#3213](https://github.com/tact-lang/tact/pull/3213)
+- [fix] Compiler now don't generate `__tact_nop()` for `dump()` and `dumpStack()` in default mode: PR [#3218](https://github.com/tact-lang/tact/pull/3218)
 
 ### Docs
 

--- a/src/abi/global.ts
+++ b/src/abi/global.ts
@@ -250,7 +250,7 @@ export const GlobalFunctions: Map<string, AbiFunction> = new Map([
             },
             generate: (ctx, args, resolved, ref) => {
                 if (!enabledDebug(ctx.ctx)) {
-                    return `${ctx.used("__tact_nop")}()`;
+                    return ``;
                 }
                 const arg0 = args[0]!;
 
@@ -319,7 +319,7 @@ export const GlobalFunctions: Map<string, AbiFunction> = new Map([
             },
             generate: (ctx, _args, _resolved, ref) => {
                 if (!enabledDebug(ctx.ctx)) {
-                    return `${ctx.used("__tact_nop")}()`;
+                    return ``;
                 }
                 const filePath = ref.file
                     ? posixNormalize(path.relative(cwd(), ref.file!))

--- a/src/generator/writers/writeFunction.ts
+++ b/src/generator/writers/writeFunction.ts
@@ -208,6 +208,9 @@ export function writeStatement(
         }
         case "statement_expression": {
             const exp = writeExpression(f.expression, ctx);
+            if (exp === "") {
+                return;
+            }
             ctx.append(`${exp};`);
             return;
         }

--- a/src/generator/writers/writeStdlib.ts
+++ b/src/generator/writers/writeStdlib.ts
@@ -9,12 +9,6 @@ export function writeStdlib(ctx: WriterContext): void {
     // stdlib extension functions
     //
 
-    ctx.fun("__tact_nop", () => {
-        ctx.signature(`() __tact_nop()`);
-        ctx.context("stdlib");
-        ctx.asm("", "NOP");
-    });
-
     ctx.fun("__tact_sha256", () => {
         ctx.signature(`int __tact_sha256(slice data)`);
         ctx.context("stdlib");

--- a/src/test/codegen-check/__snapshots__/codegen.test.ts.snap
+++ b/src/test/codegen-check/__snapshots__/codegen.test.ts.snap
@@ -62,6 +62,9 @@ exports[`codegen should correctly generate FunC code 1`] = `
 ;; $MainContract$_fun_testIfOptimizationNegative
 ((int, int, slice, cell), ()) $MainContract$_fun_testIfOptimizationNegative((int, int, slice, cell) $self, int $a) impure inline_ref;
 
+;; $MainContract$_fun_testDumpCall
+((int, int, slice, cell), ()) $MainContract$_fun_testDumpCall((int, int, slice, cell) $self, int $a) impure inline_ref;
+
 
 ;; main_MainContract.stdlib.fc
 global (int, slice, int, slice) __tact_context;
@@ -282,6 +285,11 @@ cell $Builder$_fun_endCell(builder $self) impure asm """
     return (($self'field, $self'value, $self'data, $self'mapping), ());
 }
 
+((int, int, slice, cell), ()) $MainContract$_fun_testDumpCall((int, int, slice, cell) $self, int $a) impure inline_ref {
+    var (($self'field, $self'value, $self'data, $self'mapping)) = $self;
+    return (($self'field, $self'value, $self'data, $self'mapping), ());
+}
+
 ;;
 ;; Get methods of a Contract MainContract
 ;;
@@ -332,6 +340,13 @@ _ %testIfOptimizationNegative(int $a) method_id(87434) {
     int $a = $a;
     var self = $MainContract$_contract_load();
     var res = self~$MainContract$_fun_testIfOptimizationNegative($a);
+    return res;
+}
+
+_ %testDumpCall(int $a) method_id(66927) {
+    int $a = $a;
+    var self = $MainContract$_contract_load();
+    var res = self~$MainContract$_fun_testDumpCall($a);
     return res;
 }
 

--- a/src/test/codegen-check/contracts/main.tact
+++ b/src/test/codegen-check/contracts/main.tact
@@ -185,4 +185,9 @@ contract MainContract {
             return;
         }
     }
+
+    get fun testDumpCall(a: Int) {
+        dump(a);
+        dumpStack();
+    }
 }


### PR DESCRIPTION
## Issue

Closes #3217.

## Checklist

- [x] I have updated CHANGELOG.md
- [x] I have added tests to demonstrate the contribution is correctly implemented: this usually includes both positive and negative tests, showing the happy path(s) and featuring intentionally broken cases
