### PR TITLE
setup reward for contribute

### DIFF
--- a/.github/workflows/reward.yml
+++ b/.github/workflows/reward.yml
@@ -1,0 +1,27 @@
+name: Reward
+
+on:
+  pull_request:
+    types:
+      - closed
+
+jobs:
+  reward:
+    name: Reward
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+    steps:
+      - uses: the-ton-tech/toolchain/reward@v1.3.0
+        with:
+          activity_id: 38 # https://society.ton.org/contribute-to-tact-compiler
+          xps_min: 0
+          xps_max: 15000
+          # (optional) label for marking the rewarded PR
+          # on_reward_label: rewarded # if label "rewarded" exist
+          # Credentials of TON Society Platform
+          society_api_key: ${{ secrets.SOCIETY_API_KEY }}
+          society_partner_id: ${{ secrets.SOCIETY_PARTNER_ID }}
+          # GitHub token used to read PR details and post comments/labels
+          github_token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
- [ ] **[Setup actions variables](https://github.com/tact-lang/tact/settings/secrets/actions):** `SOCIETY_API_KEY` and `SOCIETY_PARTNER_ID`
- [ ] (optional) **[Create new label](https://github.com/tact-lang/tact/labels) for example:** name="rewarded"  color="#008672" description="Awards user SBT reward for merged PR"

> [!IMPORTANT]
> By default, the XPS value is 0, it must be overridden at the final review stage by adding a comment in the review in the format `XPS=N`, where `N` is a positive integer from 0 to `<xps_max>`, if the value is 0, no reward is given

In the current config, xps_min=0 — this means that a reward will not be given without an additional reviewer comment, we don't want to issue rewards for every little thing, if we want to reward every accepted PR, we need to change this value to something greater than 0 but less than 15,000 (which is your maximum)

If xps_min=0, then to issue a reward upon PR acceptance, one of the reviewers must approve it with a comment, for example: LGTM XPS=2442, if there are two or more reviews with scores, the average value will be used

![approve it with a comment](https://github.com/user-attachments/assets/7f9bc378-074f-4e28-8cfa-251c3f0cf1a9)

![your reward is ready](https://github.com/user-attachments/assets/f8a6176d-6e47-4925-aae9-f4580da565bd)

[Documentatinon and sources GitHub Action SBT Reward the-ton-tech/toolchain/reward@v1](https://github.com/the-ton-tech/toolchain?tab=readme-ov-file#sbt-reward)

