### PR TITLE
fix(codegen): binary and octal literals as message opcodes

### DIFF
--- a/dev-docs/CHANGELOG.md
+++ b/dev-docs/CHANGELOG.md
@@ -8,8 +8,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 - [fix] Added static/instance checks for core static methods: PR [#3119](https://github.com/tact-lang/tact/pull/3119)
-- [fix] Added escaping of special-chars in receiver comments break FunC compilation: PR [#3234](https://github.com/tact-lang/tact/pull/3234)
-- [fix] Disable optimization of optional integer comparisons that leads to runtime exceptions: PR [#3210](https://github.com/tact-lang/tact/pull/3210)
 - [fix]: Fixed mismatched serialization of maps in const/fun: PR [#3172](https://github.com/tact-lang/tact/pull/3172)
 
 ### Language features
@@ -17,6 +15,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [fix] Disallow self-inheritance for contracts and traits: PR [#3094](https://github.com/tact-lang/tact/pull/3094)
 - [fix] Added fixed-bytes support to bounced message size calculations: PR [#3129](https://github.com/tact-lang/tact/pull/3129)
 - Compiler now generates more efficient code for serialization: PR [#3213](https://github.com/tact-lang/tact/pull/3213)
+
+### Code generation
+
+- [fix] Correct transformation of binary and octal message opcodes to hexadecimal format: PR [#3239](https://github.com/tact-lang/tact/pull/3239)
+- [fix] Added escaping of special-chars in receiver comments break FunC compilation: PR [#3234](https://github.com/tact-lang/tact/pull/3234)
+- [fix] Disable optimization of optional integer comparisons that leads to runtime exceptions: PR [#3210](https://github.com/tact-lang/tact/pull/3210)
 - [fix] Compiler now doesn't generate `__tact_nop()` for `dump()` and `dumpStack()` in default mode: PR [#3218](https://github.com/tact-lang/tact/pull/3218)
 
 ### Docs

--- a/src/generator/writers/writeRouter.ts
+++ b/src/generator/writers/writeRouter.ts
@@ -721,6 +721,7 @@ export function messageOpcode(n: Ast.Number): string {
             return n.value.toString(n.base);
         case 2:
         case 8:
+            return `0x${n.value.toString(16)}`;
         case 16:
             return `0x${n.value.toString(n.base)}`;
     }

--- a/src/test/codegen-check/__snapshots__/codegen.test.ts.snap
+++ b/src/test/codegen-check/__snapshots__/codegen.test.ts.snap
@@ -20,6 +20,9 @@ int __tact_int_eq_nullable_one(int a, int b) inline;
 ;; __tact_int_neq_nullable_one
 int __tact_int_neq_nullable_one(int a, int b) inline;
 
+;; $Bin$_load_without_opcode
+(slice, (tuple)) $Bin$_load_without_opcode(slice sc_0) inline;
+
 ;; $MainContract$_store
 builder $MainContract$_store(builder build_0, (int, int, slice, cell) v) inline;
 
@@ -112,6 +115,16 @@ cell $Builder$_fun_endCell(builder $self) impure asm """
 """;
 
 ;; main_MainContract.storage.fc
+;;
+;; Type: Bin
+;; Header: 0x00000002
+;; TLB: bin#00000002  = Bin
+;;
+
+(slice, (tuple)) $Bin$_load_without_opcode(slice sc_0) inline {
+    return (sc_0, null());
+}
+
 ;;
 ;; Type: A
 ;; TLB: _ a:int257 b:int257 c:Maybe int257 d:bool e:Maybe bool f:int257 g:int257 = A
@@ -435,6 +448,14 @@ _ %testDumpCall(int $a) method_id(66927) {
     int in_msg_length = slice_bits(in_msg);
     if (in_msg_length >= 32) {
         op = in_msg~load_uint(32);
+        ;; Receive Bin message
+        if (op == 0x2) {
+            var $m = in_msg~$Bin$_load_without_opcode();
+            throw_unless(53588, (0x2 == 2));
+            $MainContract$_contract_store(($self'field, $self'value, $self'data, $self'mapping));
+            return ();
+        }
+        
     }
     ;; Empty Receiver and Text Receivers
     var text_op = slice_hash(in_msg);

--- a/src/test/codegen-check/contracts/main.tact
+++ b/src/test/codegen-check/contracts/main.tact
@@ -1,3 +1,5 @@
+message(0b10) Bin {}
+
 struct A {
     a: Int;
     b: Int;
@@ -36,6 +38,8 @@ contract MainContract {
     mapping: map<Int as uint8, Int as int256>;
 
     receive("Text\x00receiver\x01.\nThis \x07 is \x0D a \x1F test \x7F comment \x9F with \x08 bad \x0C chars") {}
+
+    receive(m: Bin) { require(m.opcode() == 2, "Incorrect message opcode: binary literal") }
 
     init(field: Int as uint8, value: Int as int256, data: Slice as bytes64, mapping: map<Int as uint8, Int as int256>) {
         self.field = field;

--- a/src/test/e2e-emulated/message-sending/opcodes.spec.ts
+++ b/src/test/e2e-emulated/message-sending/opcodes.spec.ts
@@ -1,0 +1,75 @@
+import { toNano } from "@ton/core";
+import { Blockchain } from "@ton/sandbox";
+import { Tester } from "./output/opcodes_Tester";
+import "@ton/test-utils";
+import { cached } from "@/test/utils/cache-state";
+import { setStoragePrices } from "@/test/utils/gasUtils";
+
+const deployValue = toNano("0.01");
+
+const setup = async () => {
+    const blockchain = await Blockchain.create();
+    blockchain.verbosity.print = false;
+
+    const config = blockchain.config;
+
+    blockchain.setConfig(
+        setStoragePrices(config, {
+            unixTimeSince: 0,
+            bitPricePerSecond: 0n,
+            cellPricePerSecond: 0n,
+            masterChainBitPricePerSecond: 0n,
+            masterChainCellPricePerSecond: 0n,
+        }),
+    );
+
+    const treasury = await blockchain.treasury("treasury");
+
+    const contract = blockchain.openContract(await Tester.fromInit());
+
+    const deployResult = await contract.send(
+        treasury.getSender(),
+        { value: deployValue },
+        null,
+    );
+    expect(deployResult.transactions).toHaveTransaction({
+        from: treasury.address,
+        to: contract.address,
+        success: true,
+        deploy: true,
+    });
+
+    return {
+        blockchain,
+        treasury,
+        contract,
+    };
+};
+
+describe("opcode", () => {
+    const state = cached(setup);
+
+    const variants = ["Bin", "Oct", "Dec", "Hex"] as const;
+
+    it.each(variants)(
+        "should correctly generate opcodes for opcode literal: %s",
+        async (opcodeKind) => {
+            const { contract, treasury } = await state.get();
+            const result = await contract.send(
+                treasury.getSender(),
+                { value: toNano("10") },
+                {
+                    $$type: opcodeKind,
+                },
+            );
+
+            expect(result.transactions).toHaveTransaction({
+                from: treasury.address,
+                to: contract.address,
+                success: true,
+                exitCode: 0,
+                deploy: false,
+            });
+        },
+    );
+});

--- a/src/test/e2e-emulated/message-sending/opcodes.spec.ts
+++ b/src/test/e2e-emulated/message-sending/opcodes.spec.ts
@@ -3,25 +3,12 @@ import { Blockchain } from "@ton/sandbox";
 import { Tester } from "./output/opcodes_Tester";
 import "@ton/test-utils";
 import { cached } from "@/test/utils/cache-state";
-import { setStoragePrices } from "@/test/utils/gasUtils";
 
 const deployValue = toNano("0.01");
 
 const setup = async () => {
     const blockchain = await Blockchain.create();
     blockchain.verbosity.print = false;
-
-    const config = blockchain.config;
-
-    blockchain.setConfig(
-        setStoragePrices(config, {
-            unixTimeSince: 0,
-            bitPricePerSecond: 0n,
-            cellPricePerSecond: 0n,
-            masterChainBitPricePerSecond: 0n,
-            masterChainCellPricePerSecond: 0n,
-        }),
-    );
 
     const treasury = await blockchain.treasury("treasury");
 

--- a/src/test/e2e-emulated/message-sending/opcodes.tact
+++ b/src/test/e2e-emulated/message-sending/opcodes.tact
@@ -1,0 +1,16 @@
+message(0b10) Bin {}
+message(0o10) Oct {}
+message(10) Dec {}
+message(0x10) Hex {}
+
+contract Tester {
+    receive() {}
+
+    receive(m: Bin) { require(m.opcode() == 2, "Incorrect message opcode: binary literal") }
+
+    receive(m: Oct) { require(m.opcode() == 8, "Incorrect message opcode: octal literal") }
+
+    receive(m: Dec) { require(m.opcode() == 10, "Incorrect message opcode: decimal literal") }
+
+    receive(m: Hex) { require(m.opcode() == 16, "Incorrect message opcode: hex literal") }
+}


### PR DESCRIPTION
## Issue

Closes #3118.

## Checklist

- [x] I have updated CHANGELOG.md
- [x] I have added tests to demonstrate the contribution is correctly implemented: this usually includes both positive and negative tests, showing the happy path(s) and featuring intentionally broken cases
