### PR TITLE
fix(docs): replace 'it's own' with 'its own' in `receive.mdx`

### DIFF
--- a/docs/src/content/docs/book/receive.mdx
+++ b/docs/src/content/docs/book/receive.mdx
@@ -18,7 +18,7 @@ To receive a message of the required type, you need to declare a receiver functi
 
 ### Empty receiver
 
-This receiver specifically handles internal messages with no contents, i.e., the `null{:tact}` body. Note that as a function, it's own body doesn't have to be empty.
+This receiver specifically handles internal messages with no contents, i.e., the `null{:tact}` body. Note that as a function, its own body doesn't have to be empty.
 
 ```tact
 contract Emptiness() {


### PR DESCRIPTION
## Summary
- Fixed grammatical error in docs/src/content/docs/book/receive.mdx
- Changed "it's own" to "its own" (possessive form, not contraction)

## Test plan
- No tests needed, documentation change only