### PR TITLE
fix: error message when key or value in map literal is out of serialization range

### DIFF
--- a/dev-docs/CHANGELOG.md
+++ b/dev-docs/CHANGELOG.md
@@ -26,6 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Language features
 
+- [fix] Better error message when an integer key or value in a map literal is out of its serialization range: PR [#3285](https://github.com/tact-lang/tact/pull/3285)
 - [fix] Balanced quotation in error messages for out-of-project-root imports: PR [#3242](https://github.com/tact-lang/tact/pull/3242)
 - [fix] Disallow self-inheritance for contracts and traits: PR [#3094](https://github.com/tact-lang/tact/pull/3094)
 - [fix] Added fixed-bytes support to bounced message size calculations: PR [#3129](https://github.com/tact-lang/tact/pull/3129)

--- a/src/generator/writers/writeExpression.ts
+++ b/src/generator/writers/writeExpression.ts
@@ -835,7 +835,7 @@ const writeMapLiteral =
     (node: Ast.MapLiteral) =>
     (_ctx: WriterContext): string => {
         throwCompilationError(
-            "Could not reduce map literal: it either uses run-time values or unsupported features like structs, cells or asm functions",
+            "Invalid map literal: it either uses run-time values or unsupported features like structs, cells or asm functions",
             node.loc,
         );
         // NB! Intentionally left here for when we can distinguish which Ast.Id are variables

--- a/src/generator/writers/writeExpression.ts
+++ b/src/generator/writers/writeExpression.ts
@@ -835,7 +835,7 @@ const writeMapLiteral =
     (node: Ast.MapLiteral) =>
     (_ctx: WriterContext): string => {
         throwCompilationError(
-            "Only constant map literals are supported",
+            "Could not reduce map literal: it either uses run-time values or unsupported features like structs, cells or asm functions",
             node.loc,
         );
         // NB! Intentionally left here for when we can distinguish which Ast.Id are variables

--- a/src/optimizer/interpreter.ts
+++ b/src/optimizer/interpreter.ts
@@ -86,24 +86,24 @@ const ensureMapIntKeyOrValRange = (
     const val = num.value;
     switch (intFormat.kind) {
         case "int":
-            {
-                if (
-                    minSignedInt(intFormat.bits) <= val &&
-                    val <= maxSignedInt(intFormat.bits)
-                )
-                    return num;
-                throwErrorConstEval(
-                    `integer '${prettyPrint(num)}' does not fit into ${intFormat.bits}-bit signed integer type`,
-                    num.loc,
-                );
+            if (
+                minSignedInt(intFormat.bits) <= val &&
+                val <= maxSignedInt(intFormat.bits)
+            ) {
+                return num;
             }
+            throwErrorConstEval(
+                `integer '${prettyPrint(num)}' does not fit into ${intFormat.bits}-bit signed integer type`,
+                num.loc,
+            );
             break;
         case "uint":
             if (
                 minUnsignedInt(intFormat.bits) <= val &&
                 val <= maxUnsignedInt(intFormat.bits)
-            )
+            ) {
                 return num;
+            }
             throwErrorConstEval(
                 `integer '${prettyPrint(num)}' does not fit into ${intFormat.bits}-bit unsigned integer type`,
                 num.loc,
@@ -113,8 +113,9 @@ const ensureMapIntKeyOrValRange = (
             if (
                 minVarInt(intFormat.length) <= val &&
                 val <= maxVarInt(intFormat.length)
-            )
+            ) {
                 return num;
+            }
             throwErrorConstEval(
                 `integer '${prettyPrint(num)}' does not fit into variable-length signed integer type with ${intFormat.length}-bit length`,
                 num.loc,
@@ -124,8 +125,9 @@ const ensureMapIntKeyOrValRange = (
             if (
                 minVarUint(intFormat.length) <= val &&
                 val <= maxVarUint(intFormat.length)
-            )
+            ) {
                 return num;
+            }
             throwErrorConstEval(
                 `integer '${prettyPrint(num)}' does not fit into variable-length unsigned integer type with ${intFormat.length}-bit length`,
                 num.loc,

--- a/src/test/compilation-failed/contracts/map-literal-int-key-out-of-range.tact
+++ b/src/test/compilation-failed/contracts/map-literal-int-key-out-of-range.tact
@@ -1,0 +1,8 @@
+contract C {
+    get fun test(): Int {
+        let m: map<Int as int8, Int> = map<Int as int8, Int> {
+            -129: 0,
+        };
+        return m.get(2)!!;
+    }
+}

--- a/src/test/compilation-failed/contracts/map-literal-int-val-out-of-range.tact
+++ b/src/test/compilation-failed/contracts/map-literal-int-val-out-of-range.tact
@@ -1,0 +1,8 @@
+contract C {
+    get fun test(): Int {
+        let m: map<Int, Int as int4> = map<Int, Int as int4> {
+            0: 8,
+        };
+        return m.get(2)!!;
+    }
+}

--- a/src/test/compilation-failed/contracts/map-literal-structs.tact
+++ b/src/test/compilation-failed/contracts/map-literal-structs.tact
@@ -1,3 +1,8 @@
+struct Foo {
+    x: Int;
+    y: Int;
+}
+
 contract MapLiteralStructs {
     get fun structs(): map<Int as uint16, Foo> {
         return map<Int as uint16, Foo> {

--- a/src/test/compilation-failed/contracts/map-literal-uint-key-out-of-range.tact
+++ b/src/test/compilation-failed/contracts/map-literal-uint-key-out-of-range.tact
@@ -1,0 +1,8 @@
+contract C {
+    get fun test(): Int {
+        let m: map<Int as uint1, Int> = map<Int as uint1, Int> {
+            2: 0,    // key 2 is out of range for uint1 (0..1)
+        };
+        return m.get(2)!!;
+    }
+}

--- a/src/test/compilation-failed/contracts/map-literal-uint-val-out-of-range.tact
+++ b/src/test/compilation-failed/contracts/map-literal-uint-val-out-of-range.tact
@@ -1,0 +1,8 @@
+contract C {
+    get fun test(): Int {
+        let m: map<Int, Int as uint4> = map<Int, Int as uint4> {
+            2: 16,
+        };
+        return m.get(2)!!;
+    }
+}

--- a/src/test/compilation-failed/contracts/map-literal-varint-val-out-of-range.tact
+++ b/src/test/compilation-failed/contracts/map-literal-varint-val-out-of-range.tact
@@ -1,0 +1,8 @@
+contract C {
+    get fun test(): Int {
+        let m: map<Int, Int as varint32> = map<Int, Int as varint32> {
+            2: -pow2(31 * 8 - 1) - 1,
+        };
+        return m.get(2)!!;
+    }
+}

--- a/src/test/compilation-failed/contracts/map-literal-varuint-val-out-of-range.tact
+++ b/src/test/compilation-failed/contracts/map-literal-varuint-val-out-of-range.tact
@@ -1,0 +1,8 @@
+contract C {
+    get fun test(): Int {
+        let m: map<Int, Int as coins> = map<Int, Int as coins> {
+            2: pow2(120),
+        };
+        return m.get(2)!!;
+    }
+}

--- a/src/test/compilation-failed/map-literal-errors.spec.ts
+++ b/src/test/compilation-failed/map-literal-errors.spec.ts
@@ -4,17 +4,17 @@ describe("map-literal-errors", () => {
     itShouldNotCompile({
         testName: "map-literal-cell",
         errorMessage:
-            "Could not reduce map literal: it either uses run-time values or unsupported features like structs, cells or asm functions",
+            "Invalid map literal: it either uses run-time values or unsupported features like structs, cells or asm functions",
     });
     itShouldNotCompile({
         testName: "map-literal-runtime",
         errorMessage:
-            "Could not reduce map literal: it either uses run-time values or unsupported features like structs, cells or asm functions",
+            "Invalid map literal: it either uses run-time values or unsupported features like structs, cells or asm functions",
     });
     itShouldNotCompile({
         testName: "map-literal-structs",
         errorMessage:
-            "Could not reduce map literal: it either uses run-time values or unsupported features like structs, cells or asm functions",
+            "Invalid map literal: it either uses run-time values or unsupported features like structs, cells or asm functions",
     });
     itShouldNotCompile({
         testName: "map-literal-uint-key-out-of-range",

--- a/src/test/compilation-failed/map-literal-errors.spec.ts
+++ b/src/test/compilation-failed/map-literal-errors.spec.ts
@@ -1,0 +1,49 @@
+import { itShouldNotCompile } from "@/test/compilation-failed/util";
+
+describe("map-literal-errors", () => {
+    itShouldNotCompile({
+        testName: "map-literal-cell",
+        errorMessage:
+            "Could not reduce map literal: it either uses run-time values or unsupported features like structs, cells or asm functions",
+    });
+    itShouldNotCompile({
+        testName: "map-literal-runtime",
+        errorMessage:
+            "Could not reduce map literal: it either uses run-time values or unsupported features like structs, cells or asm functions",
+    });
+    itShouldNotCompile({
+        testName: "map-literal-structs",
+        errorMessage:
+            "Could not reduce map literal: it either uses run-time values or unsupported features like structs, cells or asm functions",
+    });
+    itShouldNotCompile({
+        testName: "map-literal-uint-key-out-of-range",
+        errorMessage:
+            "Cannot evaluate expression to a constant: integer '2' does not fit into 1-bit unsigned integer type",
+    });
+    itShouldNotCompile({
+        testName: "map-literal-int-key-out-of-range",
+        errorMessage:
+            "Cannot evaluate expression to a constant: integer '-129' does not fit into 8-bit signed integer type",
+    });
+    itShouldNotCompile({
+        testName: "map-literal-int-val-out-of-range",
+        errorMessage:
+            "Cannot evaluate expression to a constant: integer '8' does not fit into 4-bit signed integer type",
+    });
+    itShouldNotCompile({
+        testName: "map-literal-uint-val-out-of-range",
+        errorMessage:
+            "Cannot evaluate expression to a constant: integer '16' does not fit into 4-bit unsigned integer type",
+    });
+    itShouldNotCompile({
+        testName: "map-literal-varuint-val-out-of-range",
+        errorMessage:
+            "Cannot evaluate expression to a constant: integer '1329227995784915872903807060280344576' does not fit into variable-length unsigned integer type with 4-bit length",
+    });
+    itShouldNotCompile({
+        testName: "map-literal-varint-val-out-of-range",
+        errorMessage:
+            "Cannot evaluate expression to a constant: integer '-226156424291633194186662080095093570025917938800079226639565593765455331329' does not fit into variable-length signed integer type with 5-bit length",
+    });
+});


### PR DESCRIPTION
## Issue

Closes #2938.

## Checklist

- [x] I have updated CHANGELOG.md
- [x] I have added tests to demonstrate the contribution is correctly implemented: this usually includes both positive and negative tests, showing the happy path(s) and featuring intentionally broken cases
