### PR TITLE
feat: improve clarity of 'Unsupported format' serialization error messages

### DIFF
--- a/src/types/__snapshots__/resolveDescriptors.spec.ts.snap
+++ b/src/types/__snapshots__/resolveDescriptors.spec.ts.snap
@@ -47594,3 +47594,12 @@ exports[`resolveDescriptors should resolve descriptors for wildcard-function-par
 `;
 
 exports[`resolveDescriptors should resolve descriptors for wildcard-function-param2 2`] = `[]`;
+
+exports[`resolveDescriptors should fail descriptors for struct-unsupported-serialization-format 1`] = `
+"<unknown>:9:5: Unsupported serialization format 'uint8' for type 'NestedData'
+  8 | contract Test {
+> 9 |     opt: NestedData? as uint8;
+          ^~~~~~~~~~~~~~~~~~~~~~~~~~
+ 10 |     init() {
+"
+`;

--- a/src/types/__snapshots__/resolveDescriptors.spec.ts.snap
+++ b/src/types/__snapshots__/resolveDescriptors.spec.ts.snap
@@ -47596,10 +47596,10 @@ exports[`resolveDescriptors should resolve descriptors for wildcard-function-par
 exports[`resolveDescriptors should resolve descriptors for wildcard-function-param2 2`] = `[]`;
 
 exports[`resolveDescriptors should fail descriptors for struct-unsupported-serialization-format 1`] = `
-"<unknown>:9:5: Unsupported serialization format 'uint8' for type 'NestedData'
-  8 | contract Test {
-> 9 |     opt: NestedData? as uint8;
-          ^~~~~~~~~~~~~~~~~~~~~~~~~~
- 10 |     init() {
+"<unknown>:10:5: Unsupported serialization format "uint8" for type 'NestedData'
+   9 | contract Test {
+> 10 |     opt: NestedData? as uint8;
+           ^~~~~~~~~~~~~~~~~~~~~~~~~
+  11 |     init() {
 "
 `;

--- a/src/types/resolveABITypeRef.ts
+++ b/src/types/resolveABITypeRef.ts
@@ -250,7 +250,7 @@ export function resolveABIType({
                 };
             } else {
                 throwCompilationError(
-                    `Unsupported format ${idTextErr(as)}`,
+                    `Unsupported serialization format ${idTextErr(as)} for type '${idText(typeId)}'`,
                     loc,
                 );
             }

--- a/src/types/test-failed/struct-unsupported-serialization-format.tact
+++ b/src/types/test-failed/struct-unsupported-serialization-format.tact
@@ -1,0 +1,15 @@
+primitive Int;
+primitive Bool;
+
+struct NestedData {
+    x: Int;
+    y: Bool;
+}
+
+contract Test {
+    opt: NestedData? as uint8;
+    init() {
+        self.opt = null;
+    }
+}
+


### PR DESCRIPTION
- Add type information to struct serialization format error messages
- Change error message from 'Unsupported format X' to 'Unsupported serialization format X for type Y'
- Add test case for struct with unsupported serialization format
- Update snapshot for new error message format

Fixes #3460
