### PR TITLE
fix(docs): regular, non-type identifiers are unrelated to maps

### DIFF
--- a/docs/src/content/docs/book/expressions.mdx
+++ b/docs/src/content/docs/book/expressions.mdx
@@ -197,7 +197,7 @@ Read more: [Initialize a map with a literal](/book/maps#initialize).
 
 ## Identifiers
 
-An identifier is a sequence of characters in the code that _identifies_ a [variable](/book/statements#let), [constant](/book/constants), [map](/book/maps), a [function](/book/functions), as well as a [Struct][s], [Message][m], [contract](/book/contracts), [trait](/book/types#traits), or their fields and methods. Identifiers are case-sensitive and not quoted.
+An identifier is a sequence of characters in the code that _identifies_ a [variable](/book/statements#let), [constant](/book/constants), [function](/book/functions), as well as a [Struct][s], [Message][m], [contract](/book/contracts), [trait](/book/types#traits), or their fields and methods. Identifiers are case-sensitive and not quoted.
 
 In Tact, identifiers may contain Latin lowercase letters `a-z`, Latin uppercase letters `A-Z`, underscores `_`, and digits $\mathrm{0 - 9}$, but may not start with a digit. No other symbols are allowed, and Unicode identifiers are prohibited.
 


### PR DESCRIPTION
## Issue

Closes #3188.
