### PR TITLE
fix: allow emptyMap() as function argument for parameter of any map type

### DIFF
--- a/dev-docs/CHANGELOG.md
+++ b/dev-docs/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [fix] Compiler now doesn't require explicit re-declaration for abstract methods and fields in traits: PR [#3272](https://github.com/tact-lang/tact/pull/3272)
 - Compiler now allows `toCell()` and `toSlice()` methods on contract types: PR [#3274](https://github.com/tact-lang/tact/pull/3274)
 - Compiler now generates message loading in place for better performance: PR [#2993](https://github.com/tact-lang/tact/pull/2993)
+- Compiler now correctly handles `emptyMap()` as a function argument for parameters of any map type: PR [#3282](https://github.com/tact-lang/tact/pull/3282)
 
 ### Docs
 

--- a/src/abi/map.ts
+++ b/src/abi/map.ts
@@ -33,6 +33,10 @@ function checkMapType(
     value: string;
     valueAs: string | null;
 } {
+    if (self?.kind === "null") {
+        // allow `foo.deepEqual(emptyMap())`
+        return
+    }
     if (!self || self.kind !== "map") {
         throwCompilationError("expects a map as self argument", ref);
     }
@@ -511,6 +515,12 @@ export const MapFunctions: ReadonlyMap<string, AbiFunction> = new Map([
 
                 const [self, other] = args;
                 checkMapType(self, ref);
+
+                if (other?.kind === "null") {
+                    // allow `foo.deepEqual(emptyMap())`
+                    return { kind: "ref", name: "Bool", optional: false };
+                }
+
                 checkMapType(other, ref);
 
                 if (!isAssignable(self, other)) {

--- a/src/abi/map.ts
+++ b/src/abi/map.ts
@@ -35,7 +35,7 @@ function checkMapType(
 } {
     if (self?.kind === "null") {
         // allow `foo.deepEqual(emptyMap())`
-        return
+        return;
     }
     if (!self || self.kind !== "map") {
         throwCompilationError("expects a map as self argument", ref);

--- a/src/test/e2e-emulated/maps/emptyMap-as-argument.spec.ts
+++ b/src/test/e2e-emulated/maps/emptyMap-as-argument.spec.ts
@@ -1,0 +1,42 @@
+import { toNano } from "@ton/core";
+import { Blockchain } from "@ton/sandbox";
+import { Test } from "./output/emptyMap-as-argument_Test";
+import "@ton/test-utils";
+import { cached } from "@/test/utils/cache-state";
+
+const deployValue = toNano("1");
+
+const setup = async () => {
+    const blockchain = await Blockchain.create();
+    blockchain.verbosity.print = false;
+
+    const treasury = await blockchain.treasury("treasury");
+    const contract = blockchain.openContract(await Test.fromInit());
+
+    const deployResult = await contract.send(
+        treasury.getSender(),
+        { value: deployValue },
+        null,
+    );
+    expect(deployResult.transactions).toHaveTransaction({
+        from: treasury.address,
+        to: contract.address,
+        success: true,
+        deploy: true,
+    });
+
+    return {
+        blockchain,
+        treasury,
+        contract,
+    };
+};
+
+describe("emptyMap as argument", () => {
+    const state = cached(setup);
+
+    it("should return correctly result for emptyMap.deepEqual(emptyMap())", async () => {
+        const { contract } = await state.get();
+        expect(await contract.getF()).toEqual(true);
+    });
+});

--- a/src/test/e2e-emulated/maps/emptyMap-as-argument.tact
+++ b/src/test/e2e-emulated/maps/emptyMap-as-argument.tact
@@ -1,0 +1,8 @@
+contract Test() {
+    receive() {}
+    get fun f(): Bool {
+        let fizz: map<Int, Int> = emptyMap();
+
+        return fizz.deepEquals(emptyMap());
+    }
+}

--- a/src/types/stmts/emptyMap-as-argument.tact
+++ b/src/types/stmts/emptyMap-as-argument.tact
@@ -1,0 +1,8 @@
+contract C() {
+    receive() {}
+    get fun f(): Bool {
+        let fizz: map<Int, Int> = emptyMap();
+
+        return fizz.deepEquals(emptyMap());
+    }
+}


### PR DESCRIPTION
## Issue

Closes #2942.

## Checklist

- [x] I have updated CHANGELOG.md
- [x] I have added tests to demonstrate the contribution is correctly implemented: this usually includes both positive and negative tests, showing the happy path(s) and featuring intentionally broken cases
