### PR TITLE
fix(docs): correct confusing sentence in the expression statements section

### DIFF
--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -153,10 +153,7 @@ export default defineConfig({
 					},
 					items: [
 						{ slug: 'book' },
-						{
-							slug: 'book/learn-tact-in-y-minutes',
-							badge: { variant: 'tip', text: 'new' },
-						},
+						{ slug: 'book/learn-tact-in-y-minutes' },
 						// NOTE: saved for coming from other blockchains / languages
 						// {
 						// 	label: 'Cheatsheets',
@@ -190,7 +187,10 @@ export default defineConfig({
 						{ slug: 'book/expressions' },
 						{ slug: 'book/statements' },
 						{ slug: 'book/constants' },
-						{ slug: 'book/functions' },
+						{
+							slug: 'book/functions',
+							badge: { variant: 'tip', text: 'new' },
+						},
 						{ slug: 'book/assembly-functions' },
 						{
 							label: 'Communication',

--- a/docs/src/content/docs/book/config.mdx
+++ b/docs/src/content/docs/book/config.mdx
@@ -440,7 +440,7 @@ This option can be used to provide an extra safety level or for debugging.
 
 `true{:json}` by default.
 
-If set to `true{:json}`, stores internal and external receivers outside the methods map.
+If set to `true{:json}`, stores internal and external receivers outside the [methods map](/book/functions#low-level-representation).
 
 When enabled, it saves gas but can cause the contract to be incorrectly recognized and misparsed by some explorers and user wallets.
 

--- a/docs/src/content/docs/book/statements.mdx
+++ b/docs/src/content/docs/book/statements.mdx
@@ -133,7 +133,7 @@ Some statements, such as [`let{:tact}`](#let) or [`return{:tact}`](#return), mus
 
 ## Expression
 
-An expression statement is an expression used in a place where a statement is expected. The expression is evaluated, and its result is discarded. Therefore, it makes sense only for expressions that have side effects, such as executing a function or updating a variable.
+An expression statement is an expression used in a place where a statement is expected. The expression is evaluated, and its result is discarded. Therefore, it makes sense only for expressions that have side effects, such as [printing to the debug console](/ref/core-debug#dump) or executing an [extension mutation function](/book/functions#mutates).
 
 ```tact
 dump(2 + 2); // stdlib function


### PR DESCRIPTION
## Issue

Closes #3187. And also made functions stand out a little.