### PR TITLE
fix: don't require explicit re-declaration for abstract methods and fields in traits

### DIFF
--- a/dev-docs/CHANGELOG.md
+++ b/dev-docs/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Language features
+
+- [fix] Compiler now doesn't require explicit re-declaration for abstract methods and fields in traits: PR [#3272](https://github.com/tact-lang/tact/pull/3272)
+
+### Release contributors
+
+- [Petr Makhnev](https://github.com/i582)
+
 ## [1.6.11] - 2025-05-26
 
 ### Language features

--- a/src/test/e2e-emulated/contract-getters/contract-and-abstract-trait-method.spec.ts
+++ b/src/test/e2e-emulated/contract-getters/contract-and-abstract-trait-method.spec.ts
@@ -1,0 +1,44 @@
+import { toNano } from "@ton/core";
+import { Blockchain } from "@ton/sandbox";
+import { Test } from "./output/contract-and-abstract-trait-method_Test";
+import "@ton/test-utils";
+import { cached } from "@/test/utils/cache-state";
+
+const deployValue = toNano("1");
+
+const setup = async () => {
+    const blockchain = await Blockchain.create();
+    blockchain.verbosity.print = false;
+
+    const treasury = await blockchain.treasury("treasury");
+    const contract = blockchain.openContract(await Test.fromInit());
+
+    const deployResult = await contract.send(
+        treasury.getSender(),
+        { value: deployValue },
+        null,
+    );
+    expect(deployResult.transactions).toHaveTransaction({
+        from: treasury.address,
+        to: contract.address,
+        success: true,
+        deploy: true,
+    });
+
+    return {
+        blockchain,
+        treasury,
+        contract,
+    };
+};
+
+describe("contract with trait with abstract method", () => {
+    const state = cached(setup);
+
+    it("should return correct values", async () => {
+        const { contract } = await state.get();
+
+        expect(await contract.getGetCompute()).toEqual(20n);
+        expect(await contract.getGetVal()).toEqual(20n);
+    });
+});

--- a/src/test/e2e-emulated/contract-getters/contract-and-abstract-trait-method.tact
+++ b/src/test/e2e-emulated/contract-getters/contract-and-abstract-trait-method.tact
@@ -1,0 +1,23 @@
+trait TraitA {
+    abstract fun compute(): Int;
+    virtual fun getValue(): Int {
+        return 10;
+    }
+}
+
+trait TraitB with TraitA {
+    override fun getValue(): Int {
+        return self.compute();
+    }
+}
+
+contract Test with TraitB {
+    override fun compute(): Int {
+        return 20;
+    }
+
+    receive() {}
+
+    get fun getCompute(): Int { return self.compute() }
+    get fun getVal(): Int { return self.getValue() }
+}

--- a/src/types/__snapshots__/resolveDescriptors.spec.ts.snap
+++ b/src/types/__snapshots__/resolveDescriptors.spec.ts.snap
@@ -198,12 +198,21 @@ exports[`resolveDescriptors should fail descriptors for contract-does-not-overri
 "
 `;
 
-exports[`resolveDescriptors should fail descriptors for contract-does-not-override-abstract-getter 1`] = `
-"<unknown>:8:1: Trait "T" requires function "getter"
-  7 | 
-> 8 | contract TestContract with T {
-      ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-  9 |   // does not override an abstract getter
+exports[`resolveDescriptors should fail descriptors for contract-does-not-override-abstract-const-with-deep-inheritance 1`] = `
+"<unknown>:10:1: Trait "T" requires constant "Foo"
+   9 | 
+> 10 | contract TestContract with T1 {
+       ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  11 |   // does not override an abstract const
+"
+`;
+
+exports[`resolveDescriptors should fail descriptors for contract-does-not-override-abstract-getter-with-deep inheritance 1`] = `
+"<unknown>:10:1: Trait "T" requires function "getter"
+   9 | 
+> 10 | contract TestContract with T1 {
+       ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  11 |   // does not override an abstract getter
 "
 `;
 
@@ -17397,6 +17406,3292 @@ exports[`resolveDescriptors should resolve descriptors for multi-inheritance-wit
 `;
 
 exports[`resolveDescriptors should resolve descriptors for multi-inheritance-with-duplicate-methods-via-diamond 2`] = `[]`;
+
+exports[`resolveDescriptors should resolve descriptors for nested-trait-with-abstract-constant 1`] = `
+[
+  {
+    "ast": {
+      "id": 2,
+      "kind": "primitive_type_decl",
+      "loc": primitive Int;,
+      "name": {
+        "id": 1,
+        "kind": "id",
+        "loc": Int,
+        "text": "Int",
+      },
+    },
+    "constants": [],
+    "dependsOn": [],
+    "fields": [],
+    "functions": Map {},
+    "globalVariables": Set {},
+    "header": null,
+    "init": null,
+    "interfaces": [],
+    "kind": "primitive_type_decl",
+    "name": "Int",
+    "origin": "user",
+    "partialFieldCount": 0,
+    "receivers": [],
+    "signature": null,
+    "tlb": null,
+    "traits": [],
+    "uid": 38154,
+  },
+  {
+    "ast": {
+      "attributes": [],
+      "declarations": [],
+      "id": 4,
+      "kind": "trait",
+      "loc": trait BaseTrait {},
+      "name": {
+        "id": 3,
+        "kind": "id",
+        "loc": BaseTrait,
+        "text": "BaseTrait",
+      },
+      "traits": [],
+    },
+    "constants": [],
+    "dependsOn": [],
+    "fields": [],
+    "functions": Map {},
+    "globalVariables": Set {},
+    "header": null,
+    "init": null,
+    "interfaces": [],
+    "kind": "trait",
+    "name": "BaseTrait",
+    "origin": "user",
+    "partialFieldCount": 0,
+    "receivers": [],
+    "signature": null,
+    "tlb": null,
+    "traits": [],
+    "uid": 1020,
+  },
+  {
+    "ast": {
+      "attributes": [],
+      "declarations": [
+        {
+          "attributes": [
+            {
+              "loc": abstract,
+              "type": "abstract",
+            },
+          ],
+          "id": 8,
+          "kind": "constant_decl",
+          "loc": abstract const FOO: Int;,
+          "name": {
+            "id": 6,
+            "kind": "id",
+            "loc": FOO,
+            "text": "FOO",
+          },
+          "type": {
+            "id": 7,
+            "kind": "type_id",
+            "loc": Int,
+            "text": "Int",
+          },
+        },
+        {
+          "attributes": [
+            {
+              "kind": "function_attribute",
+              "loc": virtual,
+              "type": "virtual",
+            },
+          ],
+          "id": 13,
+          "kind": "function_def",
+          "loc": virtual fun getValue(): Int {
+        return 10;
+    },
+          "name": {
+            "id": 9,
+            "kind": "id",
+            "loc": getValue,
+            "text": "getValue",
+          },
+          "params": [],
+          "return": {
+            "id": 10,
+            "kind": "type_id",
+            "loc": Int,
+            "text": "Int",
+          },
+          "statements": [
+            {
+              "expression": {
+                "base": 10,
+                "id": 11,
+                "kind": "number",
+                "loc": 10,
+                "value": 10n,
+              },
+              "id": 12,
+              "kind": "statement_return",
+              "loc": return 10;,
+            },
+          ],
+        },
+      ],
+      "id": 14,
+      "kind": "trait",
+      "loc": trait TraitA {
+    abstract const FOO: Int;
+    virtual fun getValue(): Int {
+        return 10;
+    }
+},
+      "name": {
+        "id": 5,
+        "kind": "id",
+        "loc": TraitA,
+        "text": "TraitA",
+      },
+      "traits": [],
+    },
+    "constants": [
+      {
+        "ast": {
+          "attributes": [
+            {
+              "loc": abstract,
+              "type": "abstract",
+            },
+          ],
+          "id": 8,
+          "kind": "constant_decl",
+          "loc": abstract const FOO: Int;,
+          "name": {
+            "id": 6,
+            "kind": "id",
+            "loc": FOO,
+            "text": "FOO",
+          },
+          "type": {
+            "id": 7,
+            "kind": "type_id",
+            "loc": Int,
+            "text": "Int",
+          },
+        },
+        "loc": abstract const FOO: Int;,
+        "name": "FOO",
+        "type": {
+          "kind": "ref",
+          "name": "Int",
+          "optional": false,
+        },
+        "value": undefined,
+      },
+    ],
+    "dependsOn": [],
+    "fields": [],
+    "functions": Map {
+      "getValue" => {
+        "ast": {
+          "attributes": [
+            {
+              "kind": "function_attribute",
+              "loc": virtual,
+              "type": "virtual",
+            },
+          ],
+          "id": 13,
+          "kind": "function_def",
+          "loc": virtual fun getValue(): Int {
+        return 10;
+    },
+          "name": {
+            "id": 9,
+            "kind": "id",
+            "loc": getValue,
+            "text": "getValue",
+          },
+          "params": [],
+          "return": {
+            "id": 10,
+            "kind": "type_id",
+            "loc": Int,
+            "text": "Int",
+          },
+          "statements": [
+            {
+              "expression": {
+                "base": 10,
+                "id": 11,
+                "kind": "number",
+                "loc": 10,
+                "value": 10n,
+              },
+              "id": 12,
+              "kind": "statement_return",
+              "loc": return 10;,
+            },
+          ],
+        },
+        "isAbstract": false,
+        "isGetter": false,
+        "isInline": false,
+        "isMutating": true,
+        "isOverride": false,
+        "isVirtual": true,
+        "methodId": null,
+        "name": "getValue",
+        "origin": "user",
+        "params": [],
+        "returns": {
+          "kind": "ref",
+          "name": "Int",
+          "optional": false,
+        },
+        "self": {
+          "kind": "ref",
+          "name": "TraitA",
+          "optional": false,
+        },
+      },
+    },
+    "globalVariables": Set {},
+    "header": null,
+    "init": null,
+    "interfaces": [],
+    "kind": "trait",
+    "name": "TraitA",
+    "origin": "user",
+    "partialFieldCount": 0,
+    "receivers": [],
+    "signature": null,
+    "tlb": null,
+    "traits": [],
+    "uid": 39380,
+  },
+  {
+    "ast": {
+      "attributes": [],
+      "declarations": [
+        {
+          "attributes": [
+            {
+              "kind": "function_attribute",
+              "loc": override,
+              "type": "override",
+            },
+          ],
+          "id": 23,
+          "kind": "function_def",
+          "loc": override fun getValue(): Int {
+        return self.FOO;
+    },
+          "name": {
+            "id": 17,
+            "kind": "id",
+            "loc": getValue,
+            "text": "getValue",
+          },
+          "params": [],
+          "return": {
+            "id": 18,
+            "kind": "type_id",
+            "loc": Int,
+            "text": "Int",
+          },
+          "statements": [
+            {
+              "expression": {
+                "aggregate": {
+                  "id": 19,
+                  "kind": "id",
+                  "loc": self,
+                  "text": "self",
+                },
+                "field": {
+                  "id": 20,
+                  "kind": "id",
+                  "loc": FOO,
+                  "text": "FOO",
+                },
+                "id": 21,
+                "kind": "field_access",
+                "loc": self.FOO,
+              },
+              "id": 22,
+              "kind": "statement_return",
+              "loc": return self.FOO;,
+            },
+          ],
+        },
+      ],
+      "id": 24,
+      "kind": "trait",
+      "loc": trait TraitB with TraitA {
+    override fun getValue(): Int {
+        return self.FOO;
+    }
+},
+      "name": {
+        "id": 15,
+        "kind": "id",
+        "loc": TraitB,
+        "text": "TraitB",
+      },
+      "traits": [
+        {
+          "id": 16,
+          "kind": "id",
+          "loc": TraitA,
+          "text": "TraitA",
+        },
+      ],
+    },
+    "constants": [
+      {
+        "ast": {
+          "attributes": [
+            {
+              "loc": abstract,
+              "type": "abstract",
+            },
+          ],
+          "id": 43,
+          "kind": "constant_decl",
+          "loc": abstract const FOO: Int;,
+          "name": {
+            "id": 6,
+            "kind": "id",
+            "loc": FOO,
+            "text": "FOO",
+          },
+          "type": {
+            "id": 42,
+            "kind": "type_id",
+            "loc": Int,
+            "text": "Int",
+          },
+        },
+        "loc": abstract const FOO: Int;,
+        "name": "FOO",
+        "type": {
+          "kind": "ref",
+          "name": "Int",
+          "optional": false,
+        },
+        "value": undefined,
+      },
+    ],
+    "dependsOn": [],
+    "fields": [],
+    "functions": Map {
+      "getValue" => {
+        "ast": {
+          "attributes": [
+            {
+              "kind": "function_attribute",
+              "loc": override,
+              "type": "override",
+            },
+          ],
+          "id": 23,
+          "kind": "function_def",
+          "loc": override fun getValue(): Int {
+        return self.FOO;
+    },
+          "name": {
+            "id": 17,
+            "kind": "id",
+            "loc": getValue,
+            "text": "getValue",
+          },
+          "params": [],
+          "return": {
+            "id": 18,
+            "kind": "type_id",
+            "loc": Int,
+            "text": "Int",
+          },
+          "statements": [
+            {
+              "expression": {
+                "aggregate": {
+                  "id": 19,
+                  "kind": "id",
+                  "loc": self,
+                  "text": "self",
+                },
+                "field": {
+                  "id": 20,
+                  "kind": "id",
+                  "loc": FOO,
+                  "text": "FOO",
+                },
+                "id": 21,
+                "kind": "field_access",
+                "loc": self.FOO,
+              },
+              "id": 22,
+              "kind": "statement_return",
+              "loc": return self.FOO;,
+            },
+          ],
+        },
+        "isAbstract": false,
+        "isGetter": false,
+        "isInline": false,
+        "isMutating": true,
+        "isOverride": true,
+        "isVirtual": false,
+        "methodId": null,
+        "name": "getValue",
+        "origin": "user",
+        "params": [],
+        "returns": {
+          "kind": "ref",
+          "name": "Int",
+          "optional": false,
+        },
+        "self": {
+          "kind": "ref",
+          "name": "TraitB",
+          "optional": false,
+        },
+      },
+    },
+    "globalVariables": Set {},
+    "header": null,
+    "init": null,
+    "interfaces": [],
+    "kind": "trait",
+    "name": "TraitB",
+    "origin": "user",
+    "partialFieldCount": 0,
+    "receivers": [],
+    "signature": null,
+    "tlb": null,
+    "traits": [
+      {
+        "ast": {
+          "attributes": [],
+          "declarations": [
+            {
+              "attributes": [
+                {
+                  "loc": abstract,
+                  "type": "abstract",
+                },
+              ],
+              "id": 8,
+              "kind": "constant_decl",
+              "loc": abstract const FOO: Int;,
+              "name": {
+                "id": 6,
+                "kind": "id",
+                "loc": FOO,
+                "text": "FOO",
+              },
+              "type": {
+                "id": 7,
+                "kind": "type_id",
+                "loc": Int,
+                "text": "Int",
+              },
+            },
+            {
+              "attributes": [
+                {
+                  "kind": "function_attribute",
+                  "loc": virtual,
+                  "type": "virtual",
+                },
+              ],
+              "id": 13,
+              "kind": "function_def",
+              "loc": virtual fun getValue(): Int {
+        return 10;
+    },
+              "name": {
+                "id": 9,
+                "kind": "id",
+                "loc": getValue,
+                "text": "getValue",
+              },
+              "params": [],
+              "return": {
+                "id": 10,
+                "kind": "type_id",
+                "loc": Int,
+                "text": "Int",
+              },
+              "statements": [
+                {
+                  "expression": {
+                    "base": 10,
+                    "id": 11,
+                    "kind": "number",
+                    "loc": 10,
+                    "value": 10n,
+                  },
+                  "id": 12,
+                  "kind": "statement_return",
+                  "loc": return 10;,
+                },
+              ],
+            },
+          ],
+          "id": 14,
+          "kind": "trait",
+          "loc": trait TraitA {
+    abstract const FOO: Int;
+    virtual fun getValue(): Int {
+        return 10;
+    }
+},
+          "name": {
+            "id": 5,
+            "kind": "id",
+            "loc": TraitA,
+            "text": "TraitA",
+          },
+          "traits": [],
+        },
+        "constants": [
+          {
+            "ast": {
+              "attributes": [
+                {
+                  "loc": abstract,
+                  "type": "abstract",
+                },
+              ],
+              "id": 8,
+              "kind": "constant_decl",
+              "loc": abstract const FOO: Int;,
+              "name": {
+                "id": 6,
+                "kind": "id",
+                "loc": FOO,
+                "text": "FOO",
+              },
+              "type": {
+                "id": 7,
+                "kind": "type_id",
+                "loc": Int,
+                "text": "Int",
+              },
+            },
+            "loc": abstract const FOO: Int;,
+            "name": "FOO",
+            "type": {
+              "kind": "ref",
+              "name": "Int",
+              "optional": false,
+            },
+            "value": undefined,
+          },
+        ],
+        "dependsOn": [],
+        "fields": [],
+        "functions": Map {
+          "getValue" => {
+            "ast": {
+              "attributes": [
+                {
+                  "kind": "function_attribute",
+                  "loc": virtual,
+                  "type": "virtual",
+                },
+              ],
+              "id": 13,
+              "kind": "function_def",
+              "loc": virtual fun getValue(): Int {
+        return 10;
+    },
+              "name": {
+                "id": 9,
+                "kind": "id",
+                "loc": getValue,
+                "text": "getValue",
+              },
+              "params": [],
+              "return": {
+                "id": 10,
+                "kind": "type_id",
+                "loc": Int,
+                "text": "Int",
+              },
+              "statements": [
+                {
+                  "expression": {
+                    "base": 10,
+                    "id": 11,
+                    "kind": "number",
+                    "loc": 10,
+                    "value": 10n,
+                  },
+                  "id": 12,
+                  "kind": "statement_return",
+                  "loc": return 10;,
+                },
+              ],
+            },
+            "isAbstract": false,
+            "isGetter": false,
+            "isInline": false,
+            "isMutating": true,
+            "isOverride": false,
+            "isVirtual": true,
+            "methodId": null,
+            "name": "getValue",
+            "origin": "user",
+            "params": [],
+            "returns": {
+              "kind": "ref",
+              "name": "Int",
+              "optional": false,
+            },
+            "self": {
+              "kind": "ref",
+              "name": "TraitA",
+              "optional": false,
+            },
+          },
+        },
+        "globalVariables": Set {},
+        "header": null,
+        "init": null,
+        "interfaces": [],
+        "kind": "trait",
+        "name": "TraitA",
+        "origin": "user",
+        "partialFieldCount": 0,
+        "receivers": [],
+        "signature": null,
+        "tlb": null,
+        "traits": [],
+        "uid": 39380,
+      },
+    ],
+    "uid": 43447,
+  },
+  {
+    "ast": {
+      "attributes": [],
+      "declarations": [
+        {
+          "attributes": [
+            {
+              "loc": override,
+              "type": "override",
+            },
+          ],
+          "id": 30,
+          "initializer": {
+            "base": 10,
+            "id": 29,
+            "kind": "number",
+            "loc": 10,
+            "value": 10n,
+          },
+          "kind": "constant_def",
+          "loc": override const FOO: Int = 10;,
+          "name": {
+            "id": 27,
+            "kind": "id",
+            "loc": FOO,
+            "text": "FOO",
+          },
+          "type": {
+            "id": 28,
+            "kind": "type_id",
+            "loc": Int,
+            "text": "Int",
+          },
+        },
+        {
+          "id": 33,
+          "kind": "receiver",
+          "loc": receive() {
+        // nothing
+    },
+          "selector": {
+            "id": 32,
+            "kind": "internal",
+            "loc": receive,
+            "subKind": {
+              "id": 31,
+              "kind": "fallback",
+            },
+          },
+          "statements": [],
+        },
+      ],
+      "id": 34,
+      "kind": "contract",
+      "loc": contract C with TraitB {
+    override const FOO: Int = 10;
+
+    receive() {
+        // nothing
+    }
+},
+      "name": {
+        "id": 25,
+        "kind": "id",
+        "loc": C,
+        "text": "C",
+      },
+      "params": undefined,
+      "traits": [
+        {
+          "id": 26,
+          "kind": "id",
+          "loc": TraitB,
+          "text": "TraitB",
+        },
+      ],
+    },
+    "constants": [
+      {
+        "ast": {
+          "attributes": [
+            {
+              "loc": override,
+              "type": "override",
+            },
+          ],
+          "id": 30,
+          "initializer": {
+            "base": 10,
+            "id": 29,
+            "kind": "number",
+            "loc": 10,
+            "value": 10n,
+          },
+          "kind": "constant_def",
+          "loc": override const FOO: Int = 10;,
+          "name": {
+            "id": 27,
+            "kind": "id",
+            "loc": FOO,
+            "text": "FOO",
+          },
+          "type": {
+            "id": 28,
+            "kind": "type_id",
+            "loc": Int,
+            "text": "Int",
+          },
+        },
+        "loc": override const FOO: Int = 10;,
+        "name": "FOO",
+        "type": {
+          "kind": "ref",
+          "name": "Int",
+          "optional": false,
+        },
+        "value": undefined,
+      },
+    ],
+    "dependsOn": [],
+    "fields": [],
+    "functions": Map {
+      "getValue" => {
+        "ast": {
+          "attributes": [
+            {
+              "kind": "function_attribute",
+              "loc": override,
+              "type": "override",
+            },
+          ],
+          "id": 41,
+          "kind": "function_def",
+          "loc": override fun getValue(): Int {
+        return self.FOO;
+    },
+          "name": {
+            "id": 17,
+            "kind": "id",
+            "loc": getValue,
+            "text": "getValue",
+          },
+          "params": [],
+          "return": {
+            "id": 37,
+            "kind": "type_id",
+            "loc": Int,
+            "text": "Int",
+          },
+          "statements": [
+            {
+              "expression": {
+                "aggregate": {
+                  "id": 38,
+                  "kind": "id",
+                  "loc": self,
+                  "text": "self",
+                },
+                "field": {
+                  "id": 20,
+                  "kind": "id",
+                  "loc": FOO,
+                  "text": "FOO",
+                },
+                "id": 39,
+                "kind": "field_access",
+                "loc": self.FOO,
+              },
+              "id": 40,
+              "kind": "statement_return",
+              "loc": return self.FOO;,
+            },
+          ],
+        },
+        "isAbstract": false,
+        "isGetter": false,
+        "isInline": false,
+        "isMutating": true,
+        "isOverride": true,
+        "isVirtual": false,
+        "methodId": null,
+        "name": "getValue",
+        "origin": "user",
+        "params": [],
+        "returns": {
+          "kind": "ref",
+          "name": "Int",
+          "optional": false,
+        },
+        "self": {
+          "kind": "ref",
+          "name": "C",
+          "optional": false,
+        },
+      },
+    },
+    "globalVariables": Set {},
+    "header": null,
+    "init": {
+      "ast": {
+        "id": 36,
+        "kind": "contract_init",
+        "loc": contract C with TraitB {
+    override const FOO: Int = 10;
+
+    receive() {
+        // nothing
+    }
+},
+        "params": [],
+        "statements": [],
+      },
+      "kind": "init-function",
+      "params": [],
+    },
+    "interfaces": [],
+    "kind": "contract",
+    "name": "C",
+    "origin": "user",
+    "partialFieldCount": 0,
+    "receivers": [
+      {
+        "ast": {
+          "id": 33,
+          "kind": "receiver",
+          "loc": receive() {
+        // nothing
+    },
+          "selector": {
+            "id": 32,
+            "kind": "internal",
+            "loc": receive,
+            "subKind": {
+              "id": 31,
+              "kind": "fallback",
+            },
+          },
+          "statements": [],
+        },
+        "effects": Set {},
+        "selector": {
+          "kind": "internal-empty",
+        },
+      },
+    ],
+    "signature": "C{}",
+    "tlb": "_  = C",
+    "traits": [
+      {
+        "ast": {
+          "attributes": [],
+          "declarations": [],
+          "id": 4,
+          "kind": "trait",
+          "loc": trait BaseTrait {},
+          "name": {
+            "id": 3,
+            "kind": "id",
+            "loc": BaseTrait,
+            "text": "BaseTrait",
+          },
+          "traits": [],
+        },
+        "constants": [],
+        "dependsOn": [],
+        "fields": [],
+        "functions": Map {},
+        "globalVariables": Set {},
+        "header": null,
+        "init": null,
+        "interfaces": [],
+        "kind": "trait",
+        "name": "BaseTrait",
+        "origin": "user",
+        "partialFieldCount": 0,
+        "receivers": [],
+        "signature": null,
+        "tlb": null,
+        "traits": [],
+        "uid": 1020,
+      },
+      {
+        "ast": {
+          "attributes": [],
+          "declarations": [
+            {
+              "attributes": [
+                {
+                  "kind": "function_attribute",
+                  "loc": override,
+                  "type": "override",
+                },
+              ],
+              "id": 23,
+              "kind": "function_def",
+              "loc": override fun getValue(): Int {
+        return self.FOO;
+    },
+              "name": {
+                "id": 17,
+                "kind": "id",
+                "loc": getValue,
+                "text": "getValue",
+              },
+              "params": [],
+              "return": {
+                "id": 18,
+                "kind": "type_id",
+                "loc": Int,
+                "text": "Int",
+              },
+              "statements": [
+                {
+                  "expression": {
+                    "aggregate": {
+                      "id": 19,
+                      "kind": "id",
+                      "loc": self,
+                      "text": "self",
+                    },
+                    "field": {
+                      "id": 20,
+                      "kind": "id",
+                      "loc": FOO,
+                      "text": "FOO",
+                    },
+                    "id": 21,
+                    "kind": "field_access",
+                    "loc": self.FOO,
+                  },
+                  "id": 22,
+                  "kind": "statement_return",
+                  "loc": return self.FOO;,
+                },
+              ],
+            },
+          ],
+          "id": 24,
+          "kind": "trait",
+          "loc": trait TraitB with TraitA {
+    override fun getValue(): Int {
+        return self.FOO;
+    }
+},
+          "name": {
+            "id": 15,
+            "kind": "id",
+            "loc": TraitB,
+            "text": "TraitB",
+          },
+          "traits": [
+            {
+              "id": 16,
+              "kind": "id",
+              "loc": TraitA,
+              "text": "TraitA",
+            },
+          ],
+        },
+        "constants": [
+          {
+            "ast": {
+              "attributes": [
+                {
+                  "loc": abstract,
+                  "type": "abstract",
+                },
+              ],
+              "id": 43,
+              "kind": "constant_decl",
+              "loc": abstract const FOO: Int;,
+              "name": {
+                "id": 6,
+                "kind": "id",
+                "loc": FOO,
+                "text": "FOO",
+              },
+              "type": {
+                "id": 42,
+                "kind": "type_id",
+                "loc": Int,
+                "text": "Int",
+              },
+            },
+            "loc": abstract const FOO: Int;,
+            "name": "FOO",
+            "type": {
+              "kind": "ref",
+              "name": "Int",
+              "optional": false,
+            },
+            "value": undefined,
+          },
+        ],
+        "dependsOn": [],
+        "fields": [],
+        "functions": Map {
+          "getValue" => {
+            "ast": {
+              "attributes": [
+                {
+                  "kind": "function_attribute",
+                  "loc": override,
+                  "type": "override",
+                },
+              ],
+              "id": 23,
+              "kind": "function_def",
+              "loc": override fun getValue(): Int {
+        return self.FOO;
+    },
+              "name": {
+                "id": 17,
+                "kind": "id",
+                "loc": getValue,
+                "text": "getValue",
+              },
+              "params": [],
+              "return": {
+                "id": 18,
+                "kind": "type_id",
+                "loc": Int,
+                "text": "Int",
+              },
+              "statements": [
+                {
+                  "expression": {
+                    "aggregate": {
+                      "id": 19,
+                      "kind": "id",
+                      "loc": self,
+                      "text": "self",
+                    },
+                    "field": {
+                      "id": 20,
+                      "kind": "id",
+                      "loc": FOO,
+                      "text": "FOO",
+                    },
+                    "id": 21,
+                    "kind": "field_access",
+                    "loc": self.FOO,
+                  },
+                  "id": 22,
+                  "kind": "statement_return",
+                  "loc": return self.FOO;,
+                },
+              ],
+            },
+            "isAbstract": false,
+            "isGetter": false,
+            "isInline": false,
+            "isMutating": true,
+            "isOverride": true,
+            "isVirtual": false,
+            "methodId": null,
+            "name": "getValue",
+            "origin": "user",
+            "params": [],
+            "returns": {
+              "kind": "ref",
+              "name": "Int",
+              "optional": false,
+            },
+            "self": {
+              "kind": "ref",
+              "name": "TraitB",
+              "optional": false,
+            },
+          },
+        },
+        "globalVariables": Set {},
+        "header": null,
+        "init": null,
+        "interfaces": [],
+        "kind": "trait",
+        "name": "TraitB",
+        "origin": "user",
+        "partialFieldCount": 0,
+        "receivers": [],
+        "signature": null,
+        "tlb": null,
+        "traits": [
+          {
+            "ast": {
+              "attributes": [],
+              "declarations": [
+                {
+                  "attributes": [
+                    {
+                      "loc": abstract,
+                      "type": "abstract",
+                    },
+                  ],
+                  "id": 8,
+                  "kind": "constant_decl",
+                  "loc": abstract const FOO: Int;,
+                  "name": {
+                    "id": 6,
+                    "kind": "id",
+                    "loc": FOO,
+                    "text": "FOO",
+                  },
+                  "type": {
+                    "id": 7,
+                    "kind": "type_id",
+                    "loc": Int,
+                    "text": "Int",
+                  },
+                },
+                {
+                  "attributes": [
+                    {
+                      "kind": "function_attribute",
+                      "loc": virtual,
+                      "type": "virtual",
+                    },
+                  ],
+                  "id": 13,
+                  "kind": "function_def",
+                  "loc": virtual fun getValue(): Int {
+        return 10;
+    },
+                  "name": {
+                    "id": 9,
+                    "kind": "id",
+                    "loc": getValue,
+                    "text": "getValue",
+                  },
+                  "params": [],
+                  "return": {
+                    "id": 10,
+                    "kind": "type_id",
+                    "loc": Int,
+                    "text": "Int",
+                  },
+                  "statements": [
+                    {
+                      "expression": {
+                        "base": 10,
+                        "id": 11,
+                        "kind": "number",
+                        "loc": 10,
+                        "value": 10n,
+                      },
+                      "id": 12,
+                      "kind": "statement_return",
+                      "loc": return 10;,
+                    },
+                  ],
+                },
+              ],
+              "id": 14,
+              "kind": "trait",
+              "loc": trait TraitA {
+    abstract const FOO: Int;
+    virtual fun getValue(): Int {
+        return 10;
+    }
+},
+              "name": {
+                "id": 5,
+                "kind": "id",
+                "loc": TraitA,
+                "text": "TraitA",
+              },
+              "traits": [],
+            },
+            "constants": [
+              {
+                "ast": {
+                  "attributes": [
+                    {
+                      "loc": abstract,
+                      "type": "abstract",
+                    },
+                  ],
+                  "id": 8,
+                  "kind": "constant_decl",
+                  "loc": abstract const FOO: Int;,
+                  "name": {
+                    "id": 6,
+                    "kind": "id",
+                    "loc": FOO,
+                    "text": "FOO",
+                  },
+                  "type": {
+                    "id": 7,
+                    "kind": "type_id",
+                    "loc": Int,
+                    "text": "Int",
+                  },
+                },
+                "loc": abstract const FOO: Int;,
+                "name": "FOO",
+                "type": {
+                  "kind": "ref",
+                  "name": "Int",
+                  "optional": false,
+                },
+                "value": undefined,
+              },
+            ],
+            "dependsOn": [],
+            "fields": [],
+            "functions": Map {
+              "getValue" => {
+                "ast": {
+                  "attributes": [
+                    {
+                      "kind": "function_attribute",
+                      "loc": virtual,
+                      "type": "virtual",
+                    },
+                  ],
+                  "id": 13,
+                  "kind": "function_def",
+                  "loc": virtual fun getValue(): Int {
+        return 10;
+    },
+                  "name": {
+                    "id": 9,
+                    "kind": "id",
+                    "loc": getValue,
+                    "text": "getValue",
+                  },
+                  "params": [],
+                  "return": {
+                    "id": 10,
+                    "kind": "type_id",
+                    "loc": Int,
+                    "text": "Int",
+                  },
+                  "statements": [
+                    {
+                      "expression": {
+                        "base": 10,
+                        "id": 11,
+                        "kind": "number",
+                        "loc": 10,
+                        "value": 10n,
+                      },
+                      "id": 12,
+                      "kind": "statement_return",
+                      "loc": return 10;,
+                    },
+                  ],
+                },
+                "isAbstract": false,
+                "isGetter": false,
+                "isInline": false,
+                "isMutating": true,
+                "isOverride": false,
+                "isVirtual": true,
+                "methodId": null,
+                "name": "getValue",
+                "origin": "user",
+                "params": [],
+                "returns": {
+                  "kind": "ref",
+                  "name": "Int",
+                  "optional": false,
+                },
+                "self": {
+                  "kind": "ref",
+                  "name": "TraitA",
+                  "optional": false,
+                },
+              },
+            },
+            "globalVariables": Set {},
+            "header": null,
+            "init": null,
+            "interfaces": [],
+            "kind": "trait",
+            "name": "TraitA",
+            "origin": "user",
+            "partialFieldCount": 0,
+            "receivers": [],
+            "signature": null,
+            "tlb": null,
+            "traits": [],
+            "uid": 39380,
+          },
+        ],
+        "uid": 43447,
+      },
+      {
+        "ast": {
+          "attributes": [],
+          "declarations": [
+            {
+              "attributes": [
+                {
+                  "loc": abstract,
+                  "type": "abstract",
+                },
+              ],
+              "id": 8,
+              "kind": "constant_decl",
+              "loc": abstract const FOO: Int;,
+              "name": {
+                "id": 6,
+                "kind": "id",
+                "loc": FOO,
+                "text": "FOO",
+              },
+              "type": {
+                "id": 7,
+                "kind": "type_id",
+                "loc": Int,
+                "text": "Int",
+              },
+            },
+            {
+              "attributes": [
+                {
+                  "kind": "function_attribute",
+                  "loc": virtual,
+                  "type": "virtual",
+                },
+              ],
+              "id": 13,
+              "kind": "function_def",
+              "loc": virtual fun getValue(): Int {
+        return 10;
+    },
+              "name": {
+                "id": 9,
+                "kind": "id",
+                "loc": getValue,
+                "text": "getValue",
+              },
+              "params": [],
+              "return": {
+                "id": 10,
+                "kind": "type_id",
+                "loc": Int,
+                "text": "Int",
+              },
+              "statements": [
+                {
+                  "expression": {
+                    "base": 10,
+                    "id": 11,
+                    "kind": "number",
+                    "loc": 10,
+                    "value": 10n,
+                  },
+                  "id": 12,
+                  "kind": "statement_return",
+                  "loc": return 10;,
+                },
+              ],
+            },
+          ],
+          "id": 14,
+          "kind": "trait",
+          "loc": trait TraitA {
+    abstract const FOO: Int;
+    virtual fun getValue(): Int {
+        return 10;
+    }
+},
+          "name": {
+            "id": 5,
+            "kind": "id",
+            "loc": TraitA,
+            "text": "TraitA",
+          },
+          "traits": [],
+        },
+        "constants": [
+          {
+            "ast": {
+              "attributes": [
+                {
+                  "loc": abstract,
+                  "type": "abstract",
+                },
+              ],
+              "id": 8,
+              "kind": "constant_decl",
+              "loc": abstract const FOO: Int;,
+              "name": {
+                "id": 6,
+                "kind": "id",
+                "loc": FOO,
+                "text": "FOO",
+              },
+              "type": {
+                "id": 7,
+                "kind": "type_id",
+                "loc": Int,
+                "text": "Int",
+              },
+            },
+            "loc": abstract const FOO: Int;,
+            "name": "FOO",
+            "type": {
+              "kind": "ref",
+              "name": "Int",
+              "optional": false,
+            },
+            "value": undefined,
+          },
+        ],
+        "dependsOn": [],
+        "fields": [],
+        "functions": Map {
+          "getValue" => {
+            "ast": {
+              "attributes": [
+                {
+                  "kind": "function_attribute",
+                  "loc": virtual,
+                  "type": "virtual",
+                },
+              ],
+              "id": 13,
+              "kind": "function_def",
+              "loc": virtual fun getValue(): Int {
+        return 10;
+    },
+              "name": {
+                "id": 9,
+                "kind": "id",
+                "loc": getValue,
+                "text": "getValue",
+              },
+              "params": [],
+              "return": {
+                "id": 10,
+                "kind": "type_id",
+                "loc": Int,
+                "text": "Int",
+              },
+              "statements": [
+                {
+                  "expression": {
+                    "base": 10,
+                    "id": 11,
+                    "kind": "number",
+                    "loc": 10,
+                    "value": 10n,
+                  },
+                  "id": 12,
+                  "kind": "statement_return",
+                  "loc": return 10;,
+                },
+              ],
+            },
+            "isAbstract": false,
+            "isGetter": false,
+            "isInline": false,
+            "isMutating": true,
+            "isOverride": false,
+            "isVirtual": true,
+            "methodId": null,
+            "name": "getValue",
+            "origin": "user",
+            "params": [],
+            "returns": {
+              "kind": "ref",
+              "name": "Int",
+              "optional": false,
+            },
+            "self": {
+              "kind": "ref",
+              "name": "TraitA",
+              "optional": false,
+            },
+          },
+        },
+        "globalVariables": Set {},
+        "header": null,
+        "init": null,
+        "interfaces": [],
+        "kind": "trait",
+        "name": "TraitA",
+        "origin": "user",
+        "partialFieldCount": 0,
+        "receivers": [],
+        "signature": null,
+        "tlb": null,
+        "traits": [],
+        "uid": 39380,
+      },
+    ],
+    "uid": 30887,
+  },
+]
+`;
+
+exports[`resolveDescriptors should resolve descriptors for nested-trait-with-abstract-constant 2`] = `[]`;
+
+exports[`resolveDescriptors should resolve descriptors for nested-trait-with-abstract-method 1`] = `
+[
+  {
+    "ast": {
+      "id": 2,
+      "kind": "primitive_type_decl",
+      "loc": primitive Int;,
+      "name": {
+        "id": 1,
+        "kind": "id",
+        "loc": Int,
+        "text": "Int",
+      },
+    },
+    "constants": [],
+    "dependsOn": [],
+    "fields": [],
+    "functions": Map {},
+    "globalVariables": Set {},
+    "header": null,
+    "init": null,
+    "interfaces": [],
+    "kind": "primitive_type_decl",
+    "name": "Int",
+    "origin": "user",
+    "partialFieldCount": 0,
+    "receivers": [],
+    "signature": null,
+    "tlb": null,
+    "traits": [],
+    "uid": 38154,
+  },
+  {
+    "ast": {
+      "attributes": [],
+      "declarations": [],
+      "id": 4,
+      "kind": "trait",
+      "loc": trait BaseTrait {},
+      "name": {
+        "id": 3,
+        "kind": "id",
+        "loc": BaseTrait,
+        "text": "BaseTrait",
+      },
+      "traits": [],
+    },
+    "constants": [],
+    "dependsOn": [],
+    "fields": [],
+    "functions": Map {},
+    "globalVariables": Set {},
+    "header": null,
+    "init": null,
+    "interfaces": [],
+    "kind": "trait",
+    "name": "BaseTrait",
+    "origin": "user",
+    "partialFieldCount": 0,
+    "receivers": [],
+    "signature": null,
+    "tlb": null,
+    "traits": [],
+    "uid": 1020,
+  },
+  {
+    "ast": {
+      "attributes": [],
+      "declarations": [
+        {
+          "attributes": [
+            {
+              "kind": "function_attribute",
+              "loc": abstract,
+              "type": "abstract",
+            },
+          ],
+          "id": 8,
+          "kind": "function_decl",
+          "loc": abstract fun compute(): Int;,
+          "name": {
+            "id": 6,
+            "kind": "id",
+            "loc": compute,
+            "text": "compute",
+          },
+          "params": [],
+          "return": {
+            "id": 7,
+            "kind": "type_id",
+            "loc": Int,
+            "text": "Int",
+          },
+        },
+        {
+          "attributes": [
+            {
+              "kind": "function_attribute",
+              "loc": virtual,
+              "type": "virtual",
+            },
+          ],
+          "id": 13,
+          "kind": "function_def",
+          "loc": virtual fun getValue(): Int {
+        return 10;
+    },
+          "name": {
+            "id": 9,
+            "kind": "id",
+            "loc": getValue,
+            "text": "getValue",
+          },
+          "params": [],
+          "return": {
+            "id": 10,
+            "kind": "type_id",
+            "loc": Int,
+            "text": "Int",
+          },
+          "statements": [
+            {
+              "expression": {
+                "base": 10,
+                "id": 11,
+                "kind": "number",
+                "loc": 10,
+                "value": 10n,
+              },
+              "id": 12,
+              "kind": "statement_return",
+              "loc": return 10;,
+            },
+          ],
+        },
+      ],
+      "id": 14,
+      "kind": "trait",
+      "loc": trait TraitA {
+    abstract fun compute(): Int;
+    virtual fun getValue(): Int {
+        return 10;
+    }
+},
+      "name": {
+        "id": 5,
+        "kind": "id",
+        "loc": TraitA,
+        "text": "TraitA",
+      },
+      "traits": [],
+    },
+    "constants": [],
+    "dependsOn": [],
+    "fields": [],
+    "functions": Map {
+      "compute" => {
+        "ast": {
+          "attributes": [
+            {
+              "kind": "function_attribute",
+              "loc": abstract,
+              "type": "abstract",
+            },
+          ],
+          "id": 8,
+          "kind": "function_decl",
+          "loc": abstract fun compute(): Int;,
+          "name": {
+            "id": 6,
+            "kind": "id",
+            "loc": compute,
+            "text": "compute",
+          },
+          "params": [],
+          "return": {
+            "id": 7,
+            "kind": "type_id",
+            "loc": Int,
+            "text": "Int",
+          },
+        },
+        "isAbstract": true,
+        "isGetter": false,
+        "isInline": false,
+        "isMutating": true,
+        "isOverride": false,
+        "isVirtual": false,
+        "methodId": null,
+        "name": "compute",
+        "origin": "user",
+        "params": [],
+        "returns": {
+          "kind": "ref",
+          "name": "Int",
+          "optional": false,
+        },
+        "self": {
+          "kind": "ref",
+          "name": "TraitA",
+          "optional": false,
+        },
+      },
+      "getValue" => {
+        "ast": {
+          "attributes": [
+            {
+              "kind": "function_attribute",
+              "loc": virtual,
+              "type": "virtual",
+            },
+          ],
+          "id": 13,
+          "kind": "function_def",
+          "loc": virtual fun getValue(): Int {
+        return 10;
+    },
+          "name": {
+            "id": 9,
+            "kind": "id",
+            "loc": getValue,
+            "text": "getValue",
+          },
+          "params": [],
+          "return": {
+            "id": 10,
+            "kind": "type_id",
+            "loc": Int,
+            "text": "Int",
+          },
+          "statements": [
+            {
+              "expression": {
+                "base": 10,
+                "id": 11,
+                "kind": "number",
+                "loc": 10,
+                "value": 10n,
+              },
+              "id": 12,
+              "kind": "statement_return",
+              "loc": return 10;,
+            },
+          ],
+        },
+        "isAbstract": false,
+        "isGetter": false,
+        "isInline": false,
+        "isMutating": true,
+        "isOverride": false,
+        "isVirtual": true,
+        "methodId": null,
+        "name": "getValue",
+        "origin": "user",
+        "params": [],
+        "returns": {
+          "kind": "ref",
+          "name": "Int",
+          "optional": false,
+        },
+        "self": {
+          "kind": "ref",
+          "name": "TraitA",
+          "optional": false,
+        },
+      },
+    },
+    "globalVariables": Set {},
+    "header": null,
+    "init": null,
+    "interfaces": [],
+    "kind": "trait",
+    "name": "TraitA",
+    "origin": "user",
+    "partialFieldCount": 0,
+    "receivers": [],
+    "signature": null,
+    "tlb": null,
+    "traits": [],
+    "uid": 39380,
+  },
+  {
+    "ast": {
+      "attributes": [],
+      "declarations": [
+        {
+          "attributes": [
+            {
+              "kind": "function_attribute",
+              "loc": override,
+              "type": "override",
+            },
+          ],
+          "id": 24,
+          "kind": "function_def",
+          "loc": override fun getValue(): Int {
+        return self.compute();
+    },
+          "name": {
+            "id": 17,
+            "kind": "id",
+            "loc": getValue,
+            "text": "getValue",
+          },
+          "params": [],
+          "return": {
+            "id": 18,
+            "kind": "type_id",
+            "loc": Int,
+            "text": "Int",
+          },
+          "statements": [
+            {
+              "expression": {
+                "args": [],
+                "id": 22,
+                "kind": "method_call",
+                "loc": self.compute(),
+                "method": {
+                  "id": 20,
+                  "kind": "id",
+                  "loc": compute,
+                  "text": "compute",
+                },
+                "self": {
+                  "id": 19,
+                  "kind": "id",
+                  "loc": self,
+                  "text": "self",
+                },
+              },
+              "id": 23,
+              "kind": "statement_return",
+              "loc": return self.compute();,
+            },
+          ],
+        },
+      ],
+      "id": 25,
+      "kind": "trait",
+      "loc": trait TraitB with TraitA {
+    override fun getValue(): Int {
+        return self.compute();
+    }
+},
+      "name": {
+        "id": 15,
+        "kind": "id",
+        "loc": TraitB,
+        "text": "TraitB",
+      },
+      "traits": [
+        {
+          "id": 16,
+          "kind": "id",
+          "loc": TraitA,
+          "text": "TraitA",
+        },
+      ],
+    },
+    "constants": [],
+    "dependsOn": [],
+    "fields": [],
+    "functions": Map {
+      "getValue" => {
+        "ast": {
+          "attributes": [
+            {
+              "kind": "function_attribute",
+              "loc": override,
+              "type": "override",
+            },
+          ],
+          "id": 24,
+          "kind": "function_def",
+          "loc": override fun getValue(): Int {
+        return self.compute();
+    },
+          "name": {
+            "id": 17,
+            "kind": "id",
+            "loc": getValue,
+            "text": "getValue",
+          },
+          "params": [],
+          "return": {
+            "id": 18,
+            "kind": "type_id",
+            "loc": Int,
+            "text": "Int",
+          },
+          "statements": [
+            {
+              "expression": {
+                "args": [],
+                "id": 22,
+                "kind": "method_call",
+                "loc": self.compute(),
+                "method": {
+                  "id": 20,
+                  "kind": "id",
+                  "loc": compute,
+                  "text": "compute",
+                },
+                "self": {
+                  "id": 19,
+                  "kind": "id",
+                  "loc": self,
+                  "text": "self",
+                },
+              },
+              "id": 23,
+              "kind": "statement_return",
+              "loc": return self.compute();,
+            },
+          ],
+        },
+        "isAbstract": false,
+        "isGetter": false,
+        "isInline": false,
+        "isMutating": true,
+        "isOverride": true,
+        "isVirtual": false,
+        "methodId": null,
+        "name": "getValue",
+        "origin": "user",
+        "params": [],
+        "returns": {
+          "kind": "ref",
+          "name": "Int",
+          "optional": false,
+        },
+        "self": {
+          "kind": "ref",
+          "name": "TraitB",
+          "optional": false,
+        },
+      },
+      "compute" => {
+        "ast": {
+          "attributes": [
+            {
+              "kind": "function_attribute",
+              "loc": abstract,
+              "type": "abstract",
+            },
+          ],
+          "id": 48,
+          "kind": "function_decl",
+          "loc": abstract fun compute(): Int;,
+          "name": {
+            "id": 6,
+            "kind": "id",
+            "loc": compute,
+            "text": "compute",
+          },
+          "params": [],
+          "return": {
+            "id": 47,
+            "kind": "type_id",
+            "loc": Int,
+            "text": "Int",
+          },
+        },
+        "isAbstract": true,
+        "isGetter": false,
+        "isInline": false,
+        "isMutating": true,
+        "isOverride": false,
+        "isVirtual": false,
+        "methodId": null,
+        "name": "compute",
+        "origin": "user",
+        "params": [],
+        "returns": {
+          "kind": "ref",
+          "name": "Int",
+          "optional": false,
+        },
+        "self": {
+          "kind": "ref",
+          "name": "TraitB",
+          "optional": false,
+        },
+      },
+    },
+    "globalVariables": Set {},
+    "header": null,
+    "init": null,
+    "interfaces": [],
+    "kind": "trait",
+    "name": "TraitB",
+    "origin": "user",
+    "partialFieldCount": 0,
+    "receivers": [],
+    "signature": null,
+    "tlb": null,
+    "traits": [
+      {
+        "ast": {
+          "attributes": [],
+          "declarations": [
+            {
+              "attributes": [
+                {
+                  "kind": "function_attribute",
+                  "loc": abstract,
+                  "type": "abstract",
+                },
+              ],
+              "id": 8,
+              "kind": "function_decl",
+              "loc": abstract fun compute(): Int;,
+              "name": {
+                "id": 6,
+                "kind": "id",
+                "loc": compute,
+                "text": "compute",
+              },
+              "params": [],
+              "return": {
+                "id": 7,
+                "kind": "type_id",
+                "loc": Int,
+                "text": "Int",
+              },
+            },
+            {
+              "attributes": [
+                {
+                  "kind": "function_attribute",
+                  "loc": virtual,
+                  "type": "virtual",
+                },
+              ],
+              "id": 13,
+              "kind": "function_def",
+              "loc": virtual fun getValue(): Int {
+        return 10;
+    },
+              "name": {
+                "id": 9,
+                "kind": "id",
+                "loc": getValue,
+                "text": "getValue",
+              },
+              "params": [],
+              "return": {
+                "id": 10,
+                "kind": "type_id",
+                "loc": Int,
+                "text": "Int",
+              },
+              "statements": [
+                {
+                  "expression": {
+                    "base": 10,
+                    "id": 11,
+                    "kind": "number",
+                    "loc": 10,
+                    "value": 10n,
+                  },
+                  "id": 12,
+                  "kind": "statement_return",
+                  "loc": return 10;,
+                },
+              ],
+            },
+          ],
+          "id": 14,
+          "kind": "trait",
+          "loc": trait TraitA {
+    abstract fun compute(): Int;
+    virtual fun getValue(): Int {
+        return 10;
+    }
+},
+          "name": {
+            "id": 5,
+            "kind": "id",
+            "loc": TraitA,
+            "text": "TraitA",
+          },
+          "traits": [],
+        },
+        "constants": [],
+        "dependsOn": [],
+        "fields": [],
+        "functions": Map {
+          "compute" => {
+            "ast": {
+              "attributes": [
+                {
+                  "kind": "function_attribute",
+                  "loc": abstract,
+                  "type": "abstract",
+                },
+              ],
+              "id": 8,
+              "kind": "function_decl",
+              "loc": abstract fun compute(): Int;,
+              "name": {
+                "id": 6,
+                "kind": "id",
+                "loc": compute,
+                "text": "compute",
+              },
+              "params": [],
+              "return": {
+                "id": 7,
+                "kind": "type_id",
+                "loc": Int,
+                "text": "Int",
+              },
+            },
+            "isAbstract": true,
+            "isGetter": false,
+            "isInline": false,
+            "isMutating": true,
+            "isOverride": false,
+            "isVirtual": false,
+            "methodId": null,
+            "name": "compute",
+            "origin": "user",
+            "params": [],
+            "returns": {
+              "kind": "ref",
+              "name": "Int",
+              "optional": false,
+            },
+            "self": {
+              "kind": "ref",
+              "name": "TraitA",
+              "optional": false,
+            },
+          },
+          "getValue" => {
+            "ast": {
+              "attributes": [
+                {
+                  "kind": "function_attribute",
+                  "loc": virtual,
+                  "type": "virtual",
+                },
+              ],
+              "id": 13,
+              "kind": "function_def",
+              "loc": virtual fun getValue(): Int {
+        return 10;
+    },
+              "name": {
+                "id": 9,
+                "kind": "id",
+                "loc": getValue,
+                "text": "getValue",
+              },
+              "params": [],
+              "return": {
+                "id": 10,
+                "kind": "type_id",
+                "loc": Int,
+                "text": "Int",
+              },
+              "statements": [
+                {
+                  "expression": {
+                    "base": 10,
+                    "id": 11,
+                    "kind": "number",
+                    "loc": 10,
+                    "value": 10n,
+                  },
+                  "id": 12,
+                  "kind": "statement_return",
+                  "loc": return 10;,
+                },
+              ],
+            },
+            "isAbstract": false,
+            "isGetter": false,
+            "isInline": false,
+            "isMutating": true,
+            "isOverride": false,
+            "isVirtual": true,
+            "methodId": null,
+            "name": "getValue",
+            "origin": "user",
+            "params": [],
+            "returns": {
+              "kind": "ref",
+              "name": "Int",
+              "optional": false,
+            },
+            "self": {
+              "kind": "ref",
+              "name": "TraitA",
+              "optional": false,
+            },
+          },
+        },
+        "globalVariables": Set {},
+        "header": null,
+        "init": null,
+        "interfaces": [],
+        "kind": "trait",
+        "name": "TraitA",
+        "origin": "user",
+        "partialFieldCount": 0,
+        "receivers": [],
+        "signature": null,
+        "tlb": null,
+        "traits": [],
+        "uid": 39380,
+      },
+    ],
+    "uid": 43447,
+  },
+  {
+    "ast": {
+      "attributes": [],
+      "declarations": [
+        {
+          "attributes": [
+            {
+              "kind": "function_attribute",
+              "loc": override,
+              "type": "override",
+            },
+          ],
+          "id": 35,
+          "kind": "function_def",
+          "loc": override fun compute(): Int {
+        return self.getValue();
+    },
+          "name": {
+            "id": 28,
+            "kind": "id",
+            "loc": compute,
+            "text": "compute",
+          },
+          "params": [],
+          "return": {
+            "id": 29,
+            "kind": "type_id",
+            "loc": Int,
+            "text": "Int",
+          },
+          "statements": [
+            {
+              "expression": {
+                "args": [],
+                "id": 33,
+                "kind": "method_call",
+                "loc": self.getValue(),
+                "method": {
+                  "id": 31,
+                  "kind": "id",
+                  "loc": getValue,
+                  "text": "getValue",
+                },
+                "self": {
+                  "id": 30,
+                  "kind": "id",
+                  "loc": self,
+                  "text": "self",
+                },
+              },
+              "id": 34,
+              "kind": "statement_return",
+              "loc": return self.getValue();,
+            },
+          ],
+        },
+        {
+          "id": 38,
+          "kind": "receiver",
+          "loc": receive() {
+        // nothing
+    },
+          "selector": {
+            "id": 37,
+            "kind": "internal",
+            "loc": receive,
+            "subKind": {
+              "id": 36,
+              "kind": "fallback",
+            },
+          },
+          "statements": [],
+        },
+      ],
+      "id": 39,
+      "kind": "contract",
+      "loc": contract C with TraitB {
+    override fun compute(): Int {
+        return self.getValue();
+    }
+
+    receive() {
+        // nothing
+    }
+},
+      "name": {
+        "id": 26,
+        "kind": "id",
+        "loc": C,
+        "text": "C",
+      },
+      "params": undefined,
+      "traits": [
+        {
+          "id": 27,
+          "kind": "id",
+          "loc": TraitB,
+          "text": "TraitB",
+        },
+      ],
+    },
+    "constants": [],
+    "dependsOn": [],
+    "fields": [],
+    "functions": Map {
+      "compute" => {
+        "ast": {
+          "attributes": [
+            {
+              "kind": "function_attribute",
+              "loc": override,
+              "type": "override",
+            },
+          ],
+          "id": 35,
+          "kind": "function_def",
+          "loc": override fun compute(): Int {
+        return self.getValue();
+    },
+          "name": {
+            "id": 28,
+            "kind": "id",
+            "loc": compute,
+            "text": "compute",
+          },
+          "params": [],
+          "return": {
+            "id": 29,
+            "kind": "type_id",
+            "loc": Int,
+            "text": "Int",
+          },
+          "statements": [
+            {
+              "expression": {
+                "args": [],
+                "id": 33,
+                "kind": "method_call",
+                "loc": self.getValue(),
+                "method": {
+                  "id": 31,
+                  "kind": "id",
+                  "loc": getValue,
+                  "text": "getValue",
+                },
+                "self": {
+                  "id": 30,
+                  "kind": "id",
+                  "loc": self,
+                  "text": "self",
+                },
+              },
+              "id": 34,
+              "kind": "statement_return",
+              "loc": return self.getValue();,
+            },
+          ],
+        },
+        "isAbstract": false,
+        "isGetter": false,
+        "isInline": false,
+        "isMutating": true,
+        "isOverride": true,
+        "isVirtual": false,
+        "methodId": null,
+        "name": "compute",
+        "origin": "user",
+        "params": [],
+        "returns": {
+          "kind": "ref",
+          "name": "Int",
+          "optional": false,
+        },
+        "self": {
+          "kind": "ref",
+          "name": "C",
+          "optional": false,
+        },
+      },
+      "getValue" => {
+        "ast": {
+          "attributes": [
+            {
+              "kind": "function_attribute",
+              "loc": override,
+              "type": "override",
+            },
+          ],
+          "id": 46,
+          "kind": "function_def",
+          "loc": override fun getValue(): Int {
+        return self.compute();
+    },
+          "name": {
+            "id": 17,
+            "kind": "id",
+            "loc": getValue,
+            "text": "getValue",
+          },
+          "params": [],
+          "return": {
+            "id": 42,
+            "kind": "type_id",
+            "loc": Int,
+            "text": "Int",
+          },
+          "statements": [
+            {
+              "expression": {
+                "args": [],
+                "id": 44,
+                "kind": "method_call",
+                "loc": self.compute(),
+                "method": {
+                  "id": 20,
+                  "kind": "id",
+                  "loc": compute,
+                  "text": "compute",
+                },
+                "self": {
+                  "id": 43,
+                  "kind": "id",
+                  "loc": self,
+                  "text": "self",
+                },
+              },
+              "id": 45,
+              "kind": "statement_return",
+              "loc": return self.compute();,
+            },
+          ],
+        },
+        "isAbstract": false,
+        "isGetter": false,
+        "isInline": false,
+        "isMutating": true,
+        "isOverride": true,
+        "isVirtual": false,
+        "methodId": null,
+        "name": "getValue",
+        "origin": "user",
+        "params": [],
+        "returns": {
+          "kind": "ref",
+          "name": "Int",
+          "optional": false,
+        },
+        "self": {
+          "kind": "ref",
+          "name": "C",
+          "optional": false,
+        },
+      },
+    },
+    "globalVariables": Set {},
+    "header": null,
+    "init": {
+      "ast": {
+        "id": 41,
+        "kind": "contract_init",
+        "loc": contract C with TraitB {
+    override fun compute(): Int {
+        return self.getValue();
+    }
+
+    receive() {
+        // nothing
+    }
+},
+        "params": [],
+        "statements": [],
+      },
+      "kind": "init-function",
+      "params": [],
+    },
+    "interfaces": [],
+    "kind": "contract",
+    "name": "C",
+    "origin": "user",
+    "partialFieldCount": 0,
+    "receivers": [
+      {
+        "ast": {
+          "id": 38,
+          "kind": "receiver",
+          "loc": receive() {
+        // nothing
+    },
+          "selector": {
+            "id": 37,
+            "kind": "internal",
+            "loc": receive,
+            "subKind": {
+              "id": 36,
+              "kind": "fallback",
+            },
+          },
+          "statements": [],
+        },
+        "effects": Set {},
+        "selector": {
+          "kind": "internal-empty",
+        },
+      },
+    ],
+    "signature": "C{}",
+    "tlb": "_  = C",
+    "traits": [
+      {
+        "ast": {
+          "attributes": [],
+          "declarations": [],
+          "id": 4,
+          "kind": "trait",
+          "loc": trait BaseTrait {},
+          "name": {
+            "id": 3,
+            "kind": "id",
+            "loc": BaseTrait,
+            "text": "BaseTrait",
+          },
+          "traits": [],
+        },
+        "constants": [],
+        "dependsOn": [],
+        "fields": [],
+        "functions": Map {},
+        "globalVariables": Set {},
+        "header": null,
+        "init": null,
+        "interfaces": [],
+        "kind": "trait",
+        "name": "BaseTrait",
+        "origin": "user",
+        "partialFieldCount": 0,
+        "receivers": [],
+        "signature": null,
+        "tlb": null,
+        "traits": [],
+        "uid": 1020,
+      },
+      {
+        "ast": {
+          "attributes": [],
+          "declarations": [
+            {
+              "attributes": [
+                {
+                  "kind": "function_attribute",
+                  "loc": override,
+                  "type": "override",
+                },
+              ],
+              "id": 24,
+              "kind": "function_def",
+              "loc": override fun getValue(): Int {
+        return self.compute();
+    },
+              "name": {
+                "id": 17,
+                "kind": "id",
+                "loc": getValue,
+                "text": "getValue",
+              },
+              "params": [],
+              "return": {
+                "id": 18,
+                "kind": "type_id",
+                "loc": Int,
+                "text": "Int",
+              },
+              "statements": [
+                {
+                  "expression": {
+                    "args": [],
+                    "id": 22,
+                    "kind": "method_call",
+                    "loc": self.compute(),
+                    "method": {
+                      "id": 20,
+                      "kind": "id",
+                      "loc": compute,
+                      "text": "compute",
+                    },
+                    "self": {
+                      "id": 19,
+                      "kind": "id",
+                      "loc": self,
+                      "text": "self",
+                    },
+                  },
+                  "id": 23,
+                  "kind": "statement_return",
+                  "loc": return self.compute();,
+                },
+              ],
+            },
+          ],
+          "id": 25,
+          "kind": "trait",
+          "loc": trait TraitB with TraitA {
+    override fun getValue(): Int {
+        return self.compute();
+    }
+},
+          "name": {
+            "id": 15,
+            "kind": "id",
+            "loc": TraitB,
+            "text": "TraitB",
+          },
+          "traits": [
+            {
+              "id": 16,
+              "kind": "id",
+              "loc": TraitA,
+              "text": "TraitA",
+            },
+          ],
+        },
+        "constants": [],
+        "dependsOn": [],
+        "fields": [],
+        "functions": Map {
+          "getValue" => {
+            "ast": {
+              "attributes": [
+                {
+                  "kind": "function_attribute",
+                  "loc": override,
+                  "type": "override",
+                },
+              ],
+              "id": 24,
+              "kind": "function_def",
+              "loc": override fun getValue(): Int {
+        return self.compute();
+    },
+              "name": {
+                "id": 17,
+                "kind": "id",
+                "loc": getValue,
+                "text": "getValue",
+              },
+              "params": [],
+              "return": {
+                "id": 18,
+                "kind": "type_id",
+                "loc": Int,
+                "text": "Int",
+              },
+              "statements": [
+                {
+                  "expression": {
+                    "args": [],
+                    "id": 22,
+                    "kind": "method_call",
+                    "loc": self.compute(),
+                    "method": {
+                      "id": 20,
+                      "kind": "id",
+                      "loc": compute,
+                      "text": "compute",
+                    },
+                    "self": {
+                      "id": 19,
+                      "kind": "id",
+                      "loc": self,
+                      "text": "self",
+                    },
+                  },
+                  "id": 23,
+                  "kind": "statement_return",
+                  "loc": return self.compute();,
+                },
+              ],
+            },
+            "isAbstract": false,
+            "isGetter": false,
+            "isInline": false,
+            "isMutating": true,
+            "isOverride": true,
+            "isVirtual": false,
+            "methodId": null,
+            "name": "getValue",
+            "origin": "user",
+            "params": [],
+            "returns": {
+              "kind": "ref",
+              "name": "Int",
+              "optional": false,
+            },
+            "self": {
+              "kind": "ref",
+              "name": "TraitB",
+              "optional": false,
+            },
+          },
+          "compute" => {
+            "ast": {
+              "attributes": [
+                {
+                  "kind": "function_attribute",
+                  "loc": abstract,
+                  "type": "abstract",
+                },
+              ],
+              "id": 48,
+              "kind": "function_decl",
+              "loc": abstract fun compute(): Int;,
+              "name": {
+                "id": 6,
+                "kind": "id",
+                "loc": compute,
+                "text": "compute",
+              },
+              "params": [],
+              "return": {
+                "id": 47,
+                "kind": "type_id",
+                "loc": Int,
+                "text": "Int",
+              },
+            },
+            "isAbstract": true,
+            "isGetter": false,
+            "isInline": false,
+            "isMutating": true,
+            "isOverride": false,
+            "isVirtual": false,
+            "methodId": null,
+            "name": "compute",
+            "origin": "user",
+            "params": [],
+            "returns": {
+              "kind": "ref",
+              "name": "Int",
+              "optional": false,
+            },
+            "self": {
+              "kind": "ref",
+              "name": "TraitB",
+              "optional": false,
+            },
+          },
+        },
+        "globalVariables": Set {},
+        "header": null,
+        "init": null,
+        "interfaces": [],
+        "kind": "trait",
+        "name": "TraitB",
+        "origin": "user",
+        "partialFieldCount": 0,
+        "receivers": [],
+        "signature": null,
+        "tlb": null,
+        "traits": [
+          {
+            "ast": {
+              "attributes": [],
+              "declarations": [
+                {
+                  "attributes": [
+                    {
+                      "kind": "function_attribute",
+                      "loc": abstract,
+                      "type": "abstract",
+                    },
+                  ],
+                  "id": 8,
+                  "kind": "function_decl",
+                  "loc": abstract fun compute(): Int;,
+                  "name": {
+                    "id": 6,
+                    "kind": "id",
+                    "loc": compute,
+                    "text": "compute",
+                  },
+                  "params": [],
+                  "return": {
+                    "id": 7,
+                    "kind": "type_id",
+                    "loc": Int,
+                    "text": "Int",
+                  },
+                },
+                {
+                  "attributes": [
+                    {
+                      "kind": "function_attribute",
+                      "loc": virtual,
+                      "type": "virtual",
+                    },
+                  ],
+                  "id": 13,
+                  "kind": "function_def",
+                  "loc": virtual fun getValue(): Int {
+        return 10;
+    },
+                  "name": {
+                    "id": 9,
+                    "kind": "id",
+                    "loc": getValue,
+                    "text": "getValue",
+                  },
+                  "params": [],
+                  "return": {
+                    "id": 10,
+                    "kind": "type_id",
+                    "loc": Int,
+                    "text": "Int",
+                  },
+                  "statements": [
+                    {
+                      "expression": {
+                        "base": 10,
+                        "id": 11,
+                        "kind": "number",
+                        "loc": 10,
+                        "value": 10n,
+                      },
+                      "id": 12,
+                      "kind": "statement_return",
+                      "loc": return 10;,
+                    },
+                  ],
+                },
+              ],
+              "id": 14,
+              "kind": "trait",
+              "loc": trait TraitA {
+    abstract fun compute(): Int;
+    virtual fun getValue(): Int {
+        return 10;
+    }
+},
+              "name": {
+                "id": 5,
+                "kind": "id",
+                "loc": TraitA,
+                "text": "TraitA",
+              },
+              "traits": [],
+            },
+            "constants": [],
+            "dependsOn": [],
+            "fields": [],
+            "functions": Map {
+              "compute" => {
+                "ast": {
+                  "attributes": [
+                    {
+                      "kind": "function_attribute",
+                      "loc": abstract,
+                      "type": "abstract",
+                    },
+                  ],
+                  "id": 8,
+                  "kind": "function_decl",
+                  "loc": abstract fun compute(): Int;,
+                  "name": {
+                    "id": 6,
+                    "kind": "id",
+                    "loc": compute,
+                    "text": "compute",
+                  },
+                  "params": [],
+                  "return": {
+                    "id": 7,
+                    "kind": "type_id",
+                    "loc": Int,
+                    "text": "Int",
+                  },
+                },
+                "isAbstract": true,
+                "isGetter": false,
+                "isInline": false,
+                "isMutating": true,
+                "isOverride": false,
+                "isVirtual": false,
+                "methodId": null,
+                "name": "compute",
+                "origin": "user",
+                "params": [],
+                "returns": {
+                  "kind": "ref",
+                  "name": "Int",
+                  "optional": false,
+                },
+                "self": {
+                  "kind": "ref",
+                  "name": "TraitA",
+                  "optional": false,
+                },
+              },
+              "getValue" => {
+                "ast": {
+                  "attributes": [
+                    {
+                      "kind": "function_attribute",
+                      "loc": virtual,
+                      "type": "virtual",
+                    },
+                  ],
+                  "id": 13,
+                  "kind": "function_def",
+                  "loc": virtual fun getValue(): Int {
+        return 10;
+    },
+                  "name": {
+                    "id": 9,
+                    "kind": "id",
+                    "loc": getValue,
+                    "text": "getValue",
+                  },
+                  "params": [],
+                  "return": {
+                    "id": 10,
+                    "kind": "type_id",
+                    "loc": Int,
+                    "text": "Int",
+                  },
+                  "statements": [
+                    {
+                      "expression": {
+                        "base": 10,
+                        "id": 11,
+                        "kind": "number",
+                        "loc": 10,
+                        "value": 10n,
+                      },
+                      "id": 12,
+                      "kind": "statement_return",
+                      "loc": return 10;,
+                    },
+                  ],
+                },
+                "isAbstract": false,
+                "isGetter": false,
+                "isInline": false,
+                "isMutating": true,
+                "isOverride": false,
+                "isVirtual": true,
+                "methodId": null,
+                "name": "getValue",
+                "origin": "user",
+                "params": [],
+                "returns": {
+                  "kind": "ref",
+                  "name": "Int",
+                  "optional": false,
+                },
+                "self": {
+                  "kind": "ref",
+                  "name": "TraitA",
+                  "optional": false,
+                },
+              },
+            },
+            "globalVariables": Set {},
+            "header": null,
+            "init": null,
+            "interfaces": [],
+            "kind": "trait",
+            "name": "TraitA",
+            "origin": "user",
+            "partialFieldCount": 0,
+            "receivers": [],
+            "signature": null,
+            "tlb": null,
+            "traits": [],
+            "uid": 39380,
+          },
+        ],
+        "uid": 43447,
+      },
+      {
+        "ast": {
+          "attributes": [],
+          "declarations": [
+            {
+              "attributes": [
+                {
+                  "kind": "function_attribute",
+                  "loc": abstract,
+                  "type": "abstract",
+                },
+              ],
+              "id": 8,
+              "kind": "function_decl",
+              "loc": abstract fun compute(): Int;,
+              "name": {
+                "id": 6,
+                "kind": "id",
+                "loc": compute,
+                "text": "compute",
+              },
+              "params": [],
+              "return": {
+                "id": 7,
+                "kind": "type_id",
+                "loc": Int,
+                "text": "Int",
+              },
+            },
+            {
+              "attributes": [
+                {
+                  "kind": "function_attribute",
+                  "loc": virtual,
+                  "type": "virtual",
+                },
+              ],
+              "id": 13,
+              "kind": "function_def",
+              "loc": virtual fun getValue(): Int {
+        return 10;
+    },
+              "name": {
+                "id": 9,
+                "kind": "id",
+                "loc": getValue,
+                "text": "getValue",
+              },
+              "params": [],
+              "return": {
+                "id": 10,
+                "kind": "type_id",
+                "loc": Int,
+                "text": "Int",
+              },
+              "statements": [
+                {
+                  "expression": {
+                    "base": 10,
+                    "id": 11,
+                    "kind": "number",
+                    "loc": 10,
+                    "value": 10n,
+                  },
+                  "id": 12,
+                  "kind": "statement_return",
+                  "loc": return 10;,
+                },
+              ],
+            },
+          ],
+          "id": 14,
+          "kind": "trait",
+          "loc": trait TraitA {
+    abstract fun compute(): Int;
+    virtual fun getValue(): Int {
+        return 10;
+    }
+},
+          "name": {
+            "id": 5,
+            "kind": "id",
+            "loc": TraitA,
+            "text": "TraitA",
+          },
+          "traits": [],
+        },
+        "constants": [],
+        "dependsOn": [],
+        "fields": [],
+        "functions": Map {
+          "compute" => {
+            "ast": {
+              "attributes": [
+                {
+                  "kind": "function_attribute",
+                  "loc": abstract,
+                  "type": "abstract",
+                },
+              ],
+              "id": 8,
+              "kind": "function_decl",
+              "loc": abstract fun compute(): Int;,
+              "name": {
+                "id": 6,
+                "kind": "id",
+                "loc": compute,
+                "text": "compute",
+              },
+              "params": [],
+              "return": {
+                "id": 7,
+                "kind": "type_id",
+                "loc": Int,
+                "text": "Int",
+              },
+            },
+            "isAbstract": true,
+            "isGetter": false,
+            "isInline": false,
+            "isMutating": true,
+            "isOverride": false,
+            "isVirtual": false,
+            "methodId": null,
+            "name": "compute",
+            "origin": "user",
+            "params": [],
+            "returns": {
+              "kind": "ref",
+              "name": "Int",
+              "optional": false,
+            },
+            "self": {
+              "kind": "ref",
+              "name": "TraitA",
+              "optional": false,
+            },
+          },
+          "getValue" => {
+            "ast": {
+              "attributes": [
+                {
+                  "kind": "function_attribute",
+                  "loc": virtual,
+                  "type": "virtual",
+                },
+              ],
+              "id": 13,
+              "kind": "function_def",
+              "loc": virtual fun getValue(): Int {
+        return 10;
+    },
+              "name": {
+                "id": 9,
+                "kind": "id",
+                "loc": getValue,
+                "text": "getValue",
+              },
+              "params": [],
+              "return": {
+                "id": 10,
+                "kind": "type_id",
+                "loc": Int,
+                "text": "Int",
+              },
+              "statements": [
+                {
+                  "expression": {
+                    "base": 10,
+                    "id": 11,
+                    "kind": "number",
+                    "loc": 10,
+                    "value": 10n,
+                  },
+                  "id": 12,
+                  "kind": "statement_return",
+                  "loc": return 10;,
+                },
+              ],
+            },
+            "isAbstract": false,
+            "isGetter": false,
+            "isInline": false,
+            "isMutating": true,
+            "isOverride": false,
+            "isVirtual": true,
+            "methodId": null,
+            "name": "getValue",
+            "origin": "user",
+            "params": [],
+            "returns": {
+              "kind": "ref",
+              "name": "Int",
+              "optional": false,
+            },
+            "self": {
+              "kind": "ref",
+              "name": "TraitA",
+              "optional": false,
+            },
+          },
+        },
+        "globalVariables": Set {},
+        "header": null,
+        "init": null,
+        "interfaces": [],
+        "kind": "trait",
+        "name": "TraitA",
+        "origin": "user",
+        "partialFieldCount": 0,
+        "receivers": [],
+        "signature": null,
+        "tlb": null,
+        "traits": [],
+        "uid": 39380,
+      },
+    ],
+    "uid": 30887,
+  },
+]
+`;
+
+exports[`resolveDescriptors should resolve descriptors for nested-trait-with-abstract-method 2`] = `[]`;
 
 exports[`resolveDescriptors should resolve descriptors for override-const-map-valueas-keyas 1`] = `
 [

--- a/src/types/__snapshots__/resolveDescriptors.spec.ts.snap
+++ b/src/types/__snapshots__/resolveDescriptors.spec.ts.snap
@@ -190,7 +190,7 @@ exports[`resolveDescriptors should fail descriptors for contract-decl-remainder-
 `;
 
 exports[`resolveDescriptors should fail descriptors for contract-does-not-override-abstract-const 1`] = `
-"<unknown>:8:1: Trait "T" requires constant "Foo"
+"<unknown>:8:1: Missing implementation of abstract constant "Foo" declared in trait "T"
   7 | 
 > 8 | contract TestContract with T {
       ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -199,7 +199,7 @@ exports[`resolveDescriptors should fail descriptors for contract-does-not-overri
 `;
 
 exports[`resolveDescriptors should fail descriptors for contract-does-not-override-abstract-const-with-deep-inheritance 1`] = `
-"<unknown>:10:1: Trait "T" requires constant "Foo"
+"<unknown>:10:1: Missing implementation of abstract constant "Foo" declared in trait "T"
    9 | 
 > 10 | contract TestContract with T1 {
        ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -208,7 +208,7 @@ exports[`resolveDescriptors should fail descriptors for contract-does-not-overri
 `;
 
 exports[`resolveDescriptors should fail descriptors for contract-does-not-override-abstract-getter-with-deep inheritance 1`] = `
-"<unknown>:10:1: Trait "T" requires function "getter"
+"<unknown>:10:1: Missing implementation of abstract method "getter" declared in trait "T"
    9 | 
 > 10 | contract TestContract with T1 {
        ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/src/types/resolveDescriptors.ts
+++ b/src/types/resolveDescriptors.ts
@@ -1896,7 +1896,7 @@ export function resolveDescriptors(ctx: CompilerContext, Ast: FactoryAst) {
                     traitFunction.isAbstract
                 ) {
                     throwCompilationError(
-                        `Trait "${inheritedTrait.name}" requires function "${traitFunction.name}"`,
+                        `Missing implementation of abstract method "${traitFunction.name}" declared in trait "${inheritedTrait.name}"`,
                         contractOrTrait.ast.loc,
                     );
                 }
@@ -2004,7 +2004,7 @@ export function resolveDescriptors(ctx: CompilerContext, Ast: FactoryAst) {
                     )
                 ) {
                     throwCompilationError(
-                        `Trait "${inheritedTrait.name}" requires constant "${traitConstant.name}"`,
+                        `Missing implementation of abstract constant "${traitConstant.name}" declared in trait "${inheritedTrait.name}"`,
                         contractOrTrait.ast.loc,
                     );
                 }

--- a/src/types/resolveDescriptors.ts
+++ b/src/types/resolveDescriptors.ts
@@ -1890,7 +1890,11 @@ export function resolveDescriptors(ctx: CompilerContext, Ast: FactoryAst) {
                 const funInContractOrTrait = contractOrTrait.functions.get(
                     traitFunction.name,
                 );
-                if (!funInContractOrTrait && traitFunction.isAbstract) {
+                if (
+                    contractOrTrait.kind === "contract" &&
+                    !funInContractOrTrait &&
+                    traitFunction.isAbstract
+                ) {
                     throwCompilationError(
                         `Trait "${inheritedTrait.name}" requires function "${traitFunction.name}"`,
                         contractOrTrait.ast.loc,
@@ -1993,6 +1997,7 @@ export function resolveDescriptors(ctx: CompilerContext, Ast: FactoryAst) {
                     (v) => v.name === traitConstant.name,
                 );
                 if (
+                    contractOrTrait.kind === "contract" &&
                     !constInContractOrTrait &&
                     traitConstant.ast.attributes.find(
                         (v) => v.type === "abstract",

--- a/src/types/test-failed/contract-does-not-override-abstract-const-with-deep-inheritance.tact
+++ b/src/types/test-failed/contract-does-not-override-abstract-const-with-deep-inheritance.tact
@@ -1,0 +1,12 @@
+primitive Int;
+trait BaseTrait { }
+
+trait T {
+  abstract const Foo: Int;
+}
+
+trait T1 with T {}
+
+contract TestContract with T1 {
+  // does not override an abstract const
+}

--- a/src/types/test-failed/contract-does-not-override-abstract-getter-with-deep inheritance.tact
+++ b/src/types/test-failed/contract-does-not-override-abstract-getter-with-deep inheritance.tact
@@ -5,6 +5,8 @@ trait T {
   abstract get fun getter(): Int;
 }
 
-contract TestContract with T {
+trait T1 with T {}
+
+contract TestContract with T1 {
   // does not override an abstract getter
 }

--- a/src/types/test/nested-trait-with-abstract-constant.tact
+++ b/src/types/test/nested-trait-with-abstract-constant.tact
@@ -1,0 +1,23 @@
+primitive Int;
+trait BaseTrait {}
+
+trait TraitA {
+    abstract const FOO: Int;
+    virtual fun getValue(): Int {
+        return 10;
+    }
+}
+
+trait TraitB with TraitA {
+    override fun getValue(): Int {
+        return self.FOO;
+    }
+}
+
+contract C with TraitB {
+    override const FOO: Int = 10;
+
+    receive() {
+        // nothing
+    }
+}

--- a/src/types/test/nested-trait-with-abstract-method.tact
+++ b/src/types/test/nested-trait-with-abstract-method.tact
@@ -1,0 +1,25 @@
+primitive Int;
+trait BaseTrait {}
+
+trait TraitA {
+    abstract fun compute(): Int;
+    virtual fun getValue(): Int {
+        return 10;
+    }
+}
+
+trait TraitB with TraitA {
+    override fun getValue(): Int {
+        return self.compute();
+    }
+}
+
+contract C with TraitB {
+    override fun compute(): Int {
+        return self.getValue();
+    }
+
+    receive() {
+        // nothing
+    }
+}


### PR DESCRIPTION
## Issue

Closes #2630.

## Checklist

- [x] I have updated CHANGELOG.md
- [x] I have added tests to demonstrate the contribution is correctly implemented: this usually includes both positive and negative tests, showing the happy path(s) and featuring intentionally broken cases
