### PR TITLE
feat(docs): remark the futility of synchronous on-chain data retrieval patterns for getters

### DIFF
--- a/dev-docs/CHANGELOG.md
+++ b/dev-docs/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Docs
 
 - Described off-chain calls and mention exit code 11 for getters: PR [#3314](https://github.com/tact-lang/tact/pull/3314)
-- Remarked the futility of synchronous on-chain data retrieval patterns for getters: PR [#3315](https://github.com/tact-lang/tact/pull/3315)
+- Remarked the futility of synchronous on-chain data retrieval patterns for getters: PR [#3316](https://github.com/tact-lang/tact/pull/3316)
 
 ## [1.6.13] - 2025-05-29
 

--- a/dev-docs/CHANGELOG.md
+++ b/dev-docs/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Docs
 
 - Described off-chain calls and mention exit code 11 for getters: PR [#3314](https://github.com/tact-lang/tact/pull/3314)
+- Remarked the futility of synchronous on-chain data retrieval patterns for getters: PR [#3315](https://github.com/tact-lang/tact/pull/3315)
 
 ## [1.6.13] - 2025-05-29
 

--- a/docs/src/content/docs/book/functions.mdx
+++ b/docs/src/content/docs/book/functions.mdx
@@ -483,6 +483,12 @@ contract ManyFields(
 }
 ```
 
+Keep in mind that getters can obtain the contract's data only off-chain. However, for one contract to retrieve data from another contract on-chain, it must exchange messages with it. Since communication is asynchronous, the received data might become irrelevant or invalid because, by the time the message with that data reaches your contract, the actual state of variables on another contract might have changed already.
+
+Thus, efficient data exchange is only feasible in contract systems where you have control over the source code of all contracts or when the interface and behavior of some contracts are defined strictly according to some [standards](https://github.com/ton-blockchain/teps), such as [Jettons](/cookbook/jettons) or [NFTs](/cookbook/nfts).
+
+Even in such cases, contracts on TON exchange messages as signals to perform a certain action on or with the sent data but never merely to read the state of another contract.
+
 ### Method IDs
 
 Like other functions in TON contracts, getters have their _unique_ associated function selectors, which are 19-bit signed integer identifiers commonly called [_method IDs_](#low-level-representation).


### PR DESCRIPTION
## Issue

Closes #2574.
Closes #2573 (Plan).

The ways to architect contracts will be further discussed in receiver documentation, especially when we reach #1067.
