### PR TITLE
fix: special chars in receiver comments, that breaks code

### DIFF
--- a/dev-docs/CHANGELOG.md
+++ b/dev-docs/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- [fix] Added escaping of special-chars in receiver comments break FunC compilation: PR [#]()
+
 ### Language features
 
 - [fix] Disallow self-inheritance for contracts and traits: PR [#3094](https://github.com/tact-lang/tact/pull/3094)

--- a/src/generator/writers/writeRouter.ts
+++ b/src/generator/writers/writeRouter.ts
@@ -26,6 +26,7 @@ import { getAstFactory, idText } from "@/ast/ast-helpers";
 import { evalConstantExpression } from "@/optimizer/constEval";
 import { getAstUtil } from "@/ast/util";
 import { prettyPrint } from "@/ast/ast-printer";
+import { escapeUnicodeControlCodes } from "@/utils/text";
 
 type ContractReceivers = {
     readonly internal: Receivers;
@@ -281,7 +282,10 @@ function writeCommentReceivers(
                 !msgOpcodeRemoved,
                 commentRcv.ast.loc,
             );
-            wCtx.append(`;; Receive "${commentRcv.selector.comment}" message`);
+            const comment = escapeUnicodeControlCodes(
+                commentRcv.selector.comment,
+            );
+            wCtx.append(`;; Receive "${comment}" message`);
 
             wCtx.inBlock(`if (text_op == 0x${hash})`, () => {
                 writeReceiverBody(commentRcv, contract, wCtx);

--- a/src/test/codegen-check/__snapshots__/codegen.test.ts.snap
+++ b/src/test/codegen-check/__snapshots__/codegen.test.ts.snap
@@ -11,6 +11,9 @@ exports[`codegen should correctly generate FunC code 1`] = `
 ;; NOTE: declarations are sorted for optimal order
 ;;
 
+;; $MainContract$_store
+builder $MainContract$_store(builder build_0, (int, int, slice, cell) v) inline;
+
 ;; $MainContract$_load
 (slice, ((int, int, slice, cell))) $MainContract$_load(slice sc_0) inline;
 
@@ -31,6 +34,9 @@ exports[`codegen should correctly generate FunC code 1`] = `
 
 ;; $MainContract$_contract_load
 (int, int, slice, cell) $MainContract$_contract_load() impure inline;
+
+;; $MainContract$_contract_store
+() $MainContract$_contract_store((int, int, slice, cell) v) impure inline;
 
 ;; $MainContract$_fun_testAugmentedAssignOperators
 ((int, int, slice, cell), int) $MainContract$_fun_testAugmentedAssignOperators((int, int, slice, cell) $self, int $intVal, int $intVal2, int $boolVal, int $boolVal2) impure inline_ref;
@@ -129,6 +135,15 @@ cell $Builder$_fun_endCell(builder $self) impure asm """
 ;; TLB: _ field:uint8 value:int256 data:fixed_bytes64 mapping:dict<uint8, int256> = MainContract
 ;;
 
+builder $MainContract$_store(builder build_0, (int, int, slice, cell) v) inline {
+    var (v'field, v'value, v'data, v'mapping) = v;
+    build_0 = build_0.store_uint(v'field, 8);
+    build_0 = build_0.store_int(v'value, 256);
+    build_0 = build_0.store_slice(v'data);
+    build_0 = build_0.store_dict(v'mapping);
+    return build_0;
+}
+
 (slice, ((int, int, slice, cell))) $MainContract$_load(slice sc_0) inline {
     var v'field = sc_0~load_uint(8);
     var v'value = sc_0~load_int(256);
@@ -156,6 +171,13 @@ cell $Builder$_fun_endCell(builder $self) impure asm """
         $sc.end_parse();
         return $MainContract$_contract_init($field, $value, $data, $mapping);
     }
+}
+
+() $MainContract$_contract_store((int, int, slice, cell) v) impure inline {
+    builder b = begin_cell();
+    b = b.store_int(true, 1);
+    b = $MainContract$_store(b, v);
+    set_data(b.end_cell());
 }
 
 ;;
@@ -359,6 +381,19 @@ _ %testIfOptimizationNegative(int $a) method_id(87434) {
     
     ;; Handle bounced messages
     if (msg_bounced) { return (); }
+    int op = 0;
+    int in_msg_length = slice_bits(in_msg);
+    if (in_msg_length >= 32) {
+        op = in_msg~load_uint(32);
+    }
+    ;; Empty Receiver and Text Receivers
+    var text_op = slice_hash(in_msg);
+    ;; Receive "Text\\x00receiver\\x01.\\x0aThis\\x07is\\x0da\\x1ftest\\x7fcomment\\x9fwith\\x08bad\\x0cchars" message
+    if (text_op == 0xbda34c240a58a6fbef2e412f434571f1f7137bed89527d740583fc594ebe8e6d) {
+        $MainContract$_contract_store(($self'field, $self'value, $self'data, $self'mapping));
+        return ();
+    }
+    ;; Throw if not handled
     throw(130);
 }
 

--- a/src/test/codegen-check/contracts/main.tact
+++ b/src/test/codegen-check/contracts/main.tact
@@ -35,6 +35,8 @@ contract MainContract {
     data: Slice as bytes64;
     mapping: map<Int as uint8, Int as int256>;
 
+    receive("Text\x00receiver\x01.\nThis\x07is\x0Da\x1Ftest\x7Fcomment\x9Fwith\x08bad\x0Cchars") {}
+
     init(field: Int as uint8, value: Int as int256, data: Slice as bytes64, mapping: map<Int as uint8, Int as int256>) {
         self.field = field;
         self.value = value;


### PR DESCRIPTION
## Issue

Closes #3116.

## Checklist

- [ ] I have updated CHANGELOG.md
- [ ] I have added tests to demonstrate the contribution is correctly implemented: this usually includes both positive and negative tests, showing the happy path(s) and featuring intentionally broken cases
