### PR TITLE
fix: unbalanced quotation in error messages for out-of-project-root imports

### DIFF
--- a/dev-docs/CHANGELOG.md
+++ b/dev-docs/CHANGELOG.md
@@ -7,22 +7,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-- [fix] Correct long struct tuple destruction: PR [#3105](https://github.com/tact-lang/tact/pull/3105)
-- [fix] Added static/instance checks for core static methods: PR [#3119](https://github.com/tact-lang/tact/pull/3119)
-- [fix]: Fixed mismatched serialization of maps in const/fun: PR [#3172](https://github.com/tact-lang/tact/pull/3172)
-
 ### Language features
 
+- [fix] Balanced quotation in error messages for out-of-project-root imports: PR [#3242](https://github.com/tact-lang/tact/pull/3242)
 - [fix] Disallow self-inheritance for contracts and traits: PR [#3094](https://github.com/tact-lang/tact/pull/3094)
 - [fix] Added fixed-bytes support to bounced message size calculations: PR [#3129](https://github.com/tact-lang/tact/pull/3129)
-- Compiler now generates more efficient code for serialization: PR [#3213](https://github.com/tact-lang/tact/pull/3213)
+- [fix] Allow equivalent `as`-annotations for maps types: PR [#3172](https://github.com/tact-lang/tact/pull/3172)
+- [fix] Added static/instance checks for core static methods: PR [#3119](https://github.com/tact-lang/tact/pull/3119)
 
 ### Code generation
 
+- Compiler now generates more efficient code for slice serialization: PR [#3213](https://github.com/tact-lang/tact/pull/3213)
+- Improve gas consumption for equality comparisons of optionals: PR [#3233](https://github.com/tact-lang/tact/pull/3233)
+- Improve gas consumption for deserialization of optional addresses: PR [#3225](https://github.com/tact-lang/tact/pull/3225)
 - [fix] Correct transformation of binary and octal message opcodes to hexadecimal format: PR [#3239](https://github.com/tact-lang/tact/pull/3239)
 - [fix] Added escaping of special-chars in receiver comments break FunC compilation: PR [#3234](https://github.com/tact-lang/tact/pull/3234)
 - [fix] Disable optimization of optional integer comparisons that leads to runtime exceptions: PR [#3210](https://github.com/tact-lang/tact/pull/3210)
 - [fix] Compiler now doesn't generate `__tact_nop()` for `dump()` and `dumpStack()` in default mode: PR [#3218](https://github.com/tact-lang/tact/pull/3218)
+- [fix] Correct long struct tuple destruction: PR [#3105](https://github.com/tact-lang/tact/pull/3105)
 
 ### Docs
 
@@ -35,6 +37,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [lordivash](https://github.com/lordivash)
 - [Novus Nota](https://github.com/novusnota)
 - [Daniil Sedov](https://github.com/Gusarich)
+- [Petr Makhnev](https://github.com/i582)
+- [Andrew Gutarev](https://github.com/pyAndr3w)
+- [Anton Trunov](https://github.com/anton-trunov)
 
 ## [1.6.10] - 2025-05-16
 

--- a/spell/cspell-list.txt
+++ b/spell/cspell-list.txt
@@ -67,6 +67,7 @@ Georgiy
 getsimpleforwardfee
 gettest
 guarantor
+Gutarev
 hazyone
 Héctor
 hehe

--- a/src/test/compilation-failed/contracts/import-out-of-project-root.tact
+++ b/src/test/compilation-failed/contracts/import-out-of-project-root.tact
@@ -1,0 +1,1 @@
+import "../../e2e-emulated/debug/dump.tact";

--- a/src/test/compilation-failed/import-errors.spec.ts
+++ b/src/test/compilation-failed/import-errors.spec.ts
@@ -18,3 +18,18 @@ it("symlinks are not allowed", async () => {
         "is a symbolic link which are not processed by Tact to forbid out-of-project-root accesses via symlinks",
     );
 });
+
+it("direct out-of-project-root accesses are not allowed", async () => {
+    const result = await run({
+        config: createSingleFileConfig(
+            `import-out-of-project-root.tact`,
+            "./output",
+        ),
+        logger: new Logger(LogLevel.NONE),
+        project: createNodeFileSystem(join(__dirname, "contracts")),
+        stdlib: createVirtualFileSystem("@stdlib", Stdlib.files),
+    });
+    expect(result.ok).toBe(false);
+    const message = result.error.map((err) => err.message).join("; ");
+    expect(message).toContain("dump.tact' is outside of the root directory");
+});

--- a/src/vfs/createNodeFileSystem.ts
+++ b/src/vfs/createNodeFileSystem.ts
@@ -5,14 +5,14 @@ import path from "path";
 function ensureInsideProjectRoot(filePath: string, root: string): void {
     if (!filePath.startsWith(root)) {
         throw new Error(
-            `Path "${filePath} is outside of the root directory "${root}"`,
+            `Path '${filePath}' is outside of the root directory '${root}'`,
         );
     }
 }
 function ensureNotSymlink(filePath: string): void {
     if (fs.lstatSync(filePath).isSymbolicLink()) {
         throw new Error(
-            `Path "${filePath}" is a symbolic link which are not processed by Tact to forbid out-of-project-root accesses via symlinks`,
+            `Path '${filePath}' is a symbolic link which are not processed by Tact to forbid out-of-project-root accesses via symlinks`,
         );
     }
 }


### PR DESCRIPTION
## Issue

Closes #3101.

## Checklist

- [x] I have updated CHANGELOG.md
- [x] I have added tests to demonstrate the contribution is correctly implemented: this usually includes both positive and negative tests, showing the happy path(s) and featuring intentionally broken cases
