### PR TITLE
clarify build step after yarn install

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,0 +1,3 @@
+
+> **Note:** After running `yarn install`, you must also run `yarn build` before using the compiler.
+


### PR DESCRIPTION
This PR improves the Getting Started documentation by clarifying the build step that should be run after yarn install.

Added a note about running yarn build after dependencies are installed

Helps new contributors avoid confusion when following setup instructions

Keeps documentation up-to-date with the actual project workflow
