### PR TITLE
fix(docs) : updated invalid link for Address type

### DIFF
--- a/docs/src/content/docs/book/types.mdx
+++ b/docs/src/content/docs/book/types.mdx
@@ -19,7 +19,7 @@ Tact supports a number of primitive data types that are tailored for smart contr
 
 * [`Int{:tact}`](/book/integers) — All numbers in Tact are $257$-bit signed integers, but [smaller representations](/book/integers#serialization) can be used to reduce storage costs.
 * [`Bool{:tact}`](#booleans) — Classical boolean with `true{:tact}` and `false{:tact}` values.
-* `Address{:tact}` — Standard [smart contract address](https://docs.ton.org/learn/overviews/addresses#address-of-smart-contract) in TON Blockchain.
+* `Address{:tact}` — Standard [smart contract address](https://docs.ton.org/v3/documentation/smart-contracts/addresses/address) in TON Blockchain.
 * [`Cell{:tact}`](/book/cells#cells), [`Builder{:tact}`](/book/cells#builders), [`Slice{:tact}`](/book/cells#slices) — Low-level primitives of [TVM][tvm].
 * `String{:tact}` — Immutable text strings.
 * `StringBuilder{:tact}` — Helper type that allows you to concatenate strings in a gas-efficient way.


### PR DESCRIPTION
Now given link in docs/src/content/docs/book/types.mdx leads to https://docs.ton.org/v3/documentation/smart-contracts/addresses/address as I suppose it should. The link before was invalid.


