### PR TITLE
Fix typo in docs links comment

### DIFF
--- a/docs/links-to-web-ide.js
+++ b/docs/links-to-web-ide.js
@@ -35,7 +35,7 @@ export default function remarkLinksToWebIDE() {
       const lines = src.split('\n');
       if (lines.length <= 1) { return undefined; }
 
-      // Only allow pages in the Cookbook plus some cheat sheat pages from the Book
+      // Only allow pages in the Cookbook plus some cheat sheet pages from the Book
       // NOTE: This limitation can be lifted in the future if there's popular demand
       const notCookbook = file.path.indexOf('docs/cookbook') === -1;
       const notLearnXY = file.path.indexOf('learn-tact-in-y-minutes') === -1;


### PR DESCRIPTION
## Summary
- fix typo in `docs/links-to-web-ide.js`

## Testing
- `yarn test:fast` *(fails: Error when performing the request to registry.yarnpkg.com)*

