### PR TITLE
fix(docs): replace 'cannot defined be' with 'cannot be defined as' in `functions.mdx`

### DIFF
--- a/docs/src/content/docs/book/functions.mdx
+++ b/docs/src/content/docs/book/functions.mdx
@@ -815,7 +815,7 @@ trait DeployableFilterV1 with Ownable {
     abstract fun specialFilter();
 
     // Receivers are inherited too,
-    // but they cannot defined be virtual or abstract
+    // but they cannot be defined as virtual or abstract
     receive() { cashback(sender()) }
 }
 


### PR DESCRIPTION
## Summary
- Fixed word order typo in docs/src/content/docs/book/functions.mdx
- Changed "cannot defined be virtual or abstract" to "cannot be defined as virtual or abstract"

## Test plan
- No tests needed, documentation change only